### PR TITLE
Strong typing for Types

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -72,8 +72,6 @@ pub trait Attribute: Printable + Verify + Downcast + CastFrom + Sync + DynClone 
     fn verify_interfaces(&self, ctx: &Context) -> Result<()>;
 
     /// Register this attribute's [AttrId] in the dialect it belongs to.
-    /// **Warning**: No check is made as to whether this attr is already registered
-    ///  in `dialect`.
     fn register_attr_in_dialect(dialect: &mut Dialect, attr_parser: ParserFn<(), AttrObj>)
     where
         Self: Sized,
@@ -104,6 +102,12 @@ impl Printable for AttrObj {
     ) -> core::fmt::Result {
         write!(f, "{} ", self.get_attr_id())?;
         Printable::fmt(self.deref(), ctx, state, f)
+    }
+}
+
+impl Verify for AttrObj {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        self.as_ref().verify(ctx)
     }
 }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -7,8 +7,8 @@
 //! They are heavy (i.e., not just a pointer, handle or reference),
 //! making clones potentially expensive.
 //!
-//! The `#[def_attribute]` proc macro from the pliron-derive create can be used to implement
-//! [Attribute] for a rust type.
+//! The [def_attribute](pliron_derive::def_attribute) proc macro from the
+//! pliron-derive create can be used to implement [Attribute] for a rust type.
 //!
 //! Common semantics, API and behaviour of [Attribute]s are
 //! abstracted into interfaces. Interfaces in pliron capture MLIR

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -3,7 +3,7 @@
 use combine::{
     between,
     parser::{char::spaces, Parser},
-    position, sep_by, token,
+    sep_by, token,
 };
 use rustc_hash::FxHashMap;
 
