### PR TITLE
Add link to Pliron Rust workshop youtube videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ with other compiler projects, touching upon some design decisions.
 ### Some talks on `pliron`
 * [pliron: An Extensible IR Framework in Rust - IICT'24](https://www.youtube.com/watch?v=LobYuwcUaZA)
 * [Rust(ing) the Future of Compilers: Pliron as the MLIR Alternative (No C/C++)](https://www.youtube.com/watch?v=rRgYGBAhKQ0)
+* [Pliron Rust Workshop (6 sessions)](https://www.youtube.com/watch?v=6EjMWJ2PY-o)


### PR DESCRIPTION
I did not yet watch the videos but I plan to do so and though it might be worth referencing them in the README.