### PR TITLE
A callback based walker for the IR

### DIFF
--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -187,7 +187,7 @@ impl BasicBlock {
         self.args.len()
     }
 
-    /// Does this block a predecessor?
+    /// Does this block have a predecessor?
     pub fn has_pred(&self) -> bool {
         self.preds.has_use()
     }
@@ -195,6 +195,39 @@ impl BasicBlock {
     /// Number of predecessors to this block.
     pub fn num_preds(&self) -> usize {
         self.preds.num_uses()
+    }
+
+    /// Get the predecessors of this block.
+    pub fn predecessors(&self, ctx: &Context) -> Vec<Ptr<BasicBlock>> {
+        self.preds
+            .get_uses()
+            .iter()
+            .map(|u| {
+                u.op.deref(ctx)
+                    .get_container()
+                    .expect("Unlinked Operation branching to block")
+            })
+            .collect()
+    }
+
+    /// Get number of successors
+    pub fn num_successors(&self, ctx: &Context) -> usize {
+        self.get_tail()
+            .map(|term| term.deref(ctx).get_num_successors())
+            .unwrap_or_default()
+    }
+
+    /// Get a [Ptr] to the succ_idx'th successor.
+    pub fn successor(&self, ctx: &Context, succ_idx: usize) -> Option<Ptr<BasicBlock>> {
+        self.get_tail()
+            .and_then(|term| term.deref(ctx).get_successor(succ_idx))
+    }
+
+    /// Get the successors of this block.
+    pub fn successors(&self, ctx: &Context) -> Vec<Ptr<BasicBlock>> {
+        self.get_tail()
+            .map(|term| term.deref(ctx).successors().collect())
+            .unwrap_or_default()
     }
 
     /// Drop all uses that this block holds.

--- a/src/dialects/builtin/types.rs
+++ b/src/dialects/builtin/types.rs
@@ -330,11 +330,7 @@ mod tests {
             .unwrap()
             .0
              .0;
-        assert!(
-            res == IntegerType::get_existing(&ctx, 64, Signedness::Signed)
-                .unwrap()
-                .into()
-        )
+        assert!(res == IntegerType::get_existing(&ctx, 64, Signedness::Signed).unwrap())
     }
 
     #[test]
@@ -375,10 +371,6 @@ mod tests {
             .unwrap()
             .0
              .0;
-        assert!(
-            res == FunctionType::get_existing(&ctx, vec![], vec![si32.into()])
-                .unwrap()
-                .into()
-        )
+        assert!(res == FunctionType::get_existing(&ctx, vec![], vec![si32.into()]).unwrap())
     }
 }