@@ -17,9 +17,9 @@ use crate::{
     indented_block,
     irfmt::printers::{iter_with_sep, list_with_sep},
     linked_list::{private, ContainsLinkedList, LinkedList},
-    location::{Located, Location},
+    location::Located,
     operation::Operation,
-    parsable::{self, spaced, IntoParseResult, Parsable, ParseResult},
+    parsable::{self, location, spaced, IntoParseResult, Parsable, ParseResult},
     printable::{self, indented_nl, ListSeparator, Printable},
     r#type::{type_parser, TypeObj, Typed},
     region::Region,
@@ -337,12 +337,9 @@ impl Parsable for BasicBlock {
         _arg: Self::Arg,
     ) -> ParseResult<'a, Self::Parsed> {
         let loc = state_stream.loc();
-        let src = loc
-            .source()
-            .expect("Location from Parsable must be Location::SrcPos");
 
         let arg = (
-            (position(), Identifier::parser(())).skip(spaced(token(':'))),
+            (location(), Identifier::parser(())).skip(spaced(token(':'))),
             type_parser().skip(spaces()),
         );
         let args = spaced(between(
@@ -365,14 +362,13 @@ impl Parsable for BasicBlock {
         // We've parsed the components. Now construct the result.
         let (arg_names, arg_types): (Vec<_>, Vec<_>) = args.into_iter().unzip();
         let block = BasicBlock::new(state_stream.state.ctx, Some(label.clone()), arg_types);
-        for (arg_idx, (pos, name)) in arg_names.into_iter().enumerate() {
+        for (arg_idx, (loc, name)) in arg_names.into_iter().enumerate() {
             let def: Value = (&block.deref(state_stream.state.ctx).args[arg_idx]).into();
             let name_string = name.to_string();
-            state_stream.state.name_tracker.ssa_def(
-                state_stream.state.ctx,
-                &(name, Location::SrcPos { src, pos }),
-                def,
-            )?;
+            state_stream
+                .state
+                .name_tracker
+                .ssa_def(state_stream.state.ctx, &(name, loc), def)?;
             set_block_arg_name(state_stream.state.ctx, block, arg_idx, name_string);
         }
         for op in ops {

--- a/src/context.rs
+++ b/src/context.rs
@@ -105,7 +105,7 @@ pub struct Ptr<T: ArenaObj> {
 }
 
 impl<'a, T: ArenaObj> Ptr<T> {
-    /// Return a Ref to the pointee.
+    /// Return a [Ref] to the pointee.
     /// This borrows from a RefCell and the borrow is live
     /// as long as the returned Ref lives.
     pub fn deref(&self, ctx: &'a Context) -> Ref<'a, T> {

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -158,7 +158,7 @@ mod tests {
         dialects::builtin::register(&mut ctx);
 
         let i64_ty = IntegerType::get(&mut ctx, 64, Signedness::Signed);
-        let block = BasicBlock::new(&mut ctx, Some("entry".into()), vec![i64_ty]);
+        let block = BasicBlock::new(&mut ctx, Some("entry".into()), vec![i64_ty.into()]);
         set_block_arg_name(&ctx, block, 0, "foo".to_string());
         assert!(get_block_arg_name(&ctx, block, 0).unwrap() == "foo");
         block.deref(&ctx).verify(&ctx)?;

--- a/src/op.rs
+++ b/src/op.rs
@@ -3,7 +3,8 @@
 //!
 //! See MLIR's [Op](https://mlir.llvm.org/docs/Tutorials/Toy/Ch-2/#op-vs-operation-using-mlir-operations).
 //!
-//! New [Op]s can be easily declared using the `#[def_op]` proc macro from the pliron-derive crate.
+//! New [Op]s can be easily declared using the [def_op](pliron_derive::def_op)
+//! proc macro from the pliron-derive crate.
 //!
 //! Common semantics, API and behaviour of [Op]s are
 //! abstracted into Op interfaces. Interfaces in pliron capture MLIR

--- a/src/parsable.rs
+++ b/src/parsable.rs
@@ -210,6 +210,15 @@ pub fn spaced<Input: Stream<Token = char>, Output>(
     combine::between(spaces(), spaces(), parser)
 }
 
+/// A parser that returns the current [Location] and does nothing else
+pub fn location<'a>() -> Box<dyn Parser<StateStream<'a>, Output = Location, PartialState = ()> + 'a>
+{
+    combine::parser(|parsable_state: &mut StateStream<'a>| {
+        combine::ParseResult::PeekOk(parsable_state.loc()).into()
+    })
+    .boxed()
+}
+
 /// Convert [Result] into [StdParseResult2].
 /// Enables using `?` on [Result] during parsing.
 pub trait IntoParseResult<'a, T> {

--- a/src/type.rs
+++ b/src/type.rs
@@ -6,7 +6,8 @@
 //!
 //! See [MLIR Types](https://mlir.llvm.org/docs/DefiningDialects/AttributesAndTypes/#types)
 //!
-//! The `#[def_type]` proc macro from [pliron-derive] can be used to implement [Type] for a rust type.
+//! The [def_type](pliron_derive::def_type) proc macro from [pliron-derive]
+//! can be used to implement [Type] for a rust type.
 
 use crate::common_traits::Verify;
 use crate::context::{private::ArenaObj, ArenaCell, Context, Ptr};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,7 +30,7 @@ pub fn const_ret_in_mod(ctx: &mut Context) -> Result<(ModuleOp, FuncOp, Constant
     let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
     let module = ModuleOp::new(ctx, "bar");
     // Our function is going to have type () -> ().
-    let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty]);
+    let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.ptr()]);
     let func = FuncOp::new_unlinked(ctx, "foo", func_ty);
     module.add_operation(ctx, func.get_operation());
     let bb = func.get_entry_block(ctx);

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -12,6 +12,7 @@ use pliron::{
     operation::Operation,
     parsable::{self, spaced, state_stream_from_iterator, Parsable},
     printable::Printable,
+    r#type::TypePtr,
 };
 
 use crate::common::{const_ret_in_mod, setup_context_dialects};
@@ -51,7 +52,10 @@ fn replace_c0_with_c1() -> Result<()> {
     let (module_op, _, const_op, _) = const_ret_in_mod(ctx).unwrap();
 
     // Insert a new constant.
-    let one_const = IntegerAttr::create(const_op.get_type(ctx), ApInt::from(1));
+    let one_const = IntegerAttr::create(
+        TypePtr::new(const_op.get_type(ctx), ctx).expect("Expected const_op to have integer type"),
+        ApInt::from(1),
+    );
     let const1_op = ConstantOp::new_unlinked(ctx, one_const);
     const1_op
         .get_operation()
@@ -77,7 +81,10 @@ fn replace_c0_with_c1_operand() -> Result<()> {
     let (module_op, _, const_op, ret_op) = const_ret_in_mod(ctx).unwrap();
 
     // Insert a new constant.
-    let one_const = IntegerAttr::create(const_op.get_type(ctx), ApInt::from(1));
+    let one_const = IntegerAttr::create(
+        TypePtr::new(const_op.get_type(ctx), ctx).unwrap(),
+        ApInt::from(1),
+    );
     let const1_op = ConstantOp::new_unlinked(ctx, one_const);
     const1_op
         .get_operation()


### PR DESCRIPTION
Based on @urso's proposal [here](https://github.com/vaivaswatha/pliron/discussions/25#discussioncomment-8357975).

We probably don't need something similar for `Attribute`s because they aren't uniqued (but `Type`s are). This means we could use the concrete type or the type erased `AttrObj` as required.