### PR TITLE
Allow specifying `num_regions` during `Operation` creation

### DIFF
--- a/src/dialects/builtin/ops.rs
+++ b/src/dialects/builtin/ops.rs
@@ -68,7 +68,7 @@ impl Verify for ModuleOp {
 impl ModuleOp {
     /// Create a new [ModuleOp].
     /// The underlying [Operation] is not linked to a [BasicBlock](crate::basic_block::BasicBlock).
-    /// The returned module has a single [Region] with a single (BasicBlock)[crate::basic_block::BasicBlock].
+    /// The returned module has a single [crate::region::Region] with a single (BasicBlock)[crate::basic_block::BasicBlock].
     pub fn new(ctx: &mut Context, name: &str) -> ModuleOp {
         let op = Operation::new(ctx, Self::get_opid_static(), vec![], vec![], 1);
         let opop = ModuleOp { op };

--- a/src/dialects/builtin/ops.rs
+++ b/src/dialects/builtin/ops.rs
@@ -196,9 +196,7 @@ impl Verify for FuncOp {
             });
         }
         self.verify_one_region(ctx)?;
-        let op = &*self.op.deref(ctx);
-        op.get_region(0).unwrap().deref(ctx).verify(ctx)?;
-        Ok(())
+        op.get_region(0).unwrap().deref(ctx).verify(ctx)
     }
 }
 

--- a/src/dialects/llvm/ops.rs
+++ b/src/dialects/llvm/ops.rs
@@ -28,7 +28,7 @@ declare_op!(
 
 impl ReturnOp {
     pub fn new_unlinked(ctx: &mut Context, value: Value) -> ReturnOp {
-        let op = Operation::new(ctx, Self::get_opid_static(), vec![], vec![value]);
+        let op = Operation::new(ctx, Self::get_opid_static(), vec![], vec![value], 0);
         ReturnOp { op }
     }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -18,7 +18,6 @@ use crate::{
     r#type::TypeObj,
     region::Region,
     use_def_lists::{DefNode, DefTrait, DefUseParticipant, Use, UseNode, Value},
-    vec_exns::VecExtns,
     with_context::AttachContext,
 };
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -18,6 +18,7 @@ use crate::{
     r#type::TypeObj,
     region::Region,
     use_def_lists::{DefNode, DefTrait, DefUseParticipant, Use, UseNode, Value},
+    vec_exns::VecExtns,
     with_context::AttachContext,
 };
 
@@ -180,11 +181,8 @@ impl Operation {
             })
             .collect();
         newop.deref_mut(ctx).operands = operands;
+        newop.deref_mut(ctx).regions = Vec::new_init(num_regions, |_| Region::new(ctx, newop));
 
-        for _ in 0..num_regions {
-            let region = Region::new(ctx, newop);
-            newop.deref_mut(ctx).regions.push(region);
-        }
         newop
     }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -18,6 +18,7 @@ use crate::{
     r#type::TypeObj,
     region::Region,
     use_def_lists::{DefNode, DefTrait, DefUseParticipant, Use, UseNode, Value},
+    vec_exns::VecExtns,
     with_context::AttachContext,
 };
 
@@ -135,6 +136,7 @@ impl Operation {
         opid: OpId,
         result_types: Vec<Ptr<TypeObj>>,
         operands: Vec<Value>,
+        num_regions: usize,
     ) -> Ptr<Operation> {
         let f = |self_ptr: Ptr<Operation>| Operation {
             opid,
@@ -179,6 +181,11 @@ impl Operation {
             })
             .collect();
         newop.deref_mut(ctx).operands = operands;
+
+        for _ in 0..num_regions {
+            let region = Region::new(ctx, newop);
+            newop.deref_mut(ctx).regions.push(region);
+        }
         newop
     }
 

--- a/src/vec_exns.rs
+++ b/src/vec_exns.rs
@@ -15,7 +15,7 @@ impl<T> VecExtns<T> for Vec<T> {
 
     fn new_init<U: FnMut(usize) -> T>(size: usize, mut initf: U) -> Vec<T> {
         let mut v = Vec::<T>::with_capacity(size);
-        for i in [0, size] {
+        for i in 0..size {
             v.push(initf(i));
         }
         v

--- a/src/vec_exns.rs
+++ b/src/vec_exns.rs
@@ -4,7 +4,7 @@ pub trait VecExtns<T> {
     // Insert a new element and get back its index in the container.
     fn push_back(&mut self, t: T) -> usize;
     // Create and initialize a new vector.
-    fn new_init<U: Fn(usize) -> T>(size: usize, initf: U) -> Vec<T>;
+    fn new_init<U: FnMut(usize) -> T>(size: usize, initf: U) -> Vec<T>;
 }
 
 impl<T> VecExtns<T> for Vec<T> {
@@ -13,7 +13,7 @@ impl<T> VecExtns<T> for Vec<T> {
         self.len() - 1
     }
 
-    fn new_init<U: Fn(usize) -> T>(size: usize, initf: U) -> Vec<T> {
+    fn new_init<U: FnMut(usize) -> T>(size: usize, mut initf: U) -> Vec<T> {
         let mut v = Vec::<T>::with_capacity(size);
         for i in [0, size] {
             v.push(initf(i));


### PR DESCRIPTION
Hi! Thanks for making `pliron`! It's awesome!

I'm trying to use `pliron` in my https://github.com/greenhat/ominzk (Wasm -> various ZK VMs compilation framework). Although Wasm and ZK VMS are stack-based (non-SSA), I believe `pliron` could be an excellent fit for defining IRs and transformation passes.

I'm writing a `func` op for the `wasm` dialect, and I cannot add a region to an operation (`wasm.func`), so I added `Operation::push_back_region`.