### PR TITLE
Remove `get_` prefix from getter methods

### DIFF
--- a/pliron-derive/src/derive_attr.rs
+++ b/pliron-derive/src/derive_attr.rs
@@ -96,11 +96,11 @@ impl ToTokens for ImplAttribute {
                         .map_or(false, |other| other == self)
                 }
 
-                fn get_attr_id(&self) -> ::pliron::attribute::AttrId {
-                    Self::get_attr_id_static()
+                fn attr_id(&self) -> ::pliron::attribute::AttrId {
+                    Self::attr_id_static()
                 }
 
-                fn get_attr_id_static() -> ::pliron::attribute::AttrId {
+                fn attr_id_static() -> ::pliron::attribute::AttrId {
                     ::pliron::attribute::AttrId {
                         name: ::pliron::attribute::AttrName::new(#attr_name),
                         dialect: ::pliron::dialect::DialectName::new(#dialect),
@@ -109,7 +109,7 @@ impl ToTokens for ImplAttribute {
 
                 fn verify_interfaces(&self, ctx: &::pliron::context::Context) -> ::pliron::result::Result<()> {
                     if let Some(interface_verifiers) =
-                        ::pliron::attribute::ATTR_INTERFACE_VERIFIERS_MAP.get(&Self::get_attr_id_static())
+                        ::pliron::attribute::ATTR_INTERFACE_VERIFIERS_MAP.get(&Self::attr_id_static())
                     {
                         for (_, verifier) in interface_verifiers {
                             verifier(self, ctx)?;
@@ -146,10 +146,10 @@ mod tests {
                 fn eq_attr(&self, other: &dyn ::pliron::attribute::Attribute) -> bool {
                     other.downcast_ref::<Self>().map_or(false, |other| other == self)
                 }
-                fn get_attr_id(&self) -> ::pliron::attribute::AttrId {
-                    Self::get_attr_id_static()
+                fn attr_id(&self) -> ::pliron::attribute::AttrId {
+                    Self::attr_id_static()
                 }
-                fn get_attr_id_static() -> ::pliron::attribute::AttrId {
+                fn attr_id_static() -> ::pliron::attribute::AttrId {
                     ::pliron::attribute::AttrId {
                         name: ::pliron::attribute::AttrName::new("unit"),
                         dialect: ::pliron::dialect::DialectName::new("testing"),
@@ -160,7 +160,7 @@ mod tests {
                     ctx: &::pliron::context::Context,
                 ) -> ::pliron::result::Result<()> {
                     if let Some(interface_verifiers) = ::pliron::attribute::ATTR_INTERFACE_VERIFIERS_MAP
-                        .get(&Self::get_attr_id_static())
+                        .get(&Self::attr_id_static())
                     {
                         for (_, verifier) in interface_verifiers {
                             verifier(self, ctx)?;

--- a/pliron-derive/src/derive_op.rs
+++ b/pliron-derive/src/derive_op.rs
@@ -103,7 +103,7 @@ impl ToTokens for ImplOp {
         let op_name = &self.op_name;
         tokens.extend(quote! {
             impl ::pliron::op::Op for #name {
-                fn get_operation(&self) -> ::pliron::context::Ptr<::pliron::operation::Operation> {
+                fn operation(&self) -> ::pliron::context::Ptr<::pliron::operation::Operation> {
                     self.op
                 }
 
@@ -111,11 +111,11 @@ impl ToTokens for ImplOp {
                     Box::new(#name { op })
                 }
 
-                fn get_opid(&self) -> ::pliron::op::OpId {
-                    Self::get_opid_static()
+                fn opid(&self) -> ::pliron::op::OpId {
+                    Self::opid_static()
                 }
 
-                fn get_opid_static() -> ::pliron::op::OpId {
+                fn opid_static() -> ::pliron::op::OpId {
                     ::pliron::op::OpId {
                         name: ::pliron::op::OpName::new(#op_name),
                         dialect: ::pliron::dialect::DialectName::new(#dialect),
@@ -124,7 +124,7 @@ impl ToTokens for ImplOp {
 
                 fn verify_interfaces(&self, ctx: &::pliron::context::Context) -> ::pliron::result::Result<()> {
                     if let Some(interface_verifiers) =
-                        ::pliron::op::OP_INTERFACE_VERIFIERS_MAP.get(&Self::get_opid_static())
+                        ::pliron::op::OP_INTERFACE_VERIFIERS_MAP.get(&Self::opid_static())
                     {
                         for (_, verifier) in interface_verifiers {
                             verifier(self, ctx)?;
@@ -158,7 +158,7 @@ mod tests {
                 op: ::pliron::context::Ptr<::pliron::operation::Operation>,
             }
             impl ::pliron::op::Op for TestOp {
-                fn get_operation(&self) -> ::pliron::context::Ptr<::pliron::operation::Operation> {
+                fn operation(&self) -> ::pliron::context::Ptr<::pliron::operation::Operation> {
                     self.op
                 }
                 fn wrap_operation(
@@ -166,10 +166,10 @@ mod tests {
                 ) -> ::pliron::op::OpObj {
                     Box::new(TestOp { op })
                 }
-                fn get_opid(&self) -> ::pliron::op::OpId {
-                    Self::get_opid_static()
+                fn opid(&self) -> ::pliron::op::OpId {
+                    Self::opid_static()
                 }
-                fn get_opid_static() -> ::pliron::op::OpId {
+                fn opid_static() -> ::pliron::op::OpId {
                     ::pliron::op::OpId {
                         name: ::pliron::op::OpName::new("testop"),
                         dialect: ::pliron::dialect::DialectName::new("testing"),
@@ -180,7 +180,7 @@ mod tests {
                     ctx: &::pliron::context::Context,
                 ) -> ::pliron::result::Result<()> {
                     if let Some(interface_verifiers) = ::pliron::op::OP_INTERFACE_VERIFIERS_MAP
-                        .get(&Self::get_opid_static())
+                        .get(&Self::opid_static())
                     {
                         for (_, verifier) in interface_verifiers {
                             verifier(self, ctx)?;

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -356,14 +356,14 @@ pub fn op_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn op_interface_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let interface_verifiers_slice = parse_quote! { ::pliron::op::OP_INTERFACE_VERIFIERS };
     let id = parse_quote! { ::pliron::op::OpId };
-    let get_id_static = format_ident!("{}", "get_opid_static");
+    let id_static = format_ident!("{}", "opid_static");
     let verifier_type = parse_quote! { ::pliron::op::OpInterfaceVerifier };
     to_token_stream(interfaces::interface_impl(
         item,
         interface_verifiers_slice,
         id,
         verifier_type,
-        get_id_static,
+        id_static,
     ))
 }
 
@@ -503,7 +503,7 @@ pub fn attr_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn attr_interface_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let interface_verifiers_slice = parse_quote! { ::pliron::attribute::ATTR_INTERFACE_VERIFIERS };
     let id = parse_quote! { ::pliron::attribute::AttrId };
-    let get_id_static = format_ident!("{}", "get_attr_id_static");
+    let get_id_static = format_ident!("{}", "attr_id_static");
     let verifier_type = parse_quote! { ::pliron::attribute::AttrInterfaceVerifier };
     to_token_stream(interfaces::interface_impl(
         item,

--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -30,7 +30,7 @@ fn zero_results_zero_operands() {
 
     let op = Operation::new(
         ctx,
-        ZeroResultsZeroOperandsOp::get_opid_static(),
+        ZeroResultsZeroOperandsOp::opid_static(),
         vec![],
         vec![],
         vec![],

--- a/pliron-llvm/src/bin/llvm-opt.rs
+++ b/pliron-llvm/src/bin/llvm-opt.rs
@@ -34,7 +34,7 @@ fn run(cli: Cli, ctx: &mut Context) -> Result<()> {
 
     let pliron_module = from_llvm_ir::convert_module(ctx, &module)?;
     // println!("{}", pliron_module.disp(ctx));
-    pliron_module.get_operation().verify(ctx)?;
+    pliron_module.operation().verify(ctx)?;
 
     let module = to_llvm_ir::convert_module(ctx, &llvm_context, pliron_module)?;
     module

--- a/pliron-llvm/src/op_interfaces.rs
+++ b/pliron-llvm/src/op_interfaces.rs
@@ -37,21 +37,21 @@ pub trait BinArithOp: SameOperandsAndResultType + OneResultInterface {
     {
         let op = Operation::new(
             ctx,
-            Self::get_opid_static(),
+            Self::opid_static(),
             vec![lhs.get_type(ctx)],
             vec![lhs, rhs],
             vec![],
             0,
         );
-        *Operation::get_op(op, ctx).downcast::<Self>().ok().unwrap()
+        *Operation::op(op, ctx).downcast::<Self>().ok().unwrap()
     }
 
     fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
-        let op = op.get_operation().deref(ctx);
-        if op.get_num_operands() != 2 {
+        let op = op.operation().deref(ctx);
+        if op.num_operands() != 2 {
             return verify_err!(op.loc(), BinArithOpErr);
         }
 
@@ -78,7 +78,7 @@ pub trait IntBinArithOp: BinArithOp {
             return verify_err!(op.loc(ctx), IntBinArithOpErr);
         };
 
-        if int_ty.get_signedness() != Signedness::Signless {
+        if int_ty.signedness() != Signedness::Signless {
             return verify_err!(op.loc(ctx), IntBinArithOpErr);
         }
 
@@ -117,7 +117,7 @@ pub trait IntBinArithOpWithOverflowFlag: IntBinArithOp {
     where
         Self: Sized,
     {
-        self.get_operation()
+        self.operation()
             .deref(ctx)
             .attributes
             .get::<IntegerOverflowFlagsAttr>(&ATTR_KEY_INTEGER_OVERFLOW_FLAGS)
@@ -130,7 +130,7 @@ pub trait IntBinArithOpWithOverflowFlag: IntBinArithOp {
     where
         Self: Sized,
     {
-        self.get_operation()
+        self.operation()
             .deref_mut(ctx)
             .attributes
             .set(ATTR_KEY_INTEGER_OVERFLOW_FLAGS.clone(), flag);
@@ -140,7 +140,7 @@ pub trait IntBinArithOpWithOverflowFlag: IntBinArithOp {
     where
         Self: Sized,
     {
-        let op = op.get_operation().deref(ctx);
+        let op = op.operation().deref(ctx);
         if op
             .attributes
             .get::<IntegerOverflowFlagsAttr>(&ATTR_KEY_INTEGER_OVERFLOW_FLAGS)
@@ -190,13 +190,13 @@ pub trait CastOpInterface: OneResultInterface + OneOpdInterface {
     {
         let op = Operation::new(
             ctx,
-            Self::get_opid_static(),
+            Self::opid_static(),
             vec![res_type],
             vec![operand],
             vec![],
             0,
         );
-        *Operation::get_op(op, ctx).downcast::<Self>().ok().unwrap()
+        *Operation::op(op, ctx).downcast::<Self>().ok().unwrap()
     }
 
     fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -96,7 +96,7 @@ impl StructType {
 
     /// If a named struct already exists, get a pointer to it.
     pub fn get_existing_named(ctx: &Context, name: &Identifier) -> Option<TypePtr<Self>> {
-        Type::get_instance(
+        Type::instance(
             StructType {
                 name: Some(name.clone()),
                 // Named structs are uniqued only on the name.
@@ -108,7 +108,7 @@ impl StructType {
 
     /// If an unnamed struct already exists, get a pointer to it.
     pub fn get_existing_unnamed(ctx: &Context, fields: Vec<Ptr<TypeObj>>) -> Option<TypePtr<Self>> {
-        Type::get_instance(
+        Type::instance(
             StructType {
                 name: None,
                 fields: Some(fields),
@@ -306,7 +306,7 @@ impl PointerType {
     }
     /// Get, if it already exists, a pointer type.
     pub fn get_existing(ctx: &Context) -> Option<TypePtr<Self>> {
-        Type::get_instance(PointerType, ctx)
+        Type::instance(PointerType, ctx)
     }
 }
 
@@ -328,7 +328,7 @@ impl ArrayType {
     }
     /// Get, if it already exists, an array type.
     pub fn get_existing(ctx: &Context, elem: Ptr<TypeObj>, size: u64) -> Option<TypePtr<Self>> {
-        Type::get_instance(ArrayType { elem, size }, ctx)
+        Type::instance(ArrayType { elem, size }, ctx)
     }
 
     /// Get array element type.
@@ -473,7 +473,7 @@ mod tests {
         }
         /// Get, if it already exists, a pointer type.
         pub fn get_existing(ctx: &Context, to: Ptr<TypeObj>) -> Option<TypePtr<Self>> {
-            Type::get_instance(TypedPointerType { to }, ctx)
+            Type::instance(TypedPointerType { to }, ctx)
         }
 
         /// Get the pointee type.
@@ -532,11 +532,11 @@ mod tests {
                 .deref(&ctx)
                 .downcast_ref::<IntegerType>()
                 .unwrap()
-                .get_width()
+                .width()
                 == 64
         );
 
-        assert!(IntegerType::get_existing(&ctx, 32, Signedness::Signed).unwrap() == int32_1_ptr);
+        assert!(IntegerType::existing(&ctx, 32, Signedness::Signed).unwrap() == int32_1_ptr);
         assert!(TypedPointerType::get_existing(&ctx, int64_ptr).unwrap() == int64pointer_ptr);
         assert!(int64pointer_ptr.deref(&ctx).get_pointee_type() == int64_ptr);
     }

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -138,7 +138,7 @@ fn test_fib_plir(filename: &str) -> Result<()> {
     let module = LLVMModule::from_ir_in_file(&llvm_context, fib_mem2reg_ll_path.to_str().unwrap())
         .map_err(|err| arg_error_noloc!("{}", err))?;
     let pliron_module = from_llvm_ir::convert_module(ctx, &module)?;
-    pliron_module.get_operation().verify(ctx)?;
+    pliron_module.operation().verify(ctx)?;
 
     // Create a temp dir to place the plir file.
     let tmp_dir = tempdir().unwrap();
@@ -200,7 +200,7 @@ fn test_llvm_ir_via_pliron(input_file: &str, expected_output: i32) {
         .map_err(|err| arg_error_noloc!("{}", err))
         .unwrap();
 
-    match pliron_module.get_operation().verify(ctx) {
+    match pliron_module.operation().verify(ctx) {
         Ok(_) => (),
         Err(err) => {
             eprintln!("{}", err.disp(ctx));

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -176,10 +176,10 @@ pub trait Attribute: Printable + Verify + Downcast + Sync + Send + DynClone + De
 
     /// Get an [Attribute]'s static name. This is *not* per instantnce.
     /// It is mostly useful for printing and parsing the attribute.
-    fn get_attr_id(&self) -> AttrId;
+    fn attr_id(&self) -> AttrId;
 
-    /// Same as [get_attr_id](Self::get_attr_id), but without the self reference.
-    fn get_attr_id_static() -> AttrId
+    /// Same as [attr_id](Self::attr_id), but without the self reference.
+    fn attr_id_static() -> AttrId
     where
         Self: Sized;
 
@@ -212,12 +212,12 @@ pub trait Attribute: Printable + Verify + Downcast + Sync + Send + DynClone + De
             })
             .boxed()
         });
-        let attrid = Self::get_attr_id_static();
+        let attrid = Self::attr_id_static();
         let dialect = ctx
             .dialects
             .get_mut(&attrid.dialect)
             .unwrap_or_else(|| panic!("Unregistered dialect {}", &attrid.dialect));
-        dialect.add_attr(Self::get_attr_id_static(), Box::new(attr_parser));
+        dialect.add_attr(Self::attr_id_static(), Box::new(attr_parser));
     }
 }
 impl_downcast!(Attribute);
@@ -255,7 +255,7 @@ impl Printable for AttrObj {
         state: &printable::State,
         f: &mut core::fmt::Formatter<'_>,
     ) -> core::fmt::Result {
-        write!(f, "{} ", self.get_attr_id())?;
+        write!(f, "{} ", self.attr_id())?;
         Printable::fmt(self.deref(), ctx, state, f)
     }
 }

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -9,7 +9,7 @@ use crate::{
     attribute::AttributeDict,
     common_traits::{Named, Verify},
     context::{ArenaCell, Context, Ptr, private::ArenaObj},
-    debug_info::{get_block_arg_name, set_block_arg_name},
+    debug_info::{block_arg_name, set_block_arg_name},
     identifier::Identifier,
     indented_block,
     irfmt::{
@@ -48,7 +48,7 @@ impl Typed for BlockArgument {
 
 impl Named for BlockArgument {
     fn given_name(&self, ctx: &Context) -> Option<Identifier> {
-        get_block_arg_name(ctx, self.def_block, self.arg_idx)
+        block_arg_name(ctx, self.def_block, self.arg_idx)
     }
     fn id(&self, ctx: &Context) -> Identifier {
         format!("{}_arg{}", self.def_block.deref(ctx).id(ctx), self.arg_idx)
@@ -154,7 +154,7 @@ impl BasicBlock {
     }
 
     /// Get idx'th argument as a Value.
-    pub fn get_argument(&self, arg_idx: usize) -> Value {
+    pub fn argument(&self, arg_idx: usize) -> Value {
         self.args
             .get(arg_idx)
             .map(|arg| arg.into())
@@ -177,27 +177,27 @@ impl BasicBlock {
     }
 
     /// Get a reference to the idx'th argument.
-    pub(crate) fn get_argument_ref(&self, arg_idx: usize) -> &BlockArgument {
+    pub(crate) fn argument_ref(&self, arg_idx: usize) -> &BlockArgument {
         self.args
             .get(arg_idx)
             .unwrap_or_else(|| panic!("Block argument index {} out of bounds", arg_idx))
     }
 
     /// Get a mutable reference to the idx'th argument.
-    pub(crate) fn get_argument_mut(&mut self, arg_idx: usize) -> &mut BlockArgument {
+    pub(crate) fn argument_mut(&mut self, arg_idx: usize) -> &mut BlockArgument {
         self.args
             .get_mut(arg_idx)
             .unwrap_or_else(|| panic!("Block argument index {} out of bounds", arg_idx))
     }
 
     /// Get the number of arguments.
-    pub fn get_num_arguments(&self) -> usize {
+    pub fn num_arguments(&self) -> usize {
         self.args.len()
     }
 
     /// Get all successors of this block.
     pub fn succs(&self, ctx: &Context) -> Vec<Ptr<BasicBlock>> {
-        self.get_tail()
+        self.tail()
             .expect("A well formed BasicBlock must have a terminator")
             .deref(ctx)
             .successors()
@@ -252,11 +252,11 @@ impl private::ContainsLinkedList<Operation> for BasicBlock {
 }
 
 impl ContainsLinkedList<Operation> for BasicBlock {
-    fn get_head(&self) -> Option<Ptr<Operation>> {
+    fn head(&self) -> Option<Ptr<Operation>> {
         self.ops_list.first
     }
 
-    fn get_tail(&self) -> Option<Ptr<Operation>> {
+    fn tail(&self) -> Option<Ptr<Operation>> {
         self.ops_list.last
     }
 }
@@ -281,22 +281,22 @@ impl private::LinkedList for BasicBlock {
 }
 
 impl LinkedList for BasicBlock {
-    fn get_next(&self) -> Option<Ptr<Self>> {
+    fn next(&self) -> Option<Ptr<Self>> {
         self.region_links.next_block
     }
-    fn get_prev(&self) -> Option<Ptr<Self>> {
+    fn prev(&self) -> Option<Ptr<Self>> {
         self.region_links.prev_block
     }
-    fn get_container(&self) -> Option<Ptr<Self::ContainerType>> {
+    fn container(&self) -> Option<Ptr<Self::ContainerType>> {
         self.region_links.parent_region
     }
 }
 
 impl ArenaObj for BasicBlock {
-    fn get_arena(ctx: &Context) -> &ArenaCell<Self> {
+    fn arena(ctx: &Context) -> &ArenaCell<Self> {
         &ctx.basic_blocks
     }
-    fn get_arena_mut(ctx: &mut Context) -> &mut ArenaCell<Self> {
+    fn arena_mut(ctx: &mut Context) -> &mut ArenaCell<Self> {
         &mut ctx.basic_blocks
     }
     fn dealloc_sub_objects(ptr: Ptr<Self>, ctx: &mut Context) {
@@ -305,7 +305,7 @@ impl ArenaObj for BasicBlock {
             ArenaObj::dealloc(op, ctx);
         }
     }
-    fn get_self_ptr(&self, _ctx: &Context) -> Ptr<Self> {
+    fn self_ptr(&self, _ctx: &Context) -> Ptr<Self> {
         self.self_ptr
     }
 }

--- a/src/builtin/attributes.rs
+++ b/src/builtin/attributes.rs
@@ -142,7 +142,7 @@ impl Printable for IntegerAttr {
             f,
             "<{}: {}>",
             self.val
-                .to_string_decimal(ty.get_signedness() == Signedness::Signed),
+                .to_string_decimal(ty.signedness() == Signedness::Signed),
             ty.disp(ctx)
         )
     }
@@ -154,7 +154,7 @@ pub struct IntegerAttrBitwidthErr;
 
 impl Verify for IntegerAttr {
     fn verify(&self, ctx: &Context) -> Result<()> {
-        if self.ty.deref(ctx).get_width() as usize != self.val.bw() {
+        if self.ty.deref(ctx).width() as usize != self.val.bw() {
             return verify_err_noloc!(IntegerAttrBitwidthErr);
         }
         Ok(())
@@ -193,7 +193,7 @@ impl Parsable for IntegerAttr {
         .then(|(digits, ty)| {
             combine::parser(move |state_stream: &mut StateStream<'a>| {
                 let ty_ref = &*ty.deref(state_stream.state.ctx);
-                let apint = match APInt::from_str(&digits, ty_ref.get_width() as usize, 10) {
+                let apint = match APInt::from_str(&digits, ty_ref.width() as usize, 10) {
                     Ok(val) => Ok(val).into_parse_result(),
                     Err(err) => input_err!(state_stream.loc(), "{}", err).into_parse_result(),
                 }?;

--- a/src/builtin/types.rs
+++ b/src/builtin/types.rs
@@ -34,21 +34,17 @@ impl IntegerType {
         Type::register_instance(IntegerType { width, signedness }, ctx)
     }
     /// Get, if it already exists, an integer type.
-    pub fn get_existing(
-        ctx: &Context,
-        width: u32,
-        signedness: Signedness,
-    ) -> Option<TypePtr<Self>> {
-        Type::get_instance(IntegerType { width, signedness }, ctx)
+    pub fn existing(ctx: &Context, width: u32, signedness: Signedness) -> Option<TypePtr<Self>> {
+        Type::instance(IntegerType { width, signedness }, ctx)
     }
 
     /// Get width.
-    pub fn get_width(&self) -> u32 {
+    pub fn width(&self) -> u32 {
         self.width
     }
 
     /// Get signedness.
-    pub fn get_signedness(&self) -> Signedness {
+    pub fn signedness(&self) -> Signedness {
         self.signedness
     }
 }
@@ -123,21 +119,21 @@ impl FunctionType {
         Type::register_instance(FunctionType { inputs, results }, ctx)
     }
     /// Get, if it already exists, a Function type.
-    pub fn get_existing(
+    pub fn existing(
         ctx: &Context,
         inputs: Vec<Ptr<TypeObj>>,
         results: Vec<Ptr<TypeObj>>,
     ) -> Option<TypePtr<Self>> {
-        Type::get_instance(FunctionType { inputs, results }, ctx)
+        Type::instance(FunctionType { inputs, results }, ctx)
     }
 
     /// Get a reference to the function input / argument types.
-    pub fn get_inputs(&self) -> &Vec<Ptr<TypeObj>> {
+    pub fn inputs(&self) -> &Vec<Ptr<TypeObj>> {
         &self.inputs
     }
 
     /// Get a reference to the function result / output types.
-    pub fn get_results(&self) -> &Vec<Ptr<TypeObj>> {
+    pub fn results(&self) -> &Vec<Ptr<TypeObj>> {
         &self.results
     }
 }
@@ -196,13 +192,13 @@ mod tests {
         assert!(int32_1_ptr != int64_ptr);
         assert!(int32_1_ptr != uint32_ptr);
 
-        assert!(int32_1_ptr.deref(&ctx).get_self_ptr(&ctx) == int32_1_ptr.into());
-        assert!(int32_2_ptr.deref(&ctx).get_self_ptr(&ctx) == int32_1_ptr.into());
-        assert!(int32_2_ptr.deref(&ctx).get_self_ptr(&ctx) == int32_2_ptr.into());
-        assert!(int64_ptr.deref(&ctx).get_self_ptr(&ctx) == int64_ptr.into());
-        assert!(uint32_ptr.deref(&ctx).get_self_ptr(&ctx) == uint32_ptr.into());
-        assert!(uint32_ptr.deref(&ctx).get_self_ptr(&ctx) != int32_1_ptr.into());
-        assert!(uint32_ptr.deref(&ctx).get_self_ptr(&ctx) != int64_ptr.into());
+        assert!(int32_1_ptr.deref(&ctx).self_ptr(&ctx) == int32_1_ptr.into());
+        assert!(int32_2_ptr.deref(&ctx).self_ptr(&ctx) == int32_1_ptr.into());
+        assert!(int32_2_ptr.deref(&ctx).self_ptr(&ctx) == int32_2_ptr.into());
+        assert!(int64_ptr.deref(&ctx).self_ptr(&ctx) == int64_ptr.into());
+        assert!(uint32_ptr.deref(&ctx).self_ptr(&ctx) == uint32_ptr.into());
+        assert!(uint32_ptr.deref(&ctx).self_ptr(&ctx) != int32_1_ptr.into());
+        assert!(uint32_ptr.deref(&ctx).self_ptr(&ctx) != int64_ptr.into());
     }
 
     #[test]
@@ -214,8 +210,7 @@ mod tests {
         let ft_ref = FunctionType::get(&mut ctx, vec![int32_1_ptr.into()], vec![int64_ptr.into()])
             .deref(&ctx);
         assert!(
-            ft_ref.get_inputs()[0] == int32_1_ptr.into()
-                && ft_ref.get_results()[0] == int64_ptr.into()
+            ft_ref.inputs()[0] == int32_1_ptr.into() && ft_ref.results()[0] == int64_ptr.into()
         );
     }
 
@@ -233,7 +228,7 @@ mod tests {
             .unwrap()
             .0
             .0;
-        assert!(res == IntegerType::get_existing(&ctx, 64, Signedness::Signed).unwrap())
+        assert!(res == IntegerType::existing(&ctx, 64, Signedness::Signed).unwrap())
     }
 
     #[test]
@@ -274,6 +269,6 @@ mod tests {
             .unwrap()
             .0
             .0;
-        assert!(res == FunctionType::get_existing(&ctx, vec![], vec![si32.into()]).unwrap())
+        assert!(res == FunctionType::existing(&ctx, vec![], vec![si32.into()]).unwrap())
     }
 }

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -141,7 +141,7 @@ impl Dialect {
     }
 
     /// This Dialect's name.
-    pub fn get_name(&self) -> &DialectName {
+    pub fn name(&self) -> &DialectName {
         &self.name
     }
 }

--- a/src/graph/walkers.rs
+++ b/src/graph/walkers.rs
@@ -154,7 +154,7 @@ pub mod interruptible {
                     reg_idx < root_ref.num_regions(),
                     "Region deleted during walk"
                 );
-                root_ref.get_region(reg_idx)
+                root_ref.region(reg_idx)
             };
             walk_region(ctx, state, config, region, callback)?;
         }
@@ -182,15 +182,15 @@ pub mod interruptible {
         }
 
         let mut cur_block_opt = match config.blocks_in_region.1 {
-            Direction::Forward => root.deref(ctx).get_head(),
-            Direction::Reverse => root.deref(ctx).get_tail(),
+            Direction::Forward => root.deref(ctx).head(),
+            Direction::Reverse => root.deref(ctx).tail(),
         };
 
         while let Some(cur_block) = cur_block_opt {
             walk_block(ctx, state, config, cur_block, callback)?;
             cur_block_opt = match config.blocks_in_region.1 {
-                Direction::Forward => cur_block.deref(ctx).get_next(),
-                Direction::Reverse => cur_block.deref(ctx).get_prev(),
+                Direction::Forward => cur_block.deref(ctx).next(),
+                Direction::Reverse => cur_block.deref(ctx).prev(),
             }
         }
 
@@ -217,15 +217,15 @@ pub mod interruptible {
         }
 
         let mut cur_op_opt = match config.ops_in_block.1 {
-            Direction::Forward => root.deref(ctx).get_head(),
-            Direction::Reverse => root.deref(ctx).get_tail(),
+            Direction::Forward => root.deref(ctx).head(),
+            Direction::Reverse => root.deref(ctx).tail(),
         };
 
         while let Some(cur_op) = cur_op_opt {
             walk_op(ctx, state, config, cur_op, callback)?;
             cur_op_opt = match config.ops_in_block.1 {
-                Direction::Forward => cur_op.deref(ctx).get_next(),
-                Direction::Reverse => cur_op.deref(ctx).get_prev(),
+                Direction::Forward => cur_op.deref(ctx).next(),
+                Direction::Reverse => cur_op.deref(ctx).prev(),
             }
         }
 

--- a/src/irfmt/parsers.rs
+++ b/src/irfmt/parsers.rs
@@ -174,13 +174,13 @@ pub fn process_parsed_ssa_defs(
 ) -> Result<()> {
     let ctx = &mut state_stream.state.ctx;
     assert!(
-        results.len() == op.deref(ctx).get_num_results(),
+        results.len() == op.deref(ctx).num_results(),
         "Error processing parsed SSA definitions. Result count mismatch"
     );
 
     let name_tracker = &mut state_stream.state.name_tracker;
     for (idx, name_loc) in results.iter().enumerate() {
-        let res = op.deref(ctx).get_result(idx);
+        let res = op.deref(ctx).result(idx);
         name_tracker.ssa_def(ctx, name_loc, res)?;
         set_operation_result_name(ctx, op, idx, name_loc.0.clone());
     }

--- a/src/irfmt/printers/op.rs
+++ b/src/irfmt/printers/op.rs
@@ -18,7 +18,7 @@ use super::PrinterFn;
 pub fn symb_op_header<T: Op + SymbolOpInterface>(op: &T) -> impl Printable + '_ {
     PrinterFn(
         move |ctx: &Context, _state: &State, f: &mut fmt::Formatter<'_>| {
-            write!(f, "{} @{}", op.get_opid(), op.get_symbol_name(ctx))
+            write!(f, "{} @{}", op.opid(), op.symbol_name(ctx))
         },
     )
 }
@@ -41,7 +41,7 @@ pub fn typed_symb_op_header<T: Op + SymbolOpInterface + Typed>(op: &T) -> impl P
 pub fn region<T: Op + OneRegionInterface>(op: &T) -> impl Printable + '_ {
     PrinterFn(
         move |ctx: &Context, state: &State, f: &mut fmt::Formatter<'_>| {
-            op.get_region(ctx).fmt(ctx, state, f)
+            op.region(ctx).fmt(ctx, state, f)
         },
     )
 }

--- a/src/printable.rs
+++ b/src/printable.rs
@@ -31,7 +31,7 @@ pub struct State(Rc<RefCell<StateInner>>);
 
 impl State {
     /// Number of spaces per indentation
-    pub fn get_indent_width(&self) -> u16 {
+    pub fn indent_width(&self) -> u16 {
         self.0.as_ref().borrow().indent_width
     }
 
@@ -41,7 +41,7 @@ impl State {
     }
 
     /// What's the indentation we're at right now?
-    pub fn get_current_indent(&self) -> u16 {
+    pub fn current_indent(&self) -> u16 {
         self.0.as_ref().borrow().cur_indent
     }
 
@@ -241,7 +241,7 @@ where
 
 /// Print a new line followed by indentation as per current state.
 pub fn fmt_indented_newline(state: &State, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    let align = state.get_current_indent().into();
+    let align = state.current_indent().into();
     write!(f, "\n{:>align$}", "")?;
     Ok(())
 }
@@ -272,14 +272,14 @@ mod test {
     #[test]
     fn test_state_cloning() {
         let state = State::default();
-        let cur_indent = state.get_current_indent();
+        let cur_indent = state.current_indent();
         state.push_indent();
-        assert!(cur_indent < state.get_current_indent());
+        assert!(cur_indent < state.current_indent());
         let state_new = state.replicate();
         state.pop_indent();
-        assert!(state_new.get_current_indent() != state.get_current_indent());
+        assert!(state_new.current_indent() != state.current_indent());
         let state_new_2 = state_new.share();
         state_new_2.push_indent();
-        assert!(state_new.get_current_indent() == state_new_2.get_current_indent());
+        assert!(state_new.current_indent() == state_new_2.current_indent());
     }
 }

--- a/src/printable.rs
+++ b/src/printable.rs
@@ -45,12 +45,12 @@ impl State {
         self.0.as_ref().borrow().cur_indent
     }
 
-    /// Increase the current indentation by [Self::get_indent_width]
+    /// Increase the current indentation by [Self::indent_width]
     pub fn push_indent(&self) {
         let mut inner = self.0.as_ref().borrow_mut();
         inner.cur_indent += inner.indent_width;
     }
-    /// Decrease the current indentation by [Self::get_indent_width].
+    /// Decrease the current indentation by [Self::indent_width].
     pub fn pop_indent(&self) {
         let mut inner = self.0.as_ref().borrow_mut();
         inner.cur_indent -= inner.indent_width;

--- a/src/region.rs
+++ b/src/region.rs
@@ -47,7 +47,7 @@ impl Region {
     /// If `new_parent_op` is same as the current parent, no action.
     /// Indices of other regions in the current parent will be invalidated.
     pub fn move_to_op(ptr: Ptr<Self>, new_parent_op: Ptr<Operation>, ctx: &mut Context) {
-        let src = ptr.deref(ctx).get_parent_op();
+        let src = ptr.deref(ctx).parent_op();
         if src == new_parent_op {
             return;
         }
@@ -63,7 +63,7 @@ impl Region {
     }
 
     /// Get the operation that contains this region.
-    pub fn get_parent_op(&self) -> Ptr<Operation> {
+    pub fn parent_op(&self) -> Ptr<Operation> {
         self.parent_op
     }
 
@@ -86,24 +86,24 @@ impl private::ContainsLinkedList<BasicBlock> for Region {
 }
 
 impl ContainsLinkedList<BasicBlock> for Region {
-    fn get_head(&self) -> Option<Ptr<BasicBlock>> {
+    fn head(&self) -> Option<Ptr<BasicBlock>> {
         self.blocks.first
     }
-    fn get_tail(&self) -> Option<Ptr<BasicBlock>> {
+    fn tail(&self) -> Option<Ptr<BasicBlock>> {
         self.blocks.last
     }
 }
 
 impl ArenaObj for Region {
-    fn get_arena(ctx: &Context) -> &crate::context::ArenaCell<Self> {
+    fn arena(ctx: &Context) -> &crate::context::ArenaCell<Self> {
         &ctx.regions
     }
 
-    fn get_arena_mut(ctx: &mut Context) -> &mut crate::context::ArenaCell<Self> {
+    fn arena_mut(ctx: &mut Context) -> &mut crate::context::ArenaCell<Self> {
         &mut ctx.regions
     }
 
-    fn get_self_ptr(&self, _ctx: &Context) -> Ptr<Self> {
+    fn self_ptr(&self, _ctx: &Context) -> Ptr<Self> {
         self.self_ptr
     }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -100,7 +100,7 @@ pub trait Type: Printable + Verify + Downcast + Sync + Send + Debug {
     // Unlike in other [ArenaObj]s,
     // we do not store a self pointer inside the object itself
     // because that can upset taking automatic hashes of the object.
-    fn get_self_ptr(&self, ctx: &Context) -> Ptr<TypeObj> {
+    fn self_ptr(&self, ctx: &Context) -> Ptr<TypeObj> {
         let is = |other: &TypeObj| self.eq_type(&**other);
         let idx = ctx
             .type_store
@@ -132,7 +132,7 @@ pub trait Type: Printable + Verify + Downcast + Sync + Send + Debug {
 
     /// If an instance of `t` already exists, get a [Ptr] to it.
     /// Consumes `t` either way.
-    fn get_instance(t: Self, ctx: &Context) -> Option<TypePtr<Self>>
+    fn instance(t: Self, ctx: &Context) -> Option<TypePtr<Self>>
     where
         Self: Sized,
     {
@@ -218,7 +218,7 @@ impl Typed for Ptr<TypeObj> {
 
 impl Typed for dyn Type {
     fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
-        self.get_self_ptr(ctx)
+        self.self_ptr(ctx)
     }
 }
 
@@ -339,16 +339,16 @@ impl Hash for TypeObj {
 }
 
 impl ArenaObj for TypeObj {
-    fn get_arena(ctx: &Context) -> &ArenaCell<Self> {
+    fn arena(ctx: &Context) -> &ArenaCell<Self> {
         &ctx.type_store.unique_store
     }
 
-    fn get_arena_mut(ctx: &mut Context) -> &mut ArenaCell<Self> {
+    fn arena_mut(ctx: &mut Context) -> &mut ArenaCell<Self> {
         &mut ctx.type_store.unique_store
     }
 
-    fn get_self_ptr(&self, ctx: &Context) -> Ptr<Self> {
-        self.as_ref().get_self_ptr(ctx)
+    fn self_ptr(&self, ctx: &Context) -> Ptr<Self> {
+        self.as_ref().self_ptr(ctx)
     }
 
     fn dealloc_sub_objects(_ptr: Ptr<Self>, _ctx: &mut Context) {

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -69,8 +69,8 @@ impl Parsable for ZeroResultOp {
 
 impl ZeroResultOp {
     fn new(ctx: &mut Context) -> ZeroResultOp {
-        let op = Operation::new(ctx, Self::get_opid_static(), vec![], vec![], vec![], 1);
-        *Operation::get_op(op, ctx).downcast_ref().unwrap()
+        let op = Operation::new(ctx, Self::opid_static(), vec![], vec![], vec![], 1);
+        *Operation::op(op, ctx).downcast_ref().unwrap()
     }
 }
 
@@ -80,12 +80,12 @@ fn check_intrf_verfiy_errs() {
     let ctx = &mut setup_context_dialects();
     ZeroResultOp::register(ctx, ZeroResultOp::parser_fn);
 
-    let zero_res_op = ZeroResultOp::new(ctx).get_operation();
+    let zero_res_op = ZeroResultOp::new(ctx).operation();
     let (module_op, _, _, ret_op) = const_ret_in_mod(ctx).unwrap();
-    zero_res_op.insert_before(ctx, ret_op.get_operation());
+    zero_res_op.insert_before(ctx, ret_op.operation());
 
     assert!(matches!(
-        module_op.get_operation().verify(ctx),
+        module_op.operation().verify(ctx),
         Err(Error {
             kind: ErrorKind::VerificationFailed,
             err,
@@ -141,8 +141,8 @@ impl_canonical_syntax!(VerifyIntrOp);
 impl_verify_succ!(VerifyIntrOp);
 impl VerifyIntrOp {
     fn new(ctx: &mut Context) -> VerifyIntrOp {
-        let op = Operation::new(ctx, Self::get_opid_static(), vec![], vec![], vec![], 1);
-        *Operation::get_op(op, ctx).downcast_ref().unwrap()
+        let op = Operation::new(ctx, Self::opid_static(), vec![], vec![], vec![], 1);
+        *Operation::op(op, ctx).downcast_ref().unwrap()
     }
 }
 
@@ -153,7 +153,7 @@ fn test_op_intr_verify_order() -> Result<()> {
 
     let vio = VerifyIntrOp::new(ctx);
 
-    vio.get_operation().deref(ctx).verify(ctx)?;
+    vio.operation().deref(ctx).verify(ctx)?;
 
     expect![[r#"
         TestOpInterface verified
@@ -349,8 +349,8 @@ impl_canonical_syntax!(NoInbuiltVerifyOp);
 impl_verify_succ!(NoInbuiltVerifyOp);
 impl NoInbuiltVerifyOp {
     fn new(ctx: &mut Context) -> NoInbuiltVerifyOp {
-        let op = Operation::new(ctx, Self::get_opid_static(), vec![], vec![], vec![], 1);
-        *Operation::get_op(op, ctx).downcast_ref().unwrap()
+        let op = Operation::new(ctx, Self::opid_static(), vec![], vec![], vec![], 1);
+        *Operation::op(op, ctx).downcast_ref().unwrap()
     }
 }
 
@@ -368,7 +368,7 @@ fn test_no_inbuilt_verify() -> Result<()> {
 
     let vio = NoInbuiltVerifyOp::new(ctx);
 
-    vio.get_operation().deref(ctx).verify(ctx)?;
+    vio.operation().deref(ctx).verify(ctx)?;
 
     Ok(())
 }
@@ -379,8 +379,8 @@ impl_canonical_syntax!(NoInbuiltVerifyOp2);
 impl_verify_succ!(NoInbuiltVerifyOp2);
 impl NoInbuiltVerifyOp2 {
     fn new(ctx: &mut Context) -> NoInbuiltVerifyOp2 {
-        let op = Operation::new(ctx, Self::get_opid_static(), vec![], vec![], vec![], 1);
-        *Operation::get_op(op, ctx).downcast_ref().unwrap()
+        let op = Operation::new(ctx, Self::opid_static(), vec![], vec![], vec![], 1);
+        *Operation::op(op, ctx).downcast_ref().unwrap()
     }
 }
 
@@ -403,7 +403,7 @@ fn test_no_inbuilt_verify2() -> Result<()> {
     let vio = NoInbuiltVerifyOp2::new(ctx);
 
     assert!(matches!(
-        vio.get_operation().verify(ctx),
+        vio.operation().verify(ctx),
         Err(Error {
             kind: ErrorKind::VerificationFailed,
             err,


### PR DESCRIPTION
This takes care of most of #15. Only thing left is to refactor `get_type`, but it cannot be refactored to just `type`, as thats a reserved keyword, and figured I'd ask for clarification on what it should be named.