### PR TITLE
Add a simple preconfigured walker

### DIFF
--- a/pliron-derive/src/derive_op.rs
+++ b/pliron-derive/src/derive_op.rs
@@ -87,7 +87,7 @@ impl ToTokens for DefOp {
             let ident = &self.input.ident;
             let generics = &self.input.generics;
             quote! {
-                #[derive(Clone, Copy)]
+                #[derive(Clone, Copy, PartialEq, Eq)]
                 #(#attributes)*
                 #vis struct #ident #generics { op: ::pliron::context::Ptr<::pliron::operation::Operation> }
             }
@@ -170,7 +170,7 @@ mod tests {
         let got = prettyplease::unparse(&f);
 
         expect![[r##"
-            #[derive(Clone, Copy)]
+            #[derive(Clone, Copy, PartialEq, Eq)]
             struct TestOp {
                 op: ::pliron::context::Ptr<::pliron::operation::Operation>,
             }

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -67,8 +67,8 @@ pub fn def_type(args: TokenStream, input: TokenStream) -> TokenStream {
 /// The macro assumes an empty struct and will add the `op: Ptr<Operation>` field used to access
 /// the underlying Operation in the context.
 ///
-/// The macro will automatically derive the `Clone` and `Copy` traits for the new struct
-/// definition.
+/// The macro will automatically derive the `Clone`, `Copy`, `PartialEq` and `Eq` traits for the
+/// new struct definition.
 ///
 /// Usage:
 ///
@@ -80,7 +80,7 @@ pub fn def_type(args: TokenStream, input: TokenStream) -> TokenStream {
 /// The example will create a struct definition equivalent to:
 ///
 /// ```ignore
-/// #[derive(Clone, Copy)]
+/// #[derive(Clone, Copy, PartialEq, Eq)]
 /// pub struct MyOp {
 ///   op: Ptr<Operation>,
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,3 +30,4 @@ pub mod r#type;
 pub mod uniqued_any;
 pub mod use_def_lists;
 pub mod vec_exns;
+pub mod walkers;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -293,6 +293,11 @@ impl Operation {
         self.regions.get(reg_idx).cloned()
     }
 
+    /// Number of regions.
+    pub fn num_regions(&self) -> usize {
+        self.regions.len()
+    }
+
     /// Add a new empty region to the operation and return its [Ptr].
     pub fn add_region(ptr: Ptr<Self>, ctx: &mut Context) -> Ptr<Region> {
         let region = Region::new(ctx, ptr);

--- a/src/walkers.rs
+++ b/src/walkers.rs
@@ -162,7 +162,7 @@ pub fn walk_block<State>(
 }
 
 /// A preset config with [Order::PreOrder] and [Direction::Forward]
-// for all IR node kinds.
+/// for all IR node kinds.
 pub const WALKCONFIG_PREORDER_FORWARD: WalkConfig = WalkConfig {
     regions_in_op: (Order::PreOrder, Direction::Forward),
     ops_in_block: (Order::PreOrder, Direction::Forward),
@@ -170,7 +170,7 @@ pub const WALKCONFIG_PREORDER_FORWARD: WalkConfig = WalkConfig {
 };
 
 /// A preset config with [Order::PostOrder] and [Direction::Forward]
-// for all IR node kinds.
+/// for all IR node kinds.
 pub const WALKCONFIG_POSTORDER_FORWARD: WalkConfig = WalkConfig {
     regions_in_op: (Order::PostOrder, Direction::Forward),
     ops_in_block: (Order::PostOrder, Direction::Forward),

--- a/src/walkers.rs
+++ b/src/walkers.rs
@@ -2,9 +2,15 @@
 //! - Call a callback to process the node.
 //! - Walk over the children.
 //! The relative orders of performing the above is configurable.
+//!
 //! Throughout this module, only parent-child relations are considered,
 //!   i.e., operations->regions, region->blocks and block->operations.
 //!   Successor/predecessor relations b/w blocks (control-flow-graph) is out-of-scope.
+//!
+//! Two types of walkers are provided. The ones in [interruptible] can be interrupted
+//! during the walk, or have the walk over unvisited children skipped. The ones directly
+//! in this module cannot be interrupted and always complete the full walk.
+//!
 //! Care must be taken if modifications are made to the graph during the walk.
 //! Safe modifications:
 //!    Node deletions: A node can be deleted from its parent only when the
@@ -21,8 +27,6 @@
 use crate::{
     basic_block::BasicBlock,
     context::{Context, Ptr},
-    error::Result,
-    linked_list::{ContainsLinkedList, LinkedList},
     operation::Operation,
     region::Region,
 };
@@ -62,8 +66,171 @@ pub enum IRNode {
     Region(Ptr<Region>),
 }
 
-/// The walker functions calls back to functions of this type.
-pub type WalkerCallback<State> = fn(&mut Context, &mut State, IRNode) -> Result<()>;
+/// Walkers that can be interrupted.
+pub mod interruptible {
+    use std::ops::ControlFlow;
+
+    use crate::{
+        basic_block::BasicBlock,
+        context::{Context, Ptr},
+        linked_list::{ContainsLinkedList, LinkedList},
+        operation::Operation,
+        region::Region,
+    };
+
+    use super::*;
+
+    /// How to continue an ongoing walk.
+    pub enum WalkContinue {
+        /// The walk will simply continue.
+        Advance,
+        /// The walk of the current operation, region or block and their nested elements
+        /// that haven't been visited already will be skipped and will continue with the
+        /// next operation, region or block.
+        Skip,
+    }
+
+    impl WalkContinue {
+        /// Is this Self::Advance?
+        pub fn is_advance(&self) -> bool {
+            matches!(self, Self::Advance)
+        }
+
+        /// Is this Self::Skip?
+        pub fn is_skip(&self) -> bool {
+            matches!(self, Self::Skip)
+        }
+    }
+
+    /// Break or continue an ongoing walk. Breaks can be short-circuited using `?`.
+    /// See [mlir::WalkResult](https://mlir.llvm.org/doxygen/classmlir_1_1WalkResult.html).
+    pub type WalkResult<B> = ControlFlow<B, WalkContinue>;
+
+    /// Utility to build WalkResult::Break
+    pub fn walk_break<B>(b: B) -> WalkResult<B> {
+        WalkResult::Break(b)
+    }
+
+    /// Utility to build WalkResult::Continue(WalkContinue::Advance)
+    pub fn walk_advance<B>() -> WalkResult<B> {
+        WalkResult::Continue(WalkContinue::Advance)
+    }
+
+    /// Utility to build WalkResult::Continue(WalkContinue::Skip)
+    pub fn walk_skip<B>() -> WalkResult<B> {
+        WalkResult::Continue(WalkContinue::Skip)
+    }
+
+    /// The walker functions calls back to functions of this type.
+    pub type WalkerCallback<State, B> = fn(&mut Context, &mut State, IRNode) -> WalkResult<B>;
+
+    /// Visit an [Operation] and walk its children [Region]s.
+    pub fn walk_op<State, B>(
+        ctx: &mut Context,
+        state: &mut State,
+        config: &WalkConfig,
+        root: Ptr<Operation>,
+        callback: WalkerCallback<State, B>,
+    ) -> WalkResult<B> {
+        if let Order::PreOrder = config.regions_in_op.0 {
+            let c = callback(ctx, state, IRNode::Operation(root))?;
+            if c.is_skip() {
+                return walk_advance();
+            }
+        }
+
+        let range: Box<dyn Iterator<Item = usize>> = match config.regions_in_op.1 {
+            Direction::Forward => Box::new(0..root.deref(ctx).num_regions()),
+            Direction::Reverse => Box::new((0..root.deref(ctx).num_regions()).rev()),
+        };
+
+        for reg_idx in range {
+            let region = root
+                .deref(ctx)
+                .get_region(reg_idx)
+                .expect("Region deleted during walk");
+            walk_region(ctx, state, config, region, callback)?;
+        }
+
+        if let Order::PostOrder = config.regions_in_op.0 {
+            callback(ctx, state, IRNode::Operation(root))?;
+        }
+
+        walk_advance()
+    }
+
+    /// Visit a [Region] and walk its children [BasicBlock]s.
+    pub fn walk_region<State, B>(
+        ctx: &mut Context,
+        state: &mut State,
+        config: &WalkConfig,
+        root: Ptr<Region>,
+        callback: WalkerCallback<State, B>,
+    ) -> WalkResult<B> {
+        if let Order::PreOrder = config.blocks_in_region.0 {
+            let c = callback(ctx, state, IRNode::Region(root))?;
+            if c.is_skip() {
+                return walk_advance();
+            }
+        }
+
+        let mut cur_block_opt = match config.blocks_in_region.1 {
+            Direction::Forward => root.deref(ctx).get_head(),
+            Direction::Reverse => root.deref(ctx).get_tail(),
+        };
+
+        while let Some(cur_block) = cur_block_opt {
+            walk_block(ctx, state, config, cur_block, callback)?;
+            cur_block_opt = match config.blocks_in_region.1 {
+                Direction::Forward => cur_block.deref(ctx).get_next(),
+                Direction::Reverse => cur_block.deref(ctx).get_prev(),
+            }
+        }
+
+        if let Order::PostOrder = config.blocks_in_region.0 {
+            callback(ctx, state, IRNode::Region(root))?;
+        }
+
+        walk_advance()
+    }
+
+    /// Visit a [BasicBlock] and walk its children [Operation]s.
+    pub fn walk_block<State, B>(
+        ctx: &mut Context,
+        state: &mut State,
+        config: &WalkConfig,
+        root: Ptr<BasicBlock>,
+        callback: WalkerCallback<State, B>,
+    ) -> WalkResult<B> {
+        if let Order::PreOrder = config.ops_in_block.0 {
+            let c = callback(ctx, state, IRNode::BasicBlock(root))?;
+            if c.is_skip() {
+                return walk_advance();
+            }
+        }
+
+        let mut cur_op_opt = match config.ops_in_block.1 {
+            Direction::Forward => root.deref(ctx).get_head(),
+            Direction::Reverse => root.deref(ctx).get_tail(),
+        };
+
+        while let Some(cur_op) = cur_op_opt {
+            walk_op(ctx, state, config, cur_op, callback)?;
+            cur_op_opt = match config.ops_in_block.1 {
+                Direction::Forward => cur_op.deref(ctx).get_next(),
+                Direction::Reverse => cur_op.deref(ctx).get_prev(),
+            }
+        }
+
+        if let Order::PostOrder = config.ops_in_block.0 {
+            callback(ctx, state, IRNode::BasicBlock(root))?;
+        }
+
+        walk_advance()
+    }
+}
+
+pub type WalkerCallback<State> = fn(&mut Context, &mut State, IRNode);
 
 /// Visit an [Operation] and walk its children [Region]s.
 pub fn walk_op<State>(
@@ -72,29 +239,18 @@ pub fn walk_op<State>(
     config: &WalkConfig,
     root: Ptr<Operation>,
     callback: WalkerCallback<State>,
-) -> Result<()> {
-    if let Order::PreOrder = config.regions_in_op.0 {
-        callback(ctx, state, IRNode::Operation(root))?
+) {
+    struct S<'a, State> {
+        state: &'a mut State,
+        callback: WalkerCallback<State>,
     }
 
-    let range: Box<dyn Iterator<Item = usize>> = match config.regions_in_op.1 {
-        Direction::Forward => Box::new(0..root.deref(ctx).num_regions()),
-        Direction::Reverse => Box::new((0..root.deref(ctx).num_regions()).rev()),
-    };
+    let mut s = S { state, callback };
 
-    for reg_idx in range {
-        let region = root
-            .deref(ctx)
-            .get_region(reg_idx)
-            .expect("Region deleted during walk");
-        walk_region(ctx, state, config, region, callback)?
-    }
-
-    if let Order::PostOrder = config.regions_in_op.0 {
-        callback(ctx, state, IRNode::Operation(root))?
-    }
-
-    Ok(())
+    interruptible::walk_op(ctx, &mut s, config, root, |ctx, s, node| {
+        (s.callback)(ctx, s.state, node);
+        interruptible::walk_advance::<()>()
+    });
 }
 
 /// Visit a [Region] and walk its children [BasicBlock]s.
@@ -104,29 +260,18 @@ pub fn walk_region<State>(
     config: &WalkConfig,
     root: Ptr<Region>,
     callback: WalkerCallback<State>,
-) -> Result<()> {
-    if let Order::PreOrder = config.blocks_in_region.0 {
-        callback(ctx, state, IRNode::Region(root))?
+) {
+    struct S<'a, State> {
+        state: &'a mut State,
+        callback: WalkerCallback<State>,
     }
 
-    let mut cur_block_opt = match config.blocks_in_region.1 {
-        Direction::Forward => root.deref(ctx).get_head(),
-        Direction::Reverse => root.deref(ctx).get_tail(),
-    };
+    let mut s = S { state, callback };
 
-    while let Some(cur_block) = cur_block_opt {
-        walk_block(ctx, state, config, cur_block, callback)?;
-        cur_block_opt = match config.blocks_in_region.1 {
-            Direction::Forward => cur_block.deref(ctx).get_next(),
-            Direction::Reverse => cur_block.deref(ctx).get_prev(),
-        }
-    }
-
-    if let Order::PostOrder = config.blocks_in_region.0 {
-        callback(ctx, state, IRNode::Region(root))?
-    }
-
-    Ok(())
+    interruptible::walk_region(ctx, &mut s, config, root, |ctx, s, node| {
+        (s.callback)(ctx, s.state, node);
+        interruptible::walk_advance::<()>()
+    });
 }
 
 /// Visit a [BasicBlock] and walk its children [Operation]s.
@@ -136,29 +281,18 @@ pub fn walk_block<State>(
     config: &WalkConfig,
     root: Ptr<BasicBlock>,
     callback: WalkerCallback<State>,
-) -> Result<()> {
-    if let Order::PreOrder = config.ops_in_block.0 {
-        callback(ctx, state, IRNode::BasicBlock(root))?
+) {
+    struct S<'a, State> {
+        state: &'a mut State,
+        callback: WalkerCallback<State>,
     }
 
-    let mut cur_op_opt = match config.ops_in_block.1 {
-        Direction::Forward => root.deref(ctx).get_head(),
-        Direction::Reverse => root.deref(ctx).get_tail(),
-    };
+    let mut s = S { state, callback };
 
-    while let Some(cur_op) = cur_op_opt {
-        walk_op(ctx, state, config, cur_op, callback)?;
-        cur_op_opt = match config.ops_in_block.1 {
-            Direction::Forward => cur_op.deref(ctx).get_next(),
-            Direction::Reverse => cur_op.deref(ctx).get_prev(),
-        }
-    }
-
-    if let Order::PostOrder = config.ops_in_block.0 {
-        callback(ctx, state, IRNode::BasicBlock(root))?
-    }
-
-    Ok(())
+    interruptible::walk_block(ctx, &mut s, config, root, |ctx, s, node| {
+        (s.callback)(ctx, s.state, node);
+        interruptible::walk_advance::<()>()
+    });
 }
 
 /// A preset config with [Order::PreOrder] and [Direction::Forward]
@@ -175,4 +309,20 @@ pub const WALKCONFIG_POSTORDER_FORWARD: WalkConfig = WalkConfig {
     regions_in_op: (Order::PostOrder, Direction::Forward),
     ops_in_block: (Order::PostOrder, Direction::Forward),
     blocks_in_region: (Order::PostOrder, Direction::Forward),
+};
+
+/// A preset config with [Order::PreOrder] and [Direction::Reverse]
+/// for all IR node kinds.
+pub const WALKCONFIG_PREORDER_REVERSE: WalkConfig = WalkConfig {
+    regions_in_op: (Order::PreOrder, Direction::Reverse),
+    ops_in_block: (Order::PreOrder, Direction::Reverse),
+    blocks_in_region: (Order::PreOrder, Direction::Reverse),
+};
+
+/// A preset config with [Order::PostOrder] and [Direction::Reverse]
+/// for all IR node kinds.
+pub const WALKCONFIG_POSTORDER_REVERSE: WalkConfig = WalkConfig {
+    regions_in_op: (Order::PostOrder, Direction::Reverse),
+    ops_in_block: (Order::PostOrder, Direction::Reverse),
+    blocks_in_region: (Order::PostOrder, Direction::Reverse),
 };

--- a/src/walkers.rs
+++ b/src/walkers.rs
@@ -1,0 +1,165 @@
+//! Walk the IR graph. At each node:
+//! - Call a callback to process the node.
+//! - Walk over the children.
+//! The relative orders of performing the above is configurable.
+//! Care must be taken if modifications are made to the graph during the walk.
+//! TODO: What is the least restrictive set of guidelines for safe modification?
+
+use crate::{
+    basic_block::BasicBlock,
+    context::{Context, Ptr},
+    error::Result,
+    linked_list::{ContainsLinkedList, LinkedList},
+    operation::Operation,
+    region::Region,
+};
+
+#[derive(Clone, Copy, Debug)]
+/// Should the callback for a node be called before or after processing its children.
+pub enum Order {
+    /// Call the callback for a node before processing its children.
+    PreOrder,
+    /// Call the callback for a node after processing its children.
+    PostOrder,
+}
+
+#[derive(Clone, Copy, Debug)]
+/// The order in which children nodes are walked over.
+pub enum Direction {
+    /// Process nodes in lexicographic order.
+    Forward,
+    /// Process nodes in reverse lexicographic order.
+    Reverse,
+}
+
+/// For an IR walk, specify the order of visiting different kinds of nodes.
+pub struct WalkConfig {
+    /// Order of processing [Region]s in an [Operation].
+    pub regions_in_op: (Order, Direction),
+    /// Order of processing [Operation]s in a [BasicBlock]
+    pub ops_in_block: (Order, Direction),
+    ///Order of processing [BasicBlock]s in a [Region]
+    pub blocks_in_region: (Order, Direction),
+}
+
+/// The walker calls the callback for any of these IR entities.
+pub enum IRNode {
+    Operation(Ptr<Operation>),
+    BasicBlock(Ptr<BasicBlock>),
+    Region(Ptr<Region>),
+}
+
+/// The walker functions calls back to functions of this type.
+pub type WalkerCallback<State> = fn(&mut Context, &mut State, IRNode) -> Result<()>;
+
+/// Visit an [Operation] and walk its children [Region]s.
+pub fn walk_op<State>(
+    ctx: &mut Context,
+    state: &mut State,
+    config: &WalkConfig,
+    root: Ptr<Operation>,
+    callback: WalkerCallback<State>,
+) -> Result<()> {
+    if let Order::PreOrder = config.regions_in_op.0 {
+        callback(ctx, state, IRNode::Operation(root))?
+    }
+
+    let range: Box<dyn Iterator<Item = usize>> = match config.regions_in_op.1 {
+        Direction::Forward => Box::new(0..root.deref(ctx).num_regions()),
+        Direction::Reverse => Box::new((0..root.deref(ctx).num_regions()).rev()),
+    };
+
+    for reg_idx in range {
+        let region = root
+            .deref(ctx)
+            .get_region(reg_idx)
+            .expect("Region deleted during walk");
+        walk_region(ctx, state, config, region, callback)?
+    }
+
+    if let Order::PostOrder = config.regions_in_op.0 {
+        callback(ctx, state, IRNode::Operation(root))?
+    }
+
+    Ok(())
+}
+
+/// Visit a [Region] and walk its children [BasicBlock]s.
+pub fn walk_region<State>(
+    ctx: &mut Context,
+    state: &mut State,
+    config: &WalkConfig,
+    root: Ptr<Region>,
+    callback: WalkerCallback<State>,
+) -> Result<()> {
+    if let Order::PreOrder = config.blocks_in_region.0 {
+        callback(ctx, state, IRNode::Region(root))?
+    }
+
+    let mut cur_block_opt = match config.blocks_in_region.1 {
+        Direction::Forward => root.deref(ctx).get_head(),
+        Direction::Reverse => root.deref(ctx).get_tail(),
+    };
+
+    while let Some(cur_block) = cur_block_opt {
+        walk_block(ctx, state, config, cur_block, callback)?;
+        cur_block_opt = match config.blocks_in_region.1 {
+            Direction::Forward => cur_block.deref(ctx).get_next(),
+            Direction::Reverse => cur_block.deref(ctx).get_prev(),
+        }
+    }
+
+    if let Order::PostOrder = config.blocks_in_region.0 {
+        callback(ctx, state, IRNode::Region(root))?
+    }
+
+    Ok(())
+}
+
+/// Visit a [BasicBlock] and walk its children [Operation]s.
+pub fn walk_block<State>(
+    ctx: &mut Context,
+    state: &mut State,
+    config: &WalkConfig,
+    root: Ptr<BasicBlock>,
+    callback: WalkerCallback<State>,
+) -> Result<()> {
+    if let Order::PreOrder = config.ops_in_block.0 {
+        callback(ctx, state, IRNode::BasicBlock(root))?
+    }
+
+    let mut cur_op_opt = match config.ops_in_block.1 {
+        Direction::Forward => root.deref(ctx).get_head(),
+        Direction::Reverse => root.deref(ctx).get_tail(),
+    };
+
+    while let Some(cur_op) = cur_op_opt {
+        walk_op(ctx, state, config, cur_op, callback)?;
+        cur_op_opt = match config.ops_in_block.1 {
+            Direction::Forward => cur_op.deref(ctx).get_next(),
+            Direction::Reverse => cur_op.deref(ctx).get_prev(),
+        }
+    }
+
+    if let Order::PostOrder = config.ops_in_block.0 {
+        callback(ctx, state, IRNode::BasicBlock(root))?
+    }
+
+    Ok(())
+}
+
+/// A preset config with [Order::PreOrder] and [Direction::Forward]
+// for all IR node kinds.
+pub const WALKCONFIG_PREORDER_FORWARD: WalkConfig = WalkConfig {
+    regions_in_op: (Order::PreOrder, Direction::Forward),
+    ops_in_block: (Order::PreOrder, Direction::Forward),
+    blocks_in_region: (Order::PreOrder, Direction::Forward),
+};
+
+/// A preset config with [Order::PostOrder] and [Direction::Forward]
+// for all IR node kinds.
+pub const WALKCONFIG_POSTORDER_FORWARD: WalkConfig = WalkConfig {
+    regions_in_op: (Order::PostOrder, Direction::Forward),
+    ops_in_block: (Order::PostOrder, Direction::Forward),
+    blocks_in_region: (Order::PostOrder, Direction::Forward),
+};

--- a/src/walkers.rs
+++ b/src/walkers.rs
@@ -2,8 +2,21 @@
 //! - Call a callback to process the node.
 //! - Walk over the children.
 //! The relative orders of performing the above is configurable.
+//! Throughout this module, only parent-child relations are considered,
+//!   i.e., operations->regions, region->blocks and block->operations.
+//!   Successor/predecessor relations b/w blocks (control-flow-graph) is out-of-scope.
 //! Care must be taken if modifications are made to the graph during the walk.
-//! TODO: What is the least restrictive set of guidelines for safe modification?
+//! Safe modifications:
+//!    Node deletions: A node can be deleted from its parent only when the
+//!        parent is visited in a PostOrder walk, after all children are processed.
+//!        This ensure deleted nodes aren't visited.
+//!    Node additions: A node can be inserted into its parent only when the
+//!        parent is visited in a PreOrder walk, before any child is processed.
+//!        This ensures that the new node gets visited.
+//!    Other graph modifications such as changing the order b/w siblings are unsafe.
+//!        (i.e., doing so may lead to multiple visits of the same node or
+//!         some nodes remaining unvisited).
+//!    Non-graph modifications are safe.
 
 use crate::{
     basic_block::BasicBlock,

--- a/src/walkers.rs
+++ b/src/walkers.rs
@@ -12,10 +12,10 @@
 //! in this module cannot be interrupted and always complete the full walk.
 //!
 //! Care must be taken if modifications are made to the graph during the walk.
-//! Safe modifications:
+//! Safety:
 //!    Node deletions: A node can be deleted from its parent only when the
 //!        parent is visited in a PostOrder walk, after all children are processed.
-//!        This ensure deleted nodes aren't visited.
+//!        This ensures that deleted nodes aren't visited.
 //!    Node additions: A node can be inserted into its parent only when the
 //!        parent is visited in a PreOrder walk, before any child is processed.
 //!        This ensures that the new node gets visited.

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -314,20 +314,20 @@ fn test_preorder_forward_walk() {
     });
     expect![[r#"
         builtin.module @bar {
-          ^block_0_0():
+          ^block_1v1():
             builtin.func @foo: builtin.function<() -> (builtin.int<si64>)> {
-              ^entry_block_1_0():
-                c0_op_2_0_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
-                llvm.return c0_op_2_0_res0
+              ^entry_block_2v1():
+                c0_op_3v1_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
+                llvm.return c0_op_3v1_res0
             }
         }
         builtin.func @foo: builtin.function<() -> (builtin.int<si64>)> {
-          ^entry_block_1_0():
-            c0_op_2_0_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
-            llvm.return c0_op_2_0_res0
+          ^entry_block_2v1():
+            c0_op_3v1_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
+            llvm.return c0_op_3v1_res0
         }
-        c0_op_2_0_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>
-        llvm.return c0_op_2_0_res0
+        c0_op_3v1_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>
+        llvm.return c0_op_3v1_res0
     "#]]
     .assert_eq(&ops);
 }
@@ -355,19 +355,19 @@ fn test_postorder_forward_walk() {
         accum + &op.disp(ctx).to_string() + "\n"
     });
     expect![[r#"
-        c0_op_2_0_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>
-        llvm.return c0_op_2_0_res0
+        c0_op_3v1_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>
+        llvm.return c0_op_3v1_res0
         builtin.func @foo: builtin.function<() -> (builtin.int<si64>)> {
-          ^entry_block_1_0():
-            c0_op_2_0_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
-            llvm.return c0_op_2_0_res0
+          ^entry_block_2v1():
+            c0_op_3v1_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
+            llvm.return c0_op_3v1_res0
         }
         builtin.module @bar {
-          ^block_0_0():
+          ^block_1v1():
             builtin.func @foo: builtin.function<() -> (builtin.int<si64>)> {
-              ^entry_block_1_0():
-                c0_op_2_0_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
-                llvm.return c0_op_2_0_res0
+              ^entry_block_2v1():
+                c0_op_3v1_res0 = builtin.constant builtin.integer <0x0: builtin.int<si64>>;
+                llvm.return c0_op_3v1_res0
             }
         }
     "#]]


### PR DESCRIPTION
This PR provides a set of walkers (one for each IR node kind - op, block and region) that are pre-configured (when called with the root node) on when the callback is called (w.r.t walking over the children) and the order in which children are walked over.

The callback itself is a simple common type for all IR node kinds.

The walker provides `&mut Context` to the callback. What's safe and not is documented in the module docs.

Another slightly more extensible alternate to this approach is to provide a trait that combines the configuration, state and callbacks into one. (i.e., the trait has query functions to get each). This will allow the flexibility of objects to change the configuration and callbacks *during* the walk. I don't know if that's useful, but it's doable. It's likely going to make usage more verbose, so I suppose we're better off with the current version.

References: @urso's [proposals](https://github.com/vaivaswatha/pliron/discussions/25#discussioncomment-8364083) and my previous [PR](#31).