### PR TITLE
feat: support llvm 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 18 all
+        sudo ./llvm.sh 20 all
 
     - name: Build
       run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose

--- a/pliron-llvm/Cargo.toml
+++ b/pliron-llvm/Cargo.toml
@@ -19,7 +19,7 @@ dyn-clone.workspace = true
 thiserror.workspace = true
 linkme.workspace = true
 rustc-hash.workspace = true
-llvm-sys = "180"
+llvm-sys = "201"
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -110,7 +110,6 @@ fn convert_type(
         LLVMTypeKind::LLVMPPC_FP128TypeKind => todo!(),
         LLVMTypeKind::LLVMLabelTypeKind => todo!(),
         LLVMTypeKind::LLVMMetadataTypeKind => todo!(),
-        LLVMTypeKind::LLVMX86_MMXTypeKind => todo!(),
         LLVMTypeKind::LLVMTokenTypeKind => todo!(),
         LLVMTypeKind::LLVMScalableVectorTypeKind => todo!(),
         LLVMTypeKind::LLVMBFloatTypeKind => todo!(),


### PR DESCRIPTION
Adds support for LLVM 20 which was released 3 weeks ago. Maybe in a future PR it would be a good idea to add a feature for switching out the llvm-sys version.