### PR TITLE
Use inventory crate instead of linkme for WASM targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,9 @@ jobs:
     - name: Build
       run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
+    # We don't need to support pliron-llvm on WASM
     - name: Build Wasm Target
-      run: RUSTFLAGS="-D warnings" cargo build --worlspace --target wasm32-unknown-unknown --verbose
+      run: RUSTFLAGS="-D warnings" cargo build -p pliron -p pliron-derive --target wasm32-unknown-unknown --verbose
 
     - name: Tests (Debug)
       run: cargo test --workspace --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
     - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
 
     - name: Setup LLVM
       run: |
@@ -40,3 +43,6 @@ jobs:
 
     - name: Documentation
       run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace
+
+    - name: Wasm Check
+      run: cargo build --target wasm32-unknown-unknown

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Build
       run: RUSTFLAGS="-D warnings" cargo build --workspace --verbose
 
+    - name: Build Wasm Target
+      run: RUSTFLAGS="-D warnings" cargo build --worlspace --target wasm32-unknown-unknown --verbose
+
     - name: Tests (Debug)
       run: cargo test --workspace --verbose
 
@@ -44,5 +47,3 @@ jobs:
     - name: Documentation
       run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace
 
-    - name: Wasm Check
-      run: cargo build --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,21 @@ slotmap = "1"
 downcast-rs = "2"
 rustc-hash.workspace = true
 thiserror.workspace = true
-linkme.workspace = true
 combine.workspace = true
 utf8-chars = "3"
 regex = "1"
 dyn-clone.workspace = true
 log.workspace = true
+linkme = { workspace = true, optional = true }
+inventory = { workspace = true, optional = true }
+
+[features]
+default = ['distributed-slice']
+distributed-slice = ["dep:linkme", "pliron-derive/distributed-slice"]
+inventory = ["dep:inventory", "pliron-derive/inventory"]
+
+[target.'cfg(target_family = "wasm")'.features]
+default = ['inventory']
 
 [dev-dependencies]
 expect-test.workspace = true
@@ -58,6 +67,7 @@ rustc-hash = "2"
 combine = "4"
 thiserror = "2"
 linkme = "0"