--- a/src/dialects/llvm/types.rs
+++ b/src/dialects/llvm/types.rs
@@ -460,7 +460,7 @@ mod tests {
     #[test]
     fn test_pointer_types() {
         let mut ctx = Context::new();
-        let int32_1_ptr = IntegerType::get(&mut ctx, 32, Signedness::Signed).into();
+        let int32_1_ptr = IntegerType::get(&mut ctx, 32, Signedness::Signed);
         let int64_ptr = IntegerType::get(&mut ctx, 64, Signedness::Signed).into();
 
         let int64pointer_ptr = PointerType { to: int64_ptr };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,5 @@ pub mod r#type;
 pub mod uniqued_any;
 pub mod use_def_lists;
 pub mod vec_exns;
+pub mod walker;
+pub mod walkers;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -288,6 +288,11 @@ impl Operation {
         op::from_operation(ctx, ptr)
     }
 
+    /// Iterate over the regions of self.
+    pub fn regions(&self) -> impl Iterator<Item = Ptr<Region>> + '_ {
+        self.regions.iter().cloned()
+    }
+
     /// Get a [Ptr] to the `reg_idx`th region.
     pub fn get_region(&self, reg_idx: usize) -> Option<Ptr<Region>> {
         self.regions.get(reg_idx).cloned()

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -1,0 +1,183 @@
+//! A walker traverses the graph, visiting each node (region, block and op).
+//! At each node, it calls the provided callbacks to process the node.
+//!
+//! Visit: When a walk arrives at a node, it is called visiting the node.
+//!   Visiting a node includes processing it and visiting other related
+//!   entities, based on the node type.
+//!
+//! Process: As part of visiting a node, the node itself must be processed.
+//!   This is essentially calling back a provided function with the node as
+//!   argument.
+//!
+//! Modifications: At each node, the list of children or successor/predecessor
+//!   nodes, to be visited, is collected first, before any of them are visited.
+//!   So any modifications, insertions or deletions to the graph must take this
+//!   into account, to avoid visiting deleted nodes or missing visits to newly
+//!   inserted nodes.
+//!
+//! Termination: Cycles are possible b/w the blocks in a region.
+//!   It is the responsiblity of the [VisitBlock::blocks_visit_order] to ensure
+//!   termination. No cycle detection is done by the walker.
+
+use crate::{
+    basic_block::BasicBlock,
+    context::{Context, Ptr},
+    error::Result,
+    operation::Operation,
+    region::Region,
+};
+
+/// When the walker arrives at a node, it calls the Visit*
+/// callbacks, that return a list of [VisitAction], and does that.
+pub enum VisitAction<T> {
+    /// Process the node being visited.
+    Process,
+    /// Visit other nodes.
+    Visit(T),
+}
+
+/// When a walk arrives at a [BasicBlock], this trait decides when its
+/// successors / predecessors are visited, and when the block itself be processed.
+pub trait VisitBlock {
+    /// Given a block, determine when the successor/predecessor blocks are visited
+    /// and when the block itself is processed.
+    fn blocks_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_block: Ptr<BasicBlock>,
+    ) -> Vec<VisitAction<Ptr<BasicBlock>>>;
+
+    /// Given a block, get the list of [Operation]s in the block that must be visited.
+    fn operations_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_block: Ptr<BasicBlock>,
+    ) -> Vec<Ptr<Operation>>;
+}
+
+/// Callbacks when a [BasicBlock] is processed.
+pub trait ProcessBlock {
+    /// Call back before visiting the instructions in a [BasicBlock].
+    fn process_pre_insts(&mut self, _ctx: &mut Context, _block: Ptr<BasicBlock>) -> Result<()> {
+        Ok(())
+    }
+    /// Call back after visiting the instructions in a [BasicBlock].
+    fn process_post_insts(&mut self, _ctx: &mut Context, _block: Ptr<BasicBlock>) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// When a walk arrives at a [Region], specify which of its blocks, and in what
+/// order, must be visited.
+pub trait VisitRegion {
+    /// Given a region, get a list of child blocks that must be visited.
+    /// Typically, this is just the entry block or the exit blocks since
+    /// the other blocks subsequently get visited via [VisitBlock::blocks_visit_order].
+    fn blocks_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_region: Ptr<Region>,
+    ) -> Vec<Ptr<BasicBlock>>;
+}
+
+/// Callbacks when a [Region] is processed.
+pub trait ProcessRegion {
+    /// Call back before visiting the [BasicBlock]s in a [Region].
+    fn process_pre_blocks(&mut self, _ctx: &mut Context, _region: Ptr<Region>) -> Result<()> {
+        Ok(())
+    }
+    /// Call back after visiting the [BasicBlock]s in a [Region].
+    fn process_post_blocks(&mut self, _ctx: &mut Context, _region: Ptr<Region>) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// When a walk arrives at an [Operation],
+/// specify the order in which its [Region]s are visited.
+pub trait VisitOperation {
+    /// Given an [Operation], get a list of child [Region]s to be visited, in that order.
+    fn region_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_operation: Ptr<Operation>,
+    ) -> Vec<Ptr<Region>>;
+}
+
+/// Callbacks when an [Operation] is processed.
+pub trait ProcessOperation {
+    /// Call back before visiting the [Region]s in an [Operation].
+    fn process_pre_regions(
+        &mut self,
+        _ctx: &mut Context,
+        _operation: Ptr<Operation>,
+    ) -> Result<()> {
+        Ok(())
+    }
+    /// Call back after visiting the [Region]s in an [Operation].
+    fn process_post_regions(
+        &mut self,
+        _ctx: &mut Context,
+        _operation: Ptr<Operation>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Given Visitors and Processors (see [module documentation](crate::walker)),
+/// walk the entire IR graph, starting at a provided root node.
+pub struct Walker<Visitor, Processor>
+where
+    Visitor: VisitBlock + VisitOperation + VisitRegion,
+    Processor: ProcessBlock + ProcessOperation + ProcessRegion,
+{
+    pub visitor: Visitor,
+    pub processor: Processor,
+}
+
+impl<Visitor, Processor> Walker<Visitor, Processor>
+where
+    Visitor: VisitBlock + VisitOperation + VisitRegion,
+    Processor: ProcessBlock + ProcessOperation + ProcessRegion,
+{
+    /// Visit an operation, calling back the processors before and after visits of nested regions.
+    pub fn walk_operation(&mut self, ctx: &mut Context, operation: Ptr<Operation>) -> Result<()> {
+        self.processor.process_pre_regions(ctx, operation)?;
+        for region in self.visitor.region_visit_order(ctx, operation) {
+            self.walk_region(ctx, region)?;
+        }
+        self.processor.process_post_regions(ctx, operation)
+    }
+
+    /// Visit a region, calling back the processors before and after visiting nested blocks.
+    pub fn walk_region(&mut self, ctx: &mut Context, region: Ptr<Region>) -> Result<()> {
+        self.processor.process_pre_blocks(ctx, region)?;
+        for block in VisitRegion::blocks_visit_order(&mut self.visitor, ctx, region) {
+            self.walk_block(ctx, block)?
+        }
+        self.processor.process_post_blocks(ctx, region)
+    }
+
+    /// Visit successors / predecessors of a block and call back the block's processors
+    /// before and after visiting the nested operations. The relative order of self processing and
+    /// successor / predecessor block visits are determined by [VisitBlock::blocks_visit_order].
+    pub fn walk_block(&mut self, ctx: &mut Context, block: Ptr<BasicBlock>) -> Result<()> {
+        for action in VisitBlock::blocks_visit_order(&mut self.visitor, ctx, block) {
+            match action {
+                VisitAction::Process => {
+                    self.processor.process_pre_insts(ctx, block)?;
+                    for op in self.visitor.operations_visit_order(ctx, block) {
+                        self.walk_operation(ctx, op)?;
+                    }
+                }
+                VisitAction::Visit(next_block) => {
+                    self.walk_block(ctx, next_block)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn new(visitor: Visitor, processor: Processor) -> Self {
+        Walker { processor, visitor }
+    }
+}

--- a/src/walkers.rs
+++ b/src/walkers.rs
@@ -1,0 +1,172 @@
+//! Various walker configurations, for use with [crate::walker]
+
+use rustc_hash::FxHashSet;
+
+use crate::{
+    basic_block::BasicBlock,
+    context::{Context, Ptr},
+    error::Result,
+    linked_list::ContainsLinkedList,
+    operation::Operation,
+    region::Region,
+    walker::{
+        ProcessBlock, ProcessOperation, ProcessRegion, VisitAction, VisitBlock, VisitOperation,
+        VisitRegion,
+    },
+};
+
+/// Visit the control-flow-graph (of a [Region]) in pre-order.
+/// A state of already visited [BasicBlock]s is maintained to ensure termination.
+#[derive(Default)]
+pub struct PreOrderCFG {
+    /// The set of blocks that we've already visited.
+    visited: FxHashSet<Ptr<BasicBlock>>,
+}
+
+impl PreOrderCFG {
+    /// Clear the set of blocks marked as already visited.
+    pub fn reset(&mut self) {
+        self.visited.clear();
+    }
+}
+
+impl VisitBlock for PreOrderCFG {
+    fn blocks_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_block: Ptr<BasicBlock>,
+    ) -> Vec<VisitAction<Ptr<BasicBlock>>> {
+        if self.visited.contains(&cur_block) {
+            return vec![];
+        }
+        let mut blocks = vec![VisitAction::Process];
+        blocks.extend(
+            cur_block
+                .deref(ctx)
+                .successors(ctx)
+                .into_iter()
+                .map(VisitAction::Visit),
+        );
+        blocks
+    }
+
+    fn operations_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_block: Ptr<BasicBlock>,
+    ) -> Vec<Ptr<Operation>> {
+        cur_block.deref(ctx).iter(ctx).collect()
+    }
+}
+
+/// At every node, process the node first,
+/// and then its successor or children.
+pub struct PreOrderVisitor {
+    cfg: PreOrderCFG,
+}
+
+impl Default for PreOrderVisitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PreOrderVisitor {
+    pub fn new() -> Self {
+        PreOrderVisitor {
+            cfg: PreOrderCFG::default(),
+        }
+    }
+}
+
+// Delegate to self.cfg
+impl VisitBlock for PreOrderVisitor {
+    fn blocks_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_block: Ptr<BasicBlock>,
+    ) -> Vec<VisitAction<Ptr<BasicBlock>>> {
+        self.cfg.blocks_visit_order(ctx, cur_block)
+    }
+
+    fn operations_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_block: Ptr<BasicBlock>,
+    ) -> Vec<Ptr<Operation>> {
+        self.cfg.operations_visit_order(ctx, cur_block)
+    }
+}
+
+impl VisitOperation for PreOrderVisitor {
+    fn region_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_operation: Ptr<Operation>,
+    ) -> Vec<Ptr<Region>> {
+        cur_operation.deref(ctx).regions().collect()
+    }
+}
+
+impl VisitRegion for PreOrderVisitor {
+    fn blocks_visit_order(
+        &mut self,
+        ctx: &Context,
+        cur_region: Ptr<Region>,
+    ) -> Vec<Ptr<BasicBlock>> {
+        self.cfg.reset();
+        cur_region
+            .deref(ctx)
+            .get_head()
+            .map(|entry| vec![entry])
+            .unwrap_or_default()
+    }
+}
+
+/// A callback to process an [Operation], with the walker at `State`.
+pub type OpCallback<State> = fn(&mut State, &mut Context, Ptr<Operation>) -> Result<()>;
+/// A callback to process a [BasicBlock], with the walker at `State`.
+pub type BlockCallback<State> = fn(&mut State, &mut Context, Ptr<BasicBlock>) -> Result<()>;
+/// A callback to process an [Region], with the walker at `State`.
+pub type RegionCallback<State> = fn(&mut State, &mut Context, Ptr<Region>) -> Result<()>;
+
+pub struct PreOrderProcessor<State> {
+    pub state: State,
+    op_callback: OpCallback<State>,
+    block_callback: BlockCallback<State>,
+    region_callback: RegionCallback<State>,
+}
+
+impl<State> PreOrderProcessor<State> {
+    pub fn new(
+        state: State,
+        op_callback: OpCallback<State>,
+        block_callback: BlockCallback<State>,
+        region_callback: RegionCallback<State>,
+    ) -> Self {
+        PreOrderProcessor {
+            state,
+            op_callback,
+            block_callback,
+            region_callback,
+        }
+    }
+}
+
+impl<State> ProcessOperation for PreOrderProcessor<State> {
+    fn process_pre_regions(&mut self, ctx: &mut Context, operation: Ptr<Operation>) -> Result<()> {
+        (self.op_callback)(&mut self.state, ctx, operation)
+    }
+}
+
+impl<State> ProcessBlock for PreOrderProcessor<State> {
+    fn process_pre_insts(&mut self, ctx: &mut Context, block: Ptr<BasicBlock>) -> Result<()> {
+        (self.block_callback)(&mut self.state, ctx, block)
+    }
+}
+
+impl<State> ProcessRegion for PreOrderProcessor<State> {
+    fn process_pre_blocks(&mut self, ctx: &mut Context, region: Ptr<Region>) -> Result<()> {
+        (self.region_callback)(&mut self.state, ctx, region)
+    }
+}


### PR DESCRIPTION
This PR introduces a walker that traverses the graph, visiting each node (region, block and op).  At each node, it calls the provided callbacks to process the node.

### How does this differ from MLIR's [walk](https://mlir.llvm.org/doxygen/Visitors_8h_source.html)ers and @urso's [proposals](https://github.com/vaivaswatha/pliron/discussions/25#discussioncomment-8364083)?

The walker introduced by this PR has the ability to traverse the control-flow-graph (formed by the basic blocks in a `Region`) in custom orders (provided by callbacks). The `Order` in MLIR's visitor and @urso's proposals apply to parent-children relation (should parent be processed before / after children) but not a basic block and its CFG successors.

### Mutability
Similar to MLIR, the walker in this PR recommends that modifications be done knowing the fact that at every node, the list of successors / children to be visited next is first computed, and then each visit made. There is no "read-only" version of the trait (i.e., one that takes a `&Context` instead of `&mut Context`) because it doesn't provide much additional safety. Since every entity is inside a `RefCell`, the graph can be modified unsafely during traversal anyway (for example, an operation that was just visited, may be moved to another block where it'll be visited again, making the result possibly incorrect). Providing a `&mut Context` makes it a little more unsafe in that, bad modifications can lead to deleted nodes being visited. I think this is *okay*, with the understanding that, similar to how it's done in MLIR, the expectation is that either all modifications are done post a read-only traversal (which is the convention in MLIR too), or modifications are done such that the traversal is not impacted. With this assumption, every callback to get the next list of nodes to be visited must return a collection (`Vec<_>`) rather than an iterator.

A pre-order walker is implemented as an example (see the new test on how it's used). The main `walker` is in `walker.rs` and the different utility callbacks (at the moment, just a pre-order walker) is in `walkers.rs`.

### Pending
* Introducing proper result types, along with ability to break / continue / advance.