### PR TITLE
CI: Add llvm dependence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      LLVM_SYS_170_PREFIX: ~/pliron/llvm
     needs: llvm
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,47 +11,30 @@ env:
 
 jobs:
   build:
-    name: Build
+    name: pliron CI
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-    - name: Install LLVM
-      run: wget https://apt.llvm.org/llvm.sh; chmod +x llvm.sh; sudo ./llvm.sh 17; sudo apt-get install libpolly-17-dev
-    - run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
-  tests:
-    name: Run tests
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-    - run: cargo test --workspace --verbose
+    - name: Setup LLVM
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 17
+        sudo apt-get install libpolly-17-dev
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-    - run: cargo clippy --workspace -- -D warnings
+    - name: Build
+      run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
-  format:
-    name: Code format
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-    - run: cargo fmt --check
+    - name: Run tests
+      run: cargo test --workspace --verbose
 
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-    - run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace
+    - name: Clippy
+      run: cargo clippy --workspace -- -D warnings
+
+    - name: Code format
+      run: cargo fmt --check
+
+    - name: Documentation
+      run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,13 @@ env:
 
 jobs:
   llvm:
-    name: Install LLVM and Clang
-    uses: KyleMayes/install-llvm-action@v2.0.3
-    with:
-      version: "17.0"
+    name: Install LLVM repositories Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+    - run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 17
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - name: Install LLVM
-      run: wget https://apt.llvm.org/llvm.sh; chmod +x llvm.sh; sudo ./llvm.sh 17
+      run: wget https://apt.llvm.org/llvm.sh; chmod +x llvm.sh; sudo ./llvm.sh 17; sudo apt-get install libpolly17-dev
     - run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: llvm
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  llvm:
+    name: Install LLVM and Clang
+    uses: KyleMayes/install-llvm-action@v2.0.3
+    with:
+      version: "17.0"
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,24 +10,17 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  llvm:
-    name: Install LLVM and Clang
-    runs-on: ubuntu-latest
-    steps:
-    - name: Install LLVM and Clang
-      uses: KyleMayes/install-llvm-action@v2
-      with:
-        version: "17.0"
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    env:
-      LLVM_SYS_170_PREFIX: ~/pliron/llvm
-    needs: llvm
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
+    - name: Install LLVM
+      run:
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 17
     - run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ env:
 
 jobs:
   llvm:
-    name: Install LLVM repositories Ubuntu
+    name: Install LLVM and Clang
     runs-on: ubuntu-latest
     steps:
-    - run: |
-        wget https://apt.llvm.org/llvm.sh
-        chmod +x llvm.sh
-        sudo ./llvm.sh 17
+    - name: Install LLVM and Clang
+      uses: KyleMayes/install-llvm-action@v2
+      with:
+        version: "17.0"
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - name: Install LLVM
-      run: wget https://apt.llvm.org/llvm.sh; chmod +x llvm.sh; sudo ./llvm.sh 17; sudo apt-get install libpolly17-dev
+      run: wget https://apt.llvm.org/llvm.sh; chmod +x llvm.sh; sudo ./llvm.sh 17; sudo apt-get install libpolly-17-dev
     - run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    name: pliron CI
+    name: Build and Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -27,13 +27,13 @@ jobs:
     - name: Build
       run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
-    - name: Run tests
+    - name: Tests
       run: cargo test --workspace --verbose
 
     - name: Clippy
       run: cargo clippy --workspace -- -D warnings
 
-    - name: Code format
+    - name: Format
       run: cargo fmt --check
 
     - name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
     - name: Install LLVM
-      run:
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 17
+      run: wget https://apt.llvm.org/llvm.sh; chmod +x llvm.sh; sudo ./llvm.sh 17
     - run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
   tests:


### PR DESCRIPTION
With the recent inkwell dependence for the LLVM dialect, we need CI to install LLVM.