+inventory = "0"
 tempfile = "3"
 log = "0"
 env_logger = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ keywords = ["pliron", "llvm", "mlir", "compiler"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pliron-derive = { path = "./pliron-derive", version = "0" }
-
 awint.workspace = true
 rustc_apfloat.workspace = true
 slotmap = "1"
@@ -38,16 +36,14 @@ utf8-chars = "3"
 regex = "1"
 dyn-clone.workspace = true
 log.workspace = true
-linkme = { workspace = true, optional = true }
-inventory = { workspace = true, optional = true }
 
-[features]
-default = ['distributed-slice']
-distributed-slice = ["dep:linkme", "pliron-derive/distributed-slice"]
-inventory = ["dep:inventory", "pliron-derive/inventory"]
+[target.'cfg(target_family = "wasm")'.dependencies]
+inventory.workspace = true
+pliron-derive = { path = "./pliron-derive", version = "0", features = ["inventory"] }
 
-[target.'cfg(target_family = "wasm")'.features]
-default = ['inventory']
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+linkme.workspace = true
+pliron-derive = { path = "./pliron-derive", version = "0", features = ["linkme"] }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ keywords = ["pliron", "llvm", "mlir", "compiler"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+pliron-derive = { path = "./pliron-derive", version = "0" }
+
 awint.workspace = true
 rustc_apfloat.workspace = true
 slotmap = "1"
@@ -39,11 +41,9 @@ log.workspace = true
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 inventory.workspace = true
-pliron-derive = { path = "./pliron-derive", version = "0", features = ["inventory"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 linkme.workspace = true
-pliron-derive = { path = "./pliron-derive", version = "0", features = ["linkme"] }
 
 [dev-dependencies]
 expect-test.workspace = true

--- a/pliron-derive/Cargo.toml
+++ b/pliron-derive/Cargo.toml
@@ -31,5 +31,5 @@ inventory.workspace = true
 dyn-clone.workspace = true
 
 [features]
-distributed-slice = []
+linkme = []
 inventory = []

--- a/pliron-derive/Cargo.toml
+++ b/pliron-derive/Cargo.toml
@@ -27,4 +27,9 @@ prettyplease.workspace = true
 expect-test.workspace = true
 pliron = { path = "../" }
 linkme.workspace = true
+inventory.workspace = true
 dyn-clone.workspace = true
+
+[features]
+distributed-slice = []
+inventory = []

--- a/pliron-derive/Cargo.toml
+++ b/pliron-derive/Cargo.toml
@@ -29,7 +29,3 @@ pliron = { path = "../" }
 linkme.workspace = true
 inventory.workspace = true
 dyn-clone.workspace = true
-
-[features]
-linkme = []
-inventory = []

--- a/pliron-derive/Cargo.toml
+++ b/pliron-derive/Cargo.toml
@@ -26,6 +26,10 @@ convert_case = "0"
 prettyplease.workspace = true
 expect-test.workspace = true
 pliron = { path = "../" }
-linkme.workspace = true
-inventory.workspace = true
 dyn-clone.workspace = true
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+inventory.workspace = true
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+linkme.workspace = true

--- a/pliron-derive/src/interfaces.rs
+++ b/pliron-derive/src/interfaces.rs
@@ -21,6 +21,7 @@ pub(crate) fn interface_define(
     input: proc_macro::TokenStream,
     supertrait: Path,
     interface_deps_slice: Path,
+    id: Path,
     append_dyn_clone_trait: bool,
 ) -> Result<proc_macro2::TokenStream> {
     let mut r#trait = syn::parse2::<ItemTrait>(input.into())?;
@@ -44,11 +45,16 @@ pub(crate) fn interface_define(
     // our map, so that we can sort them all later for the verifiers to run.
     let deps_entry = quote! {
         const _: () = {
-            #[linkme::distributed_slice(#interface_deps_slice)]
+            #[cfg_attr(not(target_family = "wasm"), linkme::distributed_slice(#interface_deps_slice))]
             static INTERFACE_DEP: std::sync::LazyLock<(std::any::TypeId, Vec<std::any::TypeId>)>
                 = std::sync::LazyLock::new(|| {
                     (std::any::TypeId::of::<dyn #intr_name>(), vec![#(std::any::TypeId::of::<dyn #dep_interfaces>(),)*])
              });
+
+            #[cfg(target_family = "wasm")]
+            inventory::submit! {
+                ::pliron::utils::inventory::LazyLockWrapper::<_, #id>::new(&INTERFACE_DEP)
+            }
         };
     };
 
@@ -89,7 +95,7 @@ pub(crate) fn interface_impl(
 
     let verifiers_entry = quote! {
         const _: () = {
-            #[linkme::distributed_slice(#interface_verifiers_slice)]
+            #[cfg_attr(not(target_family = "wasm"), linkme::distributed_slice(#interface_verifiers_slice))]
             static INTERFACE_VERIFIER: std::sync::LazyLock<
                 (#id, (std::any::TypeId, #verifier_type))
             > =
@@ -97,6 +103,11 @@ pub(crate) fn interface_impl(
                 (#rust_ty::#get_id_static(), (std::any::TypeId::of::<dyn #intr_name>(),
                      <#rust_ty as #intr_name>::verify))
             );
+
+            #[cfg(target_family = "wasm")]
+            inventory::submit! {
+                ::pliron::utils::inventory::LazyLockWrapper::new(&INTERFACE_VERIFIER)
+            }
         };
     };
 

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -379,6 +379,7 @@ pub(crate) fn to_token_stream(res: syn::Result<proc_macro2::TokenStream>) -> Tok
 /// ```
 #[proc_macro_attribute]
 pub fn op_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let id = parse_quote! { ::pliron::op::OpId };
     let supertrait = parse_quote! { ::pliron::op::Op };
     let interface_deps_slice = parse_quote! { ::pliron::op::OP_INTERFACE_DEPS };
 
@@ -386,6 +387,7 @@ pub fn op_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
         item,
         supertrait,
         interface_deps_slice,
+        id,
         true,
     ))
 }
@@ -516,6 +518,7 @@ pub fn derive_op_interface_impl(attr: TokenStream, item: TokenStream) -> TokenSt
 /// ```
 #[proc_macro_attribute]
 pub fn attr_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let id = parse_quote! { ::pliron::attribute::AttrId };
     let supertrait = parse_quote! { ::pliron::attribute::Attribute };
     let interface_deps_slice = parse_quote! { ::pliron::attribute::ATTR_INTERFACE_DEPS };
 
@@ -523,6 +526,7 @@ pub fn attr_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
         item,
         supertrait,
         interface_deps_slice,
+        id,
         true,
     ))
 }
@@ -629,6 +633,7 @@ pub fn attr_interface_impl(_attr: TokenStream, item: TokenStream) -> TokenStream
 /// ```
 #[proc_macro_attribute]
 pub fn type_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let id = parse_quote! { ::pliron::r#type::TypeId };
     let supertrait = parse_quote! { ::pliron::r#type::Type };
     let interface_deps_slice = parse_quote! { ::pliron::r#type::TYPE_INTERFACE_DEPS };
 
@@ -636,6 +641,7 @@ pub fn type_interface(_attr: TokenStream, item: TokenStream) -> TokenStream {
         item,
         supertrait,
         interface_deps_slice,
+        id,
         false,
     ))
 }

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -12,6 +12,7 @@ set -e
 cargo fmt --check
 cargo clippy --workspace --all-targets -- -D warnings
 RUSTFLAGS="-D warnings" cargo build --workspace
+RUSTFLAGS="-D warnings" cargo build -p pliron -p pliron-derive --target wasm32-unknown-unknown
 cargo test --workspace
 cargo test --release --workspace
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -47,7 +47,6 @@ use std::{
 use combine::{Parser, parser, token};
 use downcast_rs::{Downcast, impl_downcast};
 use dyn_clone::DynClone;
-use linkme::distributed_slice;
 use rustc_hash::FxHashMap;
 
 use crate::{
@@ -440,18 +439,49 @@ impl Parsable for AttrId {
 /// Every attribute interface must have a function named `verify` with this type.
 pub type AttrInterfaceVerifier = fn(&dyn Attribute, &Context) -> Result<()>;
 
+/// Type alias for attribute interface verifier information
+type AttrInterfaceVerifierInfo = (AttrId, (std::any::TypeId, AttrInterfaceVerifier));
+
+/// Type alias for attribute interface dependency information
+type AttrInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
+
 #[doc(hidden)]
 /// [Attribute]s paired with every interface it implements (and the verifier for that interface).
-#[distributed_slice]
-pub static ATTR_INTERFACE_VERIFIERS: [LazyLock<(
-    AttrId,
-    (std::any::TypeId, AttrInterfaceVerifier),
-)>];
+#[cfg(not(target_family = "wasm"))]
+#[linkme::distributed_slice]
+pub static ATTR_INTERFACE_VERIFIERS: [LazyLock<AttrInterfaceVerifierInfo>] = [..];
 
 #[doc(hidden)]
 /// All interfaces mapped to their super-interfaces
-#[distributed_slice]
-pub static ATTR_INTERFACE_DEPS: [LazyLock<(std::any::TypeId, Vec<std::any::TypeId>)>];
+#[cfg(not(target_family = "wasm"))]
+#[linkme::distributed_slice]
+pub static ATTR_INTERFACE_DEPS: [LazyLock<AttrInterfaceDepsInfo>] = [..];
+
+#[cfg(target_family = "wasm")]
+inventory::collect!(crate::utils::inventory::LazyLockWrapper<AttrInterfaceVerifierInfo>);
+
+#[cfg(target_family = "wasm")]
+inventory::collect!(crate::utils::inventory::LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>);
+
+#[cfg(target_family = "wasm")]
+fn get_attr_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceVerifierInfo>>().map(|llw| llw.0)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn get_attr_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
+    ATTR_INTERFACE_VERIFIERS.iter()
+}
+
+#[cfg(target_family = "wasm")]
+fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>>().map(|llw| llw.0)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
+    ATTR_INTERFACE_DEPS.iter()
+}
 
 #[doc(hidden)]
 /// A map from every [Attribute] to its ordered (as per interface deps) list of interface verifiers.
@@ -462,7 +492,7 @@ pub static ATTR_INTERFACE_VERIFIERS_MAP: LazyLock<
     use std::any::TypeId;
     // Collect ATTR_INTERFACE_VERIFIERS into an [AttrId] indexed map.
     let mut attr_intr_verifiers = FxHashMap::default();
-    for lazy in ATTR_INTERFACE_VERIFIERS {
+    for lazy in get_attr_interface_verifiers() {
         let (attr_id, (type_id, verifier)) = (**lazy).clone();
         attr_intr_verifiers
             .entry(attr_id)
@@ -473,8 +503,7 @@ pub static ATTR_INTERFACE_VERIFIERS_MAP: LazyLock<
     }
 
     // Collect interface deps into a map.
-    let interface_deps: FxHashMap<_, _> = ATTR_INTERFACE_DEPS
-        .iter()
+    let interface_deps: FxHashMap<_, _> = get_attr_interface_deps()
         .map(|lazy| (**lazy).clone())
         .collect();
 
@@ -507,7 +536,7 @@ pub static ATTR_INTERFACE_VERIFIERS_MAP: LazyLock<
     }
 
     // Assign dep_sort_idx to every interface.
-    for lazy in ATTR_INTERFACE_DEPS.iter() {
+    for lazy in get_attr_interface_deps() {
         let (intr, _deps) = &**lazy;
         assign_idx_to_intr(&interface_deps, &mut dep_sort_idx, &mut sort_idx, intr);
     }
@@ -537,8 +566,7 @@ mod tests {
     /// sub-interface verifier.
     fn check_verifiers_deps() -> Result<()> {
         // Collect interface deps into a map.
-        let interface_deps: FxHashMap<_, _> = ATTR_INTERFACE_DEPS
-            .iter()
+        let interface_deps: FxHashMap<_, _> = get_attr_interface_deps()
             .map(|lazy| (**lazy).clone())
             .collect();
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -446,11 +446,11 @@ type AttrInterfaceVerifierInfo = (AttrId, (std::any::TypeId, AttrInterfaceVerifi
 type AttrInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
+/// [Attribute]s paired with every interface it implements (and the verifier for that interface).
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;
 
-    /// [Attribute]s paired with every interface it implements (and the verifier for that interface).
     #[linkme::distributed_slice]
     pub static ATTR_INTERFACE_VERIFIERS: [LazyLock<AttrInterfaceVerifierInfo>] = [..];
 
@@ -473,7 +473,6 @@ pub mod statics {
     use super::*;
     use crate::utils::inventory::LazyLockWrapper;
 
-    /// [Attribute]s paired with every interface it implements (and the verifier for that interface).
     inventory::collect!(LazyLockWrapper<AttrInterfaceVerifierInfo>);
 
     inventory::collect!(LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>);

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -440,13 +440,14 @@ impl Parsable for AttrId {
 pub type AttrInterfaceVerifier = fn(&dyn Attribute, &Context) -> Result<()>;
 
 /// Type alias for attribute interface verifier information
+/// [Attribute]s paired with every interface it implements (and the verifier for that interface).
 type AttrInterfaceVerifierInfo = (AttrId, (std::any::TypeId, AttrInterfaceVerifier));
 
 /// Type alias for attribute interface dependency information
+/// All interfaces mapped to their super-interfaces
 type AttrInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
-/// [Attribute]s paired with every interface it implements (and the verifier for that interface).
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -464,18 +464,22 @@ inventory::collect!(crate::utils::inventory::LazyLockWrapper<AttrInterfaceVerifi
 inventory::collect!(crate::utils::inventory::LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>);
 
 #[cfg(target_family = "wasm")]
-fn get_attr_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceVerifierInfo>>().map(|llw| llw.0)
+fn get_attr_interface_verifiers()
+-> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceVerifierInfo>>()
+        .map(|llw| llw.0)
 }
 
 #[cfg(not(target_family = "wasm"))]
-fn get_attr_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
+fn get_attr_interface_verifiers()
+-> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
     ATTR_INTERFACE_VERIFIERS.iter()
 }
 
 #[cfg(target_family = "wasm")]
 fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>>().map(|llw| llw.0)
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>>()
+        .map(|llw| llw.0)
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -446,12 +446,11 @@ type AttrInterfaceVerifierInfo = (AttrId, (std::any::TypeId, AttrInterfaceVerifi
 type AttrInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
-/// [Attribute]s paired with every interface it implements (and the verifier for that interface).
-
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;
 
+    /// [Attribute]s paired with every interface it implements (and the verifier for that interface).
     #[linkme::distributed_slice]
     pub static ATTR_INTERFACE_VERIFIERS: [LazyLock<AttrInterfaceVerifierInfo>] = [..];
 
@@ -474,6 +473,7 @@ pub mod statics {
     use super::*;
     use crate::utils::inventory::LazyLockWrapper;
 
+    /// [Attribute]s paired with every interface it implements (and the verifier for that interface).
     inventory::collect!(LazyLockWrapper<AttrInterfaceVerifierInfo>);
 
     inventory::collect!(LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>);

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -463,7 +463,8 @@ pub mod statics {
         ATTR_INTERFACE_VERIFIERS.iter()
     }
 
-    pub fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
+    pub fn get_attr_interface_deps()
+    -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
         ATTR_INTERFACE_DEPS.iter()
     }
 }
@@ -479,13 +480,12 @@ pub mod statics {
 
     pub fn get_attr_interface_verifiers()
     -> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
-        inventory::iter::<LazyLockWrapper<AttrInterfaceVerifierInfo>>()
-            .map(|llw| llw.0)
+        inventory::iter::<LazyLockWrapper<AttrInterfaceVerifierInfo>>().map(|llw| llw.0)
     }
 
-    pub fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
-        inventory::iter::<LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>>()
-            .map(|llw| llw.0)
+    pub fn get_attr_interface_deps()
+    -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
+        inventory::iter::<LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>>().map(|llw| llw.0)
     }
 }
 

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -562,7 +562,7 @@ mod tests {
 
     use crate::verify_err_noloc;
 
-    use super::{ATTR_INTERFACE_DEPS, ATTR_INTERFACE_VERIFIERS_MAP};
+    use super::{ATTR_INTERFACE_VERIFIERS_MAP, get_attr_interface_deps};
 
     #[test]
     /// For every interface that an [Attr] implements, ensure that the interface verifiers

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -447,45 +447,49 @@ type AttrInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
 /// [Attribute]s paired with every interface it implements (and the verifier for that interface).
-#[cfg(not(target_family = "wasm"))]
-#[linkme::distributed_slice]
-pub static ATTR_INTERFACE_VERIFIERS: [LazyLock<AttrInterfaceVerifierInfo>] = [..];
-
-#[doc(hidden)]
-/// All interfaces mapped to their super-interfaces
-#[cfg(not(target_family = "wasm"))]
-#[linkme::distributed_slice]
-pub static ATTR_INTERFACE_DEPS: [LazyLock<AttrInterfaceDepsInfo>] = [..];
-
-#[cfg(target_family = "wasm")]
-inventory::collect!(crate::utils::inventory::LazyLockWrapper<AttrInterfaceVerifierInfo>);
-
-#[cfg(target_family = "wasm")]
-inventory::collect!(crate::utils::inventory::LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>);
-
-#[cfg(target_family = "wasm")]
-fn get_attr_interface_verifiers()
--> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceVerifierInfo>>()
-        .map(|llw| llw.0)
-}
 
 #[cfg(not(target_family = "wasm"))]
-fn get_attr_interface_verifiers()
--> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
-    ATTR_INTERFACE_VERIFIERS.iter()
+pub mod statics {
+    use super::*;
+
+    #[linkme::distributed_slice]
+    pub static ATTR_INTERFACE_VERIFIERS: [LazyLock<AttrInterfaceVerifierInfo>] = [..];
+
+    #[linkme::distributed_slice]
+    pub static ATTR_INTERFACE_DEPS: [LazyLock<AttrInterfaceDepsInfo>] = [..];
+
+    pub fn get_attr_interface_verifiers()
+    -> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
+        ATTR_INTERFACE_VERIFIERS.iter()
+    }
+
+    pub fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
+        ATTR_INTERFACE_DEPS.iter()
+    }
 }
 
 #[cfg(target_family = "wasm")]
-fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>>()
-        .map(|llw| llw.0)
+pub mod statics {
+    use super::*;
+    use crate::utils::inventory::LazyLockWrapper;
+
+    inventory::collect!(LazyLockWrapper<AttrInterfaceVerifierInfo>);
+
+    inventory::collect!(LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>);
+
+    pub fn get_attr_interface_verifiers()
+    -> impl Iterator<Item = &'static LazyLock<AttrInterfaceVerifierInfo>> {
+        inventory::iter::<LazyLockWrapper<AttrInterfaceVerifierInfo>>()
+            .map(|llw| llw.0)
+    }
+
+    pub fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
+        inventory::iter::<LazyLockWrapper<AttrInterfaceDepsInfo, AttrId>>()
+            .map(|llw| llw.0)
+    }
 }
 
-#[cfg(not(target_family = "wasm"))]
-fn get_attr_interface_deps() -> impl Iterator<Item = &'static LazyLock<AttrInterfaceDepsInfo>> {
-    ATTR_INTERFACE_DEPS.iter()
-}
+pub use statics::*;
 
 #[doc(hidden)]
 /// A map from every [Attribute] to its ordered (as per interface deps) list of interface verifiers.

--- a/src/context.rs
+++ b/src/context.rs
@@ -287,7 +287,7 @@ fn get_dict_key_ids() -> impl Iterator<Item = &'static LazyLock<DictKeyId>> {
 
 #[cfg(not(target_family = "wasm"))]
 fn get_dict_key_ids() -> impl Iterator<Item = &'static LazyLock<DictKeyId>> {
-    DICT_KEY_ENTRIES.iter()
+    DICT_KEY_IDS.iter()
 }
 
 #[doc(hidden)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -273,7 +273,6 @@ pub struct DictKeyId {
 /// we use the [placeholder] macro to verify that all such keys declared using the macro
 /// are unique. The macro adds the keys to this static slice, which is then verified
 /// when a [Context] is created.
-
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;

--- a/src/context.rs
+++ b/src/context.rs
@@ -352,7 +352,7 @@ macro_rules! dict_key {
 
             #[cfg(target_family = "wasm")]
             inventory::submit! {
-                ::pliron::utils::inventory::LazyLockWrapper(&$decl)
+                ::pliron::utils::inventory::LazyLockWrapper::new(&$decl)
             }
         };
         $(#[$outer])*

--- a/src/context.rs
+++ b/src/context.rs
@@ -351,7 +351,7 @@ macro_rules! dict_key {
         // to ensure that all keys are unique.
         // The static variable is created in a separate anonmyous module.
         const _: () = {
-            #[cfg_attr(not(target_family = "wasm"), linkme::distributed_slice(::pliron::context::statics::statics::DICT_KEY_IDS))]
+            #[cfg_attr(not(target_family = "wasm"), linkme::distributed_slice(::pliron::context::DICT_KEY_IDS))]
             pub static $decl: std::sync::LazyLock<::pliron::context::DictKeyId> =
                 std::sync::LazyLock::new(|| ::pliron::context::DictKeyId {
                     id: $name.try_into().unwrap(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -270,7 +270,7 @@ pub struct DictKeyId {
 /// `pliron` uses dictionaries indexed by static [Identifier]s in many places,
 /// such as [Context::aux_data_map], and the states of [Printable](crate::printable::State)
 /// and [Parsable](crate::parsable::State). To avoid collisions in these [Identifier]s,
-/// we use the [placeholder] macro to verify that all such keys declared using the macro
+/// we use the [crate::dict_key!] macro to verify that all such keys declared using the macro
 /// are unique. The macro adds the keys to this static slice, which is then verified
 /// when a [Context] is created.
 #[cfg(not(target_family = "wasm"))]

--- a/src/op.rs
+++ b/src/op.rs
@@ -255,13 +255,14 @@ pub fn op_impls<T: ?Sized + Op>(op: &dyn Op) -> bool {
 pub type OpInterfaceVerifier = fn(&dyn Op, &Context) -> Result<()>;
 
 /// Type alias for op interface verifier information
+/// [Op]s paired with every interface it implements (and the verifier for that interface).
 type OpInterfaceVerifierInfo = (OpId, (std::any::TypeId, OpInterfaceVerifier));
 
 /// Type alias for op interface dependency information
+/// All interfaces mapped to their super-interfaces
 type OpInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
-/// [Op]s paired with every interface it implements (and the verifier for that interface).
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;

--- a/src/op.rs
+++ b/src/op.rs
@@ -39,7 +39,6 @@ use combine::{
 };
 use downcast_rs::{Downcast, impl_downcast};
 use dyn_clone::DynClone;
-use linkme::distributed_slice;
 use rustc_hash::FxHashMap;
 use std::{
     fmt::{self, Display},
@@ -255,15 +254,49 @@ pub fn op_impls<T: ?Sized + Op>(op: &dyn Op) -> bool {
 /// Every op interface must have a function named `verify` with this type.
 pub type OpInterfaceVerifier = fn(&dyn Op, &Context) -> Result<()>;
 
+/// Type alias for op interface verifier information
+type OpInterfaceVerifierInfo = (OpId, (std::any::TypeId, OpInterfaceVerifier));
+
+/// Type alias for op interface dependency information
+type OpInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
+
 #[doc(hidden)]
 /// [Op]s paired with every interface it implements (and the verifier for that interface).
-#[distributed_slice]
-pub static OP_INTERFACE_VERIFIERS: [LazyLock<(OpId, (std::any::TypeId, OpInterfaceVerifier))>];
+#[cfg(not(target_family = "wasm"))]
+#[linkme::distributed_slice]
+pub static OP_INTERFACE_VERIFIERS: [LazyLock<OpInterfaceVerifierInfo>] = [..];
 
 #[doc(hidden)]
 /// All interfaces mapped to their super-interfaces
-#[distributed_slice]
-pub static OP_INTERFACE_DEPS: [LazyLock<(std::any::TypeId, Vec<std::any::TypeId>)>];
+#[cfg(not(target_family = "wasm"))]
+#[linkme::distributed_slice]
+pub static OP_INTERFACE_DEPS: [LazyLock<OpInterfaceDepsInfo>] = [..];
+
+#[cfg(target_family = "wasm")]
+inventory::collect!(crate::utils::inventory::LazyLockWrapper<OpInterfaceVerifierInfo>);
+
+#[cfg(target_family = "wasm")]
+inventory::collect!(crate::utils::inventory::LazyLockWrapper<OpInterfaceDepsInfo, OpId>);
+
+#[cfg(target_family = "wasm")]
+fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>> {
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceVerifierInfo>>().map(|llw| llw.0)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>> {
+    OP_INTERFACE_VERIFIERS.iter()
+}
+
+#[cfg(target_family = "wasm")]
+fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceDepsInfo, OpId>>().map(|llw| llw.0)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
+    OP_INTERFACE_DEPS.iter()
+}
 
 #[doc(hidden)]
 /// A map from every [Op] to its ordered (as per interface deps) list of interface verifiers.
@@ -274,7 +307,7 @@ pub static OP_INTERFACE_VERIFIERS_MAP: LazyLock<
     use std::any::TypeId;
     // Collect OP_INTERFACE_VERIFIERS into an [OpId] indexed map.
     let mut op_intr_verifiers = FxHashMap::default();
-    for lazy in OP_INTERFACE_VERIFIERS {
+    for lazy in get_op_interface_verifiers() {
         let (op_id, (type_id, verifier)) = (**lazy).clone();
         op_intr_verifiers
             .entry(op_id)
@@ -285,8 +318,7 @@ pub static OP_INTERFACE_VERIFIERS_MAP: LazyLock<
     }
 
     // Collect interface deps into a map.
-    let interface_deps: FxHashMap<_, _> = OP_INTERFACE_DEPS
-        .iter()
+    let interface_deps: FxHashMap<_, _> = get_op_interface_deps()
         .map(|lazy| (**lazy).clone())
         .collect();
 
@@ -319,7 +351,7 @@ pub static OP_INTERFACE_VERIFIERS_MAP: LazyLock<
     }
 
     // Assign dep_sort_idx to every interface.
-    for lazy in OP_INTERFACE_DEPS.iter() {
+    for lazy in get_op_interface_deps() {
         let (intr, _deps) = &**lazy;
         assign_idx_to_intr(&interface_deps, &mut dep_sort_idx, &mut sort_idx, intr);
     }
@@ -549,8 +581,7 @@ mod tests {
     /// sub-interface verifier.
     fn check_verifiers_deps() -> Result<()> {
         // Collect interface deps into a map.
-        let interface_deps: FxHashMap<_, _> = OP_INTERFACE_DEPS
-            .iter()
+        let interface_deps: FxHashMap<_, _> = get_op_interface_deps()
             .map(|lazy| (**lazy).clone())
             .collect();
 

--- a/src/op.rs
+++ b/src/op.rs
@@ -279,18 +279,22 @@ inventory::collect!(crate::utils::inventory::LazyLockWrapper<OpInterfaceVerifier
 inventory::collect!(crate::utils::inventory::LazyLockWrapper<OpInterfaceDepsInfo, OpId>);
 
 #[cfg(target_family = "wasm")]
-fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceVerifierInfo>>().map(|llw| llw.0)
+fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
+{
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceVerifierInfo>>()
+        .map(|llw| llw.0)
 }
 
 #[cfg(not(target_family = "wasm"))]
-fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>> {
+fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
+{
     OP_INTERFACE_VERIFIERS.iter()
 }
 
 #[cfg(target_family = "wasm")]
 fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceDepsInfo, OpId>>().map(|llw| llw.0)
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceDepsInfo, OpId>>()
+        .map(|llw| llw.0)
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/src/op.rs
+++ b/src/op.rs
@@ -577,7 +577,7 @@ mod tests {
 
     use crate::verify_err_noloc;
 
-    use super::{OP_INTERFACE_DEPS, OP_INTERFACE_VERIFIERS_MAP};
+    use super::{OP_INTERFACE_VERIFIERS_MAP, get_op_interface_deps};
 
     #[test]
     /// For every interface that an [Op] implements, ensure that the interface verifiers

--- a/src/op.rs
+++ b/src/op.rs
@@ -273,8 +273,8 @@ pub mod statics {
     #[linkme::distributed_slice]
     pub static OP_INTERFACE_DEPS: [LazyLock<OpInterfaceDepsInfo>] = [..];
 
-    pub fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
-    {
+    pub fn get_op_interface_verifiers()
+    -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>> {
         OP_INTERFACE_VERIFIERS.iter()
     }
 
@@ -292,15 +292,13 @@ pub mod statics {
 
     inventory::collect!(LazyLockWrapper<OpInterfaceDepsInfo, OpId>);
 
-    pub fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
-    {
-        inventory::iter::<LazyLockWrapper<OpInterfaceVerifierInfo>>()
-            .map(|llw| llw.0)
+    pub fn get_op_interface_verifiers()
+    -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>> {
+        inventory::iter::<LazyLockWrapper<OpInterfaceVerifierInfo>>().map(|llw| llw.0)
     }
 
     pub fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
-        inventory::iter::<LazyLockWrapper<OpInterfaceDepsInfo, OpId>>()
-            .map(|llw| llw.0)
+        inventory::iter::<LazyLockWrapper<OpInterfaceDepsInfo, OpId>>().map(|llw| llw.0)
     }
 }
 

--- a/src/op.rs
+++ b/src/op.rs
@@ -262,45 +262,49 @@ type OpInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
 /// [Op]s paired with every interface it implements (and the verifier for that interface).
-#[cfg(not(target_family = "wasm"))]
-#[linkme::distributed_slice]
-pub static OP_INTERFACE_VERIFIERS: [LazyLock<OpInterfaceVerifierInfo>] = [..];
-
-#[doc(hidden)]
-/// All interfaces mapped to their super-interfaces
-#[cfg(not(target_family = "wasm"))]
-#[linkme::distributed_slice]
-pub static OP_INTERFACE_DEPS: [LazyLock<OpInterfaceDepsInfo>] = [..];
-
-#[cfg(target_family = "wasm")]
-inventory::collect!(crate::utils::inventory::LazyLockWrapper<OpInterfaceVerifierInfo>);
-
-#[cfg(target_family = "wasm")]
-inventory::collect!(crate::utils::inventory::LazyLockWrapper<OpInterfaceDepsInfo, OpId>);
-
-#[cfg(target_family = "wasm")]
-fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
-{
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceVerifierInfo>>()
-        .map(|llw| llw.0)
-}
 
 #[cfg(not(target_family = "wasm"))]
-fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
-{
-    OP_INTERFACE_VERIFIERS.iter()
+pub mod statics {
+    use super::*;
+
+    #[linkme::distributed_slice]
+    pub static OP_INTERFACE_VERIFIERS: [LazyLock<OpInterfaceVerifierInfo>] = [..];
+
+    #[linkme::distributed_slice]
+    pub static OP_INTERFACE_DEPS: [LazyLock<OpInterfaceDepsInfo>] = [..];
+
+    pub fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
+    {
+        OP_INTERFACE_VERIFIERS.iter()
+    }
+
+    pub fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
+        OP_INTERFACE_DEPS.iter()
+    }
 }
 
 #[cfg(target_family = "wasm")]
-fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<OpInterfaceDepsInfo, OpId>>()
-        .map(|llw| llw.0)
+pub mod statics {
+    use super::*;
+    use crate::utils::inventory::LazyLockWrapper;
+
+    inventory::collect!(LazyLockWrapper<OpInterfaceVerifierInfo>);
+
+    inventory::collect!(LazyLockWrapper<OpInterfaceDepsInfo, OpId>);
+
+    pub fn get_op_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<OpInterfaceVerifierInfo>>
+    {
+        inventory::iter::<LazyLockWrapper<OpInterfaceVerifierInfo>>()
+            .map(|llw| llw.0)
+    }
+
+    pub fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
+        inventory::iter::<LazyLockWrapper<OpInterfaceDepsInfo, OpId>>()
+            .map(|llw| llw.0)
+    }
 }
 
-#[cfg(not(target_family = "wasm"))]
-fn get_op_interface_deps() -> impl Iterator<Item = &'static LazyLock<OpInterfaceDepsInfo>> {
-    OP_INTERFACE_DEPS.iter()
-}
+pub use statics::*;
 
 #[doc(hidden)]
 /// A map from every [Op] to its ordered (as per interface deps) list of interface verifiers.

--- a/src/op.rs
+++ b/src/op.rs
@@ -262,7 +262,6 @@ type OpInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
 /// [Op]s paired with every interface it implements (and the verifier for that interface).
-
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;

--- a/src/type.rs
+++ b/src/type.rs
@@ -571,7 +571,8 @@ pub mod statics {
         TYPE_INTERFACE_VERIFIERS.iter()
     }
 
-    pub fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
+    pub fn get_type_interface_deps()
+    -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
         TYPE_INTERFACE_DEPS.iter()
     }
 }
@@ -587,13 +588,12 @@ pub mod statics {
 
     pub fn get_type_interface_verifiers()
     -> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
-        inventory::iter::<LazyLockWrapper<TypeInterfaceVerifierInfo>>()
-            .map(|llw| llw.0)
+        inventory::iter::<LazyLockWrapper<TypeInterfaceVerifierInfo>>().map(|llw| llw.0)
     }
 
-    pub fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
-        inventory::iter::<LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>>()
-            .map(|llw| llw.0)
+    pub fn get_type_interface_deps()
+    -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
+        inventory::iter::<LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>>().map(|llw| llw.0)
     }
 }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -555,7 +555,6 @@ type TypeInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
 /// [Type]s paired with every interface it implements (and the verifier for that interface).
-
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;

--- a/src/type.rs
+++ b/src/type.rs
@@ -548,13 +548,14 @@ pub fn type_impls<T: ?Sized + Type>(ty: &dyn Type) -> bool {
 pub type TypeInterfaceVerifier = fn(&dyn Type, &Context) -> Result<()>;
 
 /// Type alias for type interface verifier information
+/// [Type]s paired with every interface it implements (and the verifier for that interface).
 type TypeInterfaceVerifierInfo = (TypeId, (std::any::TypeId, TypeInterfaceVerifier));
 
 /// Type alias for type interface dependency information  
+/// All interfaces mapped to their super-interfaces
 type TypeInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
-/// [Type]s paired with every interface it implements (and the verifier for that interface).
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;

--- a/src/type.rs
+++ b/src/type.rs
@@ -644,7 +644,7 @@ pub static TYPE_INTERFACE_VERIFIERS_MAP: LazyLock<
     }
 
     // Assign dep_sort_idx to every interface.
-    for lazy in TYPE_INTERFACE_DEPS.iter() {
+    for lazy in get_type_interface_deps() {
         let (intr, _deps) = &**lazy;
         assign_idx_to_intr(&interface_deps, &mut dep_sort_idx, &mut sort_idx, intr);
     }

--- a/src/type.rs
+++ b/src/type.rs
@@ -670,7 +670,7 @@ mod tests {
 
     use crate::verify_err_noloc;
 
-    use super::{TYPE_INTERFACE_DEPS, TYPE_INTERFACE_VERIFIERS_MAP};
+    use super::{TYPE_INTERFACE_VERIFIERS_MAP, get_type_interface_deps};
 
     #[test]
     /// For every interface that a [Type] implements, ensure that the interface verifiers

--- a/src/type.rs
+++ b/src/type.rs
@@ -555,13 +555,13 @@ type TypeInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
 /// [Type]s paired with every interface it implements (and the verifier for that interface).
-#[cfg(not(target_family = "wasm"))] 
+#[cfg(not(target_family = "wasm"))]
 #[linkme::distributed_slice]
 pub static TYPE_INTERFACE_VERIFIERS: [LazyLock<TypeInterfaceVerifierInfo>] = [..];
 
 #[doc(hidden)]
 /// All interfaces mapped to their super-interfaces
-#[cfg(not(target_family = "wasm"))] 
+#[cfg(not(target_family = "wasm"))]
 #[linkme::distributed_slice]
 pub static TYPE_INTERFACE_DEPS: [LazyLock<TypeInterfaceDepsInfo>] = [..];
 
@@ -572,18 +572,22 @@ inventory::collect!(crate::utils::inventory::LazyLockWrapper<TypeInterfaceVerifi
 inventory::collect!(crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>);
 
 #[cfg(target_family = "wasm")]
-fn get_type_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceVerifierInfo>>().map(|llw| llw.0)
+fn get_type_interface_verifiers()
+-> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceVerifierInfo>>()
+        .map(|llw| llw.0)
 }
 
 #[cfg(not(target_family = "wasm"))]
-fn get_type_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
+fn get_type_interface_verifiers()
+-> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
     TYPE_INTERFACE_VERIFIERS.iter()
 }
 
 #[cfg(target_family = "wasm")]
 fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>>().map(|llw| llw.0)
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>>()
+        .map(|llw| llw.0)
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/src/type.rs
+++ b/src/type.rs
@@ -555,45 +555,49 @@ type TypeInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
 /// [Type]s paired with every interface it implements (and the verifier for that interface).
-#[cfg(not(target_family = "wasm"))]
-#[linkme::distributed_slice]
-pub static TYPE_INTERFACE_VERIFIERS: [LazyLock<TypeInterfaceVerifierInfo>] = [..];
-
-#[doc(hidden)]
-/// All interfaces mapped to their super-interfaces
-#[cfg(not(target_family = "wasm"))]
-#[linkme::distributed_slice]
-pub static TYPE_INTERFACE_DEPS: [LazyLock<TypeInterfaceDepsInfo>] = [..];
-
-#[cfg(target_family = "wasm")]
-inventory::collect!(crate::utils::inventory::LazyLockWrapper<TypeInterfaceVerifierInfo>);
-
-#[cfg(target_family = "wasm")]
-inventory::collect!(crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>);
-
-#[cfg(target_family = "wasm")]
-fn get_type_interface_verifiers()
--> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceVerifierInfo>>()
-        .map(|llw| llw.0)
-}
 
 #[cfg(not(target_family = "wasm"))]
-fn get_type_interface_verifiers()
--> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
-    TYPE_INTERFACE_VERIFIERS.iter()
+pub mod statics {
+    use super::*;
+
+    #[linkme::distributed_slice]
+    pub static TYPE_INTERFACE_VERIFIERS: [LazyLock<TypeInterfaceVerifierInfo>] = [..];
+
+    #[linkme::distributed_slice]
+    pub static TYPE_INTERFACE_DEPS: [LazyLock<TypeInterfaceDepsInfo>] = [..];
+
+    pub fn get_type_interface_verifiers()
+    -> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
+        TYPE_INTERFACE_VERIFIERS.iter()
+    }
+
+    pub fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
+        TYPE_INTERFACE_DEPS.iter()
+    }
 }
 
 #[cfg(target_family = "wasm")]
-fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>>()
-        .map(|llw| llw.0)
+pub mod statics {
+    use super::*;
+    use crate::utils::inventory::LazyLockWrapper;
+
+    inventory::collect!(LazyLockWrapper<TypeInterfaceVerifierInfo>);
+
+    inventory::collect!(LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>);
+
+    pub fn get_type_interface_verifiers()
+    -> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
+        inventory::iter::<LazyLockWrapper<TypeInterfaceVerifierInfo>>()
+            .map(|llw| llw.0)
+    }
+
+    pub fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
+        inventory::iter::<LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>>()
+            .map(|llw| llw.0)
+    }
 }
 
-#[cfg(not(target_family = "wasm"))]
-fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
-    TYPE_INTERFACE_DEPS.iter()
-}
+pub use statics::*;
 
 #[doc(hidden)]
 /// A map from every [Type] to its ordered (as per interface deps) list of interface verifiers.

--- a/src/type.rs
+++ b/src/type.rs
@@ -555,19 +555,21 @@ type TypeInterfaceDepsInfo = (std::any::TypeId, Vec<std::any::TypeId>);
 
 #[doc(hidden)]
 /// [Type]s paired with every interface it implements (and the verifier for that interface).
-#[cfg_attr(not(target_family = "wasm"), linkme::distributed_slice)]
+#[cfg(not(target_family = "wasm"))] 
+#[linkme::distributed_slice]
 pub static TYPE_INTERFACE_VERIFIERS: [LazyLock<TypeInterfaceVerifierInfo>] = [..];
 
 #[doc(hidden)]
 /// All interfaces mapped to their super-interfaces
-#[cfg_attr(not(target_family = "wasm"), linkme::distributed_slice)]
+#[cfg(not(target_family = "wasm"))] 
+#[linkme::distributed_slice]
 pub static TYPE_INTERFACE_DEPS: [LazyLock<TypeInterfaceDepsInfo>] = [..];
 
 #[cfg(target_family = "wasm")]
 inventory::collect!(crate::utils::inventory::LazyLockWrapper<TypeInterfaceVerifierInfo>);
 
 #[cfg(target_family = "wasm")]
-inventory::collect!(crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo>);
+inventory::collect!(crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>);
 
 #[cfg(target_family = "wasm")]
 fn get_type_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceVerifierInfo>> {
@@ -581,7 +583,7 @@ fn get_type_interface_verifiers() -> impl Iterator<Item = &'static LazyLock<Type
 
 #[cfg(target_family = "wasm")]
 fn get_type_interface_deps() -> impl Iterator<Item = &'static LazyLock<TypeInterfaceDepsInfo>> {
-    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo>>().map(|llw| llw.0)
+    inventory::iter::<crate::utils::inventory::LazyLockWrapper<TypeInterfaceDepsInfo, TypeId>>().map(|llw| llw.0)
 }
 
 #[cfg(not(target_family = "wasm"))]

--- a/src/utils/inventory.rs
+++ b/src/utils/inventory.rs
@@ -1,5 +1,8 @@
-// This is used to print out different types for use
-// with the inventory crate so that we can register
-// items that have one-time dynamic initialization
-// processes via LazyLock.
-pub struct LazyLockWrapper<T>(pub &'static LazyLock<T>);
+//! Helpers for integration for inventory
+use std::sync::LazyLock;
+
+/// This is used to print out different types for use
+/// with the inventory crate so that we can register
+/// items that have one-time dynamic initialization
+/// processes via LazyLock.
+pub struct LazyLockWrapper<T: 'static>(pub &'static LazyLock<T>);

--- a/src/utils/inventory.rs
+++ b/src/utils/inventory.rs
@@ -1,0 +1,5 @@
+// This is used to print out different types for use
+// with the inventory crate so that we can register
+// items that have one-time dynamic initialization
+// processes via LazyLock.
+pub struct LazyLockWrapper<T>(pub &'static LazyLock<T>);

--- a/src/utils/inventory.rs
+++ b/src/utils/inventory.rs
@@ -1,8 +1,19 @@
 //! Helpers for integration for inventory
+use std::marker::PhantomData;
 use std::sync::LazyLock;
 
 /// This is used to print out different types for use
 /// with the inventory crate so that we can register
 /// items that have one-time dynamic initialization
-/// processes via LazyLock.
-pub struct LazyLockWrapper<T: 'static>(pub &'static LazyLock<T>);
+/// processes via LazyLock. The U parameter is for
+/// further distinguishing in cases where T is similar.
+pub struct LazyLockWrapper<T: 'static, U = ()>(
+    pub &'static LazyLock<T>,
+    pub PhantomData<U>,
+);
+
+impl<T, U> LazyLockWrapper<T, U> {
+    pub const fn new(t: &'static LazyLock<T>) -> Self {
+        Self(t, PhantomData)
+    }
+}

--- a/src/utils/inventory.rs
+++ b/src/utils/inventory.rs
@@ -7,10 +7,7 @@ use std::sync::LazyLock;
 /// items that have one-time dynamic initialization
 /// processes via LazyLock. The U parameter is for
 /// further distinguishing in cases where T is similar.
-pub struct LazyLockWrapper<T: 'static, U = ()>(
-    pub &'static LazyLock<T>,
-    pub PhantomData<U>,
-);
+pub struct LazyLockWrapper<T: 'static, U = ()>(pub &'static LazyLock<T>, pub PhantomData<U>);
 
 impl<T, U> LazyLockWrapper<T, U> {
     pub const fn new(t: &'static LazyLock<T>) -> Self {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod apfloat;
 pub mod apint;
-#[cfg(feature = "inventory")]
+#[cfg(target_family = "wasm")]
 pub mod inventory;
 pub mod trait_cast;
 pub mod vec_exns;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,5 +2,7 @@
 
 pub mod apfloat;
 pub mod apint;
+#[cfg(feature = "inventory")]
+pub mod inventory;
 pub mod trait_cast;
 pub mod vec_exns;

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -129,7 +129,7 @@ macro_rules! type_to_trait {
 
             #[cfg(target_family = "wasm")]
             inventory::submit! {
-                $crate::utils::inventory::LazyLockWrapper(&CAST_TO_TRAIT)
+                $crate::utils::inventory::LazyLockWrapper::new(&CAST_TO_TRAIT)
             }
 
             fn cast_to_trait<'a>(

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -53,7 +53,6 @@ pub type TraitCasterInfo = ((TypeId, TypeId), &'static (dyn Any + Sync + Send));
 
 #[doc(hidden)]
 /// A distributed slice of (type_id of the object, type_id of the trait to cast to, cast function)
-
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -49,10 +49,10 @@ pub fn any_to_trait<T: ?Sized + 'static>(r: &dyn Any) -> Option<&T> {
 }
 
 /// Type aliases to simplify types below
+/// (type_id of the object, type_id of the trait to cast to, cast function)
 pub type TraitCasterInfo = ((TypeId, TypeId), &'static (dyn Any + Sync + Send));
 
 #[doc(hidden)]
-/// A distributed slice of (type_id of the object, type_id of the trait to cast to, cast function)
 #[cfg(not(target_family = "wasm"))]
 pub mod statics {
     use super::*;


### PR DESCRIPTION
Implements the discussion in https://github.com/vaivaswatha/pliron/issues/66.

For non-WASM targets, we still use `linkme::distributed_slice` to avoid running code before main and for WASM targets (which `linkme` doesn't work on), we use `inventory`. It was attempted to make the smallest number of code changes to make it happen, but there is certainly room for improvement.

One key decision here was to use direct target family checks instead of crate features. Because of the heavy macro usage in the `pliron*` crates, gating on crate features would imply a bit of code duplication because we can't really do crate feature conditional code generation in a `macro_rules!` (AFAIK). Target family checks will be consistent on the macro definer as well as macro user so that seemed simple and easy to use for now.

When designing struct types for use with `inventory`, we had to distinguish between the dependency information for operations, types, and attributes which otherwise had the same types by adding a phantom type parameter with the id type for the respective IR entity. We could make a different choice for that type parameter that may avoid changing the `interface_define` macros at all, but this is what I've done so far. We could also just define proper distinct structs for each set of dependency information. I went with the route that was least invasive to the existing setup.

I verified this worked for both standard backends and wasm with:
```
cargo build -p pliron
cargo build -p pliron --target wasm32-unknown-unknown
```

There is enough usage of the macros internally in the crate that this seemed like sufficient validation - I got a lot of build errors inside of `src/builtin/*` until I went through and made the necessary macro changes to fix the uses.