### PR TITLE
Added dominance checking for operations

### DIFF
--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -244,7 +244,9 @@ pub trait RegionKindInterface {
     fn get_region_kind(&self, idx: usize) -> RegionKind;
     /// Return true if the region with the given index inside this operation
     /// must require dominance to hold.
-    fn has_ssa_dominance(&self, idx: usize) -> bool;
+    fn has_ssa_dominance(&self, idx: usize) -> bool {
+        matches!(self.get_region_kind(idx), RegionKind::SSACFG)
+    }
 
     fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>
     where

--- a/src/builtin/ops.rs
+++ b/src/builtin/ops.rs
@@ -1,5 +1,6 @@
 use combine::{Parser, optional, token};
 use pliron::derive::pliron_op;
+use pliron_derive::op_interface_impl;
 use thiserror::Error;
 
 use crate::{
@@ -8,6 +9,7 @@ use crate::{
     builtin::{
         op_interfaces::{
             ATTR_KEY_SYM_NAME, NRegionsInterface, NResultsInterface, NoTerminatorInterface,
+            RegionKind, RegionKindInterface,
         },
         ops::func_op_attr_names::ATTR_KEY_FUNC_TYPE,
         type_interfaces::FunctionTypeInterface,
@@ -45,7 +47,7 @@ use super::{
 /// Represents a module, a top level container operation.
 ///
 /// See MLIR's [builtin.module](https://mlir.llvm.org/docs/Dialects/Builtin/#builtinmodule-mlirmoduleop).
-/// It contains a single [SSACFG](super::op_interfaces::RegionKind::SSACFG)
+/// It contains a single [Graph](super::op_interfaces::RegionKind::Graph)
 /// region containing a single block which can contain any operations and
 /// does not have a terminator.
 ///
@@ -65,6 +67,17 @@ use super::{
     verifier = "succ",
 )]
 pub struct ModuleOp;
+
+#[op_interface_impl]
+impl RegionKindInterface for ModuleOp {
+    fn get_region_kind(&self, _idx: usize) -> RegionKind {
+        RegionKind::Graph
+    }
+
+    fn has_ssa_dominance(&self, _idx: usize) -> bool {
+        false
+    }
+}
 
 impl Printable for ModuleOp {
     fn fmt(

--- a/src/builtin/ops.rs
+++ b/src/builtin/ops.rs
@@ -73,10 +73,6 @@ impl RegionKindInterface for ModuleOp {
     fn get_region_kind(&self, _idx: usize) -> RegionKind {
         RegionKind::Graph
     }
-
-    fn has_ssa_dominance(&self, _idx: usize) -> bool {
-        false
-    }
 }
 
 impl Printable for ModuleOp {

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -1,6 +1,14 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::graph::{ControlFlowGraph, traversals};
+use crate::{
+    builtin::op_interfaces::{IsolatedFromAboveInterface, RegionKindInterface},
+    context::{Context, Ptr},
+    graph::{ControlFlowGraph, traversals},
+    linked_list::LinkedList,
+    op::op_cast,
+    operation::Operation,
+    region::Region,
+};
 
 /// A node in the dominator tree.
 struct DomTreeNode<G, GraphContext>
@@ -204,11 +212,74 @@ where
     }
 }
 
+/// Does the given region use SSA dominance?
+fn region_has_ssa_dominance(ctx: &Context, region: Ptr<Region>) -> bool {
+    let parent_op = region.deref(ctx).get_parent_op();
+    let op_dyn = Operation::get_op_dyn(parent_op, ctx);
+    match op_cast::<dyn RegionKindInterface>(op_dyn.as_ref()) {
+        Some(rki) => {
+            let region_idx = region.deref(ctx).get_index_in_parent(ctx);
+            rki.has_ssa_dominance(region_idx)
+        }
+        None => true,
+    }
+}
+
+/// Does `a` dominate `b`?
+///
+/// Following MLIR-style scoping, assumes that `b` is nested inside `a`'s parent region.
+pub fn dominates(
+    ctx: &Context,
+    dom_trees: &FxHashMap<Ptr<Region>, DomTree<Ptr<Region>, Context>>,
+    a: Ptr<Operation>,
+    b: Ptr<Operation>,
+) -> bool {
+    let Some(block_a) = a.deref(ctx).get_parent_block() else {
+        return false;
+    };
+    let region_a = block_a.deref(ctx).get_parent_region().unwrap();
+    let region_a_ssa = region_has_ssa_dominance(ctx, region_a);
+
+    let mut b = b;
+    while let Some(block_b) = b.deref(ctx).get_parent_block() {
+        let region_b = block_b.deref(ctx).get_parent_region().unwrap();
+
+        if block_a == block_b {
+            if !region_a_ssa {
+                return true;
+            }
+
+            let mut cursor = a.deref(ctx).get_next();
+            while let Some(op) = cursor {
+                if op == b {
+                    return true;
+                }
+                cursor = op.deref(ctx).get_next();
+            }
+            return false;
+        }
+
+        if region_a == region_b {
+            let dom_tree = &dom_trees[&region_a];
+            return dom_tree.dominates(&block_a, &block_b);
+        }
+
+        let parent_op = region_b.deref(ctx).get_parent_op();
+        let op_dyn = Operation::get_op_dyn(parent_op, ctx);
+        if op_cast::<dyn IsolatedFromAboveInterface>(op_dyn.as_ref()).is_some() {
+            return false;
+        }
+        b = parent_op;
+    }
+
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::{DomFrontierMap, compute_dominator_tree};
     use crate::graph::ControlFlowGraph;
-    use rustc_hash::FxHashSet;
+    use rustc_hash::{FxHashMap, FxHashSet};
     use std::collections::HashSet;
 
     #[derive(Clone, Debug)]
@@ -501,5 +572,366 @@ mod tests {
         let dom = compute_dominator_tree(&ctx, &ArenaGraph);
         let df = DomFrontierMap::new(&ctx, &ArenaGraph, &dom);
         assert_eq!(*df.frontier(&4), FxHashSet::from_iter([3, 4, 11, 12]));
+    }
+
+    // --- Operation-level dominance tests ---
+
+    use crate::{
+        basic_block::BasicBlock,
+        builtin::{
+            op_interfaces::{
+                IsTerminatorInterface, NRegionsInterface, OneRegionInterface,
+                SingleBlockRegionInterface,
+            },
+            ops::{FuncOp, ModuleOp},
+            types::{FunctionType, IntegerType, Signedness},
+        },
+        context::{Context, Ptr},
+        derive::pliron_op,
+        linked_list::ContainsLinkedList,
+        op::Op,
+        operation::Operation,
+        region::Region,
+    };
+
+    /// A test-only terminator operation for setting up CFG edges.
+    #[pliron_op(
+        name = "test.branch",
+        interfaces = [IsTerminatorInterface],
+        verifier = "succ",
+    )]
+    struct BranchOp;
+    impl crate::printable::Printable for BranchOp {
+        fn fmt(
+            &self,
+            _ctx: &Context,
+            _state: &crate::printable::State,
+            f: &mut core::fmt::Formatter<'_>,
+        ) -> core::fmt::Result {
+            write!(f, "test.branch")
+        }
+    }
+    impl crate::parsable::Parsable for BranchOp {
+        type Arg = Vec<(crate::identifier::Identifier, crate::location::Location)>;
+        type Parsed = crate::op::OpObj;
+        fn parse<'a>(
+            _state_stream: &mut crate::parsable::StateStream<'a>,
+            _results: Self::Arg,
+        ) -> crate::parsable::ParseResult<'a, Self::Parsed> {
+            unimplemented!("TestTerminatorOp parsing not needed for tests")
+        }
+    }
+
+    /// A test-only operation with one region that is NOT IsolatedFromAbove.
+    /// Represents something like a loop or scope construct.
+    #[pliron_op(
+        name = "test.scope",
+        interfaces = [NRegionsInterface<1>, OneRegionInterface],
+        verifier = "succ",
+    )]
+    struct ScopeOp;
+    impl crate::printable::Printable for ScopeOp {
+        fn fmt(
+            &self,
+            _ctx: &Context,
+            _state: &crate::printable::State,
+            f: &mut core::fmt::Formatter<'_>,
+        ) -> core::fmt::Result {
+            write!(f, "test.scope")
+        }
+    }
+    impl crate::parsable::Parsable for ScopeOp {
+        type Arg = Vec<(crate::identifier::Identifier, crate::location::Location)>;
+        type Parsed = crate::op::OpObj;
+        fn parse<'a>(
+            _state_stream: &mut crate::parsable::StateStream<'a>,
+            _results: Self::Arg,
+        ) -> crate::parsable::ParseResult<'a, Self::Parsed> {
+            unimplemented!("ScopeOp parsing not needed for tests")
+        }
+    }
+    impl ScopeOp {
+        fn new(ctx: &mut Context) -> ScopeOp {
+            let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 1);
+            // Create an entry block in the region.
+            let region = op.deref(ctx).get_region(0);
+            let block = BasicBlock::new(ctx, None, vec![]);
+            block.insert_at_front(region, ctx);
+            ScopeOp { op }
+        }
+
+        fn get_entry_block(&self, ctx: &Context) -> Ptr<BasicBlock> {
+            self.get_region(ctx).deref(ctx).get_head().unwrap()
+        }
+    }
+
+    /// Build dom_trees map for all regions reachable from a module (recursively).
+    fn build_dom_trees(
+        ctx: &Context,
+        module: &ModuleOp,
+    ) -> FxHashMap<Ptr<Region>, super::DomTree<Ptr<Region>, Context>> {
+        fn collect_regions(
+            ctx: &Context,
+            region: Ptr<Region>,
+            map: &mut FxHashMap<Ptr<Region>, super::DomTree<Ptr<Region>, Context>>,
+        ) {
+            map.insert(region, compute_dominator_tree(ctx, &region));
+            for block in region.deref(ctx).iter(ctx) {
+                for op in block.deref(ctx).iter(ctx) {
+                    for child_region in op.deref(ctx).regions() {
+                        collect_regions(ctx, child_region, map);
+                    }
+                }
+            }
+        }
+        let mut map = FxHashMap::default();
+        let mod_region = module.get_operation().deref(ctx).get_region(0);
+        collect_regions(ctx, mod_region, &mut map);
+        map
+    }
+
+    #[test]
+    fn op_dominates_same_block() {
+        let ctx = &mut Context::new();
+        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+        let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+        let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+        let func = FuncOp::new(ctx, "f".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, func.get_operation(), 0);
+
+        let bb = func.get_entry_block(ctx);
+
+        let op_a = Operation::new(
+            ctx,
+            FuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_a.insert_at_back(bb, ctx);
+
+        let op_b = Operation::new(
+            ctx,
+            FuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_b.insert_at_back(bb, ctx);
+
+        let dom_trees = build_dom_trees(ctx, &module);
+
+        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
+        assert!(!super::dominates(ctx, &dom_trees, op_b, op_a));
+        assert!(!super::dominates(ctx, &dom_trees, op_a, op_a));
+    }
+
+    #[test]
+    fn op_dominates_graph_region() {
+        let ctx = &mut Context::new();
+        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+        let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+        let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+
+        let func_a = FuncOp::new(ctx, "a".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, func_a.get_operation(), 0);
+        let func_b = FuncOp::new(ctx, "b".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, func_b.get_operation(), 0);
+
+        let dom_trees = build_dom_trees(ctx, &module);
+
+        let op_a = func_a.get_operation();
+        let op_b = func_b.get_operation();
+
+        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
+        assert!(super::dominates(ctx, &dom_trees, op_b, op_a));
+    }
+
+    #[test]
+    fn op_dominates_isolated_from_above() {
+        let ctx = &mut Context::new();
+        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+        let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+
+        let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+        let outer_func = FuncOp::new(ctx, "outer".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, outer_func.get_operation(), 0);
+        let outer_bb = outer_func.get_entry_block(ctx);
+        let op_a = Operation::new(
+            ctx,
+            FuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_a.insert_at_back(outer_bb, ctx);
+        let inner_func = FuncOp::new(ctx, "inner".try_into().unwrap(), func_ty);
+        inner_func.get_operation().insert_at_back(outer_bb, ctx);
+        let op_b = Operation::new(
+            ctx,
+            FuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_b.insert_at_back(inner_func.get_entry_block(ctx), ctx);
+
+        let dom_trees = build_dom_trees(ctx, &module);
+
+        assert!(super::dominates(
+            ctx,
+            &dom_trees,
+            op_a,
+            inner_func.get_operation()
+        ));
+        assert!(!super::dominates(ctx, &dom_trees, op_a, op_b));
+    }
+
+    #[test]
+    fn op_does_not_dominate_own_body() {
+        let ctx = &mut Context::new();
+        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+        let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+        let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+
+        let func = FuncOp::new(ctx, "f".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, func.get_operation(), 0);
+
+        let inner_op = Operation::new(
+            ctx,
+            FuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        inner_op.insert_at_back(func.get_entry_block(ctx), ctx);
+
+        let dom_trees = build_dom_trees(ctx, &module);
+
+        assert!(!super::dominates(
+            ctx,
+            &dom_trees,
+            func.get_operation(),
+            inner_op
+        ));
+    }
+
+    #[test]
+    fn op_dominates_nested_non_isolated_region() {
+        let ctx = &mut Context::new();
+        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+        let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+        let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+
+        let func = FuncOp::new(ctx, "f".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, func.get_operation(), 0);
+        let bb = func.get_entry_block(ctx);
+
+        let op_a = Operation::new(
+            ctx,
+            FuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_a.insert_at_back(bb, ctx);
+
+        let scope = ScopeOp::new(ctx);
+        scope.get_operation().insert_at_back(bb, ctx);
+
+        let op_b = Operation::new(
+            ctx,
+            FuncOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_b.insert_at_back(scope.get_entry_block(ctx), ctx);
+
+        let dom_trees = build_dom_trees(ctx, &module);
+
+        assert!(super::dominates(
+            ctx,
+            &dom_trees,
+            op_a,
+            scope.get_operation()
+        ));
+        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
+    }
+
+    #[test]
+    fn op_dominates_cross_block() {
+        // CFG:
+        //     entry (opA)
+        //      / \
+        //    b1    b2
+        //   (opB)  (opC)
+        //
+        let ctx = &mut Context::new();
+        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+        let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+        let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+
+        let func = FuncOp::new(ctx, "f".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, func.get_operation(), 0);
+        let func_region = func.get_region(ctx);
+        let entry = func.get_entry_block(ctx);
+
+        let b1 = BasicBlock::new(ctx, None, vec![]);
+        b1.insert_at_back(func_region, ctx);
+        let b2 = BasicBlock::new(ctx, None, vec![]);
+        b2.insert_at_back(func_region, ctx);
+
+        let op_a = Operation::new(
+            ctx,
+            ScopeOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_a.insert_at_back(entry, ctx);
+        let branch = Operation::new(
+            ctx,
+            BranchOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![b1, b2],
+            0,
+        );
+        branch.insert_at_back(entry, ctx);
+
+        let op_b = Operation::new(
+            ctx,
+            ScopeOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_b.insert_at_back(b1, ctx);
+
+        let op_c = Operation::new(
+            ctx,
+            ScopeOp::get_concrete_op_info(),
+            vec![],
+            vec![],
+            vec![],
+            0,
+        );
+        op_c.insert_at_back(b2, ctx);
+
+        let dom_trees = build_dom_trees(ctx, &module);
+
+        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
+        assert!(super::dominates(ctx, &dom_trees, op_a, op_c));
+        assert!(!super::dominates(ctx, &dom_trees, op_b, op_c));
     }
 }

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -275,7 +275,12 @@ impl DomInfo {
     ///
     /// Caches region dominator trees as a side effect. This is an MLIR-specific notion of
     /// dominance. Operations in graph regions dominate themselves, so it is only "strict" for SSA regions.
-    pub fn strictly_dominates(&mut self, ctx: &Context, a: Ptr<Operation>, b: Ptr<Operation>) -> bool {
+    pub fn strictly_dominates(
+        &mut self,
+        ctx: &Context,
+        a: Ptr<Operation>,
+        b: Ptr<Operation>,
+    ) -> bool {
         let Some(block_a) = a.deref(ctx).get_parent_block() else {
             return false;
         };

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -292,15 +292,7 @@ impl DomInfo {
         let block_b = b.deref(ctx).get_parent_block().unwrap();
 
         if block_a == block_b {
-            if !region_a_ssa {
-                return true;
-            }
-
-            if strictly_precedes_in_block(ctx, a, b) {
-                return true;
-            }
-
-            return false;
+            return !region_a_ssa || strictly_precedes_in_block(ctx, a, b);
         }
 
         let dom_tree = self.get_dom_tree(ctx, region_a);

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
-    builtin::op_interfaces::{IsolatedFromAboveInterface, RegionKindInterface},
+    builtin::op_interfaces::RegionKindInterface,
     context::{Context, Ptr},
     graph::{ControlFlowGraph, traversals},
     linked_list::LinkedList,
@@ -212,6 +212,23 @@ where
     }
 }
 
+/// Returns the ancestor operation of `op` contained in `region`, or returns `None` if
+/// no ancestor of `op` is in `region`.
+fn find_ancestor_in_region(
+    ctx: &Context,
+    op: Ptr<Operation>,
+    target_region: Ptr<Region>,
+) -> Option<Ptr<Operation>> {
+    let mut op = op;
+    while let Some(ancestor_region) = op.deref(ctx).get_parent_region(ctx) {
+        if ancestor_region == target_region {
+            return Some(op);
+        }
+        op = ancestor_region.deref(ctx).get_parent_op();
+    }
+    None
+}
+
 /// Does the given region use SSA dominance?
 fn region_has_ssa_dominance(ctx: &Context, region: Ptr<Region>) -> bool {
     let parent_op = region.deref(ctx).get_parent_op();
@@ -225,61 +242,77 @@ fn region_has_ssa_dominance(ctx: &Context, region: Ptr<Region>) -> bool {
     }
 }
 
-/// Does `a` dominate `b`?
-///
-/// Following MLIR-style scoping, assumes that `b` is nested inside `a`'s parent region.
-pub fn dominates(
-    ctx: &Context,
-    dom_trees: &FxHashMap<Ptr<Region>, DomTree<Ptr<Region>, Context>>,
-    a: Ptr<Operation>,
-    b: Ptr<Operation>,
-) -> bool {
-    let Some(block_a) = a.deref(ctx).get_parent_block() else {
-        return false;
-    };
-    let region_a = block_a.deref(ctx).get_parent_region().unwrap();
-    let region_a_ssa = region_has_ssa_dominance(ctx, region_a);
+/// Does operation `a` strictly precede operation `b` in `a`'s block?
+fn strictly_precedes_in_block(ctx: &Context, a: Ptr<Operation>, b: Ptr<Operation>) -> bool {
+    let mut cursor = a.deref(ctx).get_next();
+    while let Some(op) = cursor {
+        if op == b {
+            return true;
+        }
+        cursor = op.deref(ctx).get_next();
+    }
+    false
+}
 
-    let mut b = b;
-    while let Some(block_b) = b.deref(ctx).get_parent_block() {
-        let region_b = block_b.deref(ctx).get_parent_region().unwrap();
+/// Caches dominance trees for multiple regions in a program
+#[derive(Default)]
+pub struct DomInfo(FxHashMap<Ptr<Region>, DomTree<Ptr<Region>, Context>>);
+
+impl DomInfo {
+    /// If dominator tree for `region` is cached, return it.
+    /// Otherwise, computes, caches, and returns the `region`'s dominator tree.
+    pub fn get_dom_tree(
+        &mut self,
+        ctx: &Context,
+        region: Ptr<Region>,
+    ) -> &DomTree<Ptr<Region>, Context> {
+        if self.0.contains_key(&region) {
+            return &self.0[&region];
+        }
+
+        let dom_tree = compute_dominator_tree(ctx, &region);
+        self.0.insert(region, dom_tree);
+
+        &self.0[&region]
+    }
+
+    /// Does `a` dominate `b`? Caches region dominator trees as a side effect.
+    ///
+    /// Following MLIR-style scoping, assumes that `b` is nested inside `a`'s parent region.
+    pub fn dominates(&mut self, ctx: &Context, a: Ptr<Operation>, b: Ptr<Operation>) -> bool {
+        let Some(block_a) = a.deref(ctx).get_parent_block() else {
+            return false;
+        };
+        let region_a = block_a.deref(ctx).get_parent_region().unwrap();
+        let region_a_ssa = region_has_ssa_dominance(ctx, region_a);
+
+        let Some(b) = find_ancestor_in_region(ctx, b, region_a) else {
+            return false;
+        };
+        let block_b = b.deref(ctx).get_parent_block().unwrap();
 
         if block_a == block_b {
             if !region_a_ssa {
                 return true;
             }
 
-            let mut cursor = a.deref(ctx).get_next();
-            while let Some(op) = cursor {
-                if op == b {
-                    return true;
-                }
-                cursor = op.deref(ctx).get_next();
+            if strictly_precedes_in_block(ctx, a, b) {
+                return true;
             }
+
             return false;
         }
 
-        if region_a == region_b {
-            let dom_tree = &dom_trees[&region_a];
-            return dom_tree.dominates(&block_a, &block_b);
-        }
-
-        let parent_op = region_b.deref(ctx).get_parent_op();
-        let op_dyn = Operation::get_op_dyn(parent_op, ctx);
-        if op_cast::<dyn IsolatedFromAboveInterface>(op_dyn.as_ref()).is_some() {
-            return false;
-        }
-        b = parent_op;
+        let dom_tree = self.get_dom_tree(ctx, region_a);
+        dom_tree.dominates(&block_a, &block_b)
     }
-
-    false
 }
 
 #[cfg(test)]
 mod tests {
     use super::{DomFrontierMap, compute_dominator_tree};
     use crate::graph::ControlFlowGraph;
-    use rustc_hash::{FxHashMap, FxHashSet};
+    use rustc_hash::FxHashSet;
     use std::collections::HashSet;
 
     #[derive(Clone, Debug)]
@@ -591,7 +624,6 @@ mod tests {
         linked_list::ContainsLinkedList,
         op::Op,
         operation::Operation,
-        region::Region,
     };
 
     /// A test-only terminator operation for setting up CFG edges.
@@ -665,31 +697,6 @@ mod tests {
         }
     }
 
-    /// Build dom_trees map for all regions reachable from a module (recursively).
-    fn build_dom_trees(
-        ctx: &Context,
-        module: &ModuleOp,
-    ) -> FxHashMap<Ptr<Region>, super::DomTree<Ptr<Region>, Context>> {
-        fn collect_regions(
-            ctx: &Context,
-            region: Ptr<Region>,
-            map: &mut FxHashMap<Ptr<Region>, super::DomTree<Ptr<Region>, Context>>,
-        ) {
-            map.insert(region, compute_dominator_tree(ctx, &region));
-            for block in region.deref(ctx).iter(ctx) {
-                for op in block.deref(ctx).iter(ctx) {
-                    for child_region in op.deref(ctx).regions() {
-                        collect_regions(ctx, child_region, map);
-                    }
-                }
-            }
-        }
-        let mut map = FxHashMap::default();
-        let mod_region = module.get_operation().deref(ctx).get_region(0);
-        collect_regions(ctx, mod_region, &mut map);
-        map
-    }
-
     #[test]
     fn op_dominates_same_block() {
         let ctx = &mut Context::new();
@@ -721,11 +728,11 @@ mod tests {
         );
         op_b.insert_at_back(bb, ctx);
 
-        let dom_trees = build_dom_trees(ctx, &module);
+        let mut dom_info = super::DomInfo::default();
 
-        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
-        assert!(!super::dominates(ctx, &dom_trees, op_b, op_a));
-        assert!(!super::dominates(ctx, &dom_trees, op_a, op_a));
+        assert!(dom_info.dominates(ctx, op_a, op_b));
+        assert!(!dom_info.dominates(ctx, op_b, op_a));
+        assert!(!dom_info.dominates(ctx, op_a, op_a));
     }
 
     #[test]
@@ -740,26 +747,30 @@ mod tests {
         let func_b = FuncOp::new(ctx, "b".try_into().unwrap(), func_ty);
         module.append_operation(ctx, func_b.get_operation(), 0);
 
-        let dom_trees = build_dom_trees(ctx, &module);
+        let mut dom_info = super::DomInfo::default();
 
         let op_a = func_a.get_operation();
         let op_b = func_b.get_operation();
 
-        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
-        assert!(super::dominates(ctx, &dom_trees, op_b, op_a));
+        assert!(dom_info.dominates(ctx, op_a, op_b));
+        assert!(dom_info.dominates(ctx, op_b, op_a));
     }
 
     #[test]
-    fn op_dominates_isolated_from_above() {
+    fn ssa_op_does_not_dominate_own_body() {
         let ctx = &mut Context::new();
         let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
         let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
-
         let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+
         let outer_func = FuncOp::new(ctx, "outer".try_into().unwrap(), func_ty);
         module.append_operation(ctx, outer_func.get_operation(), 0);
-        let outer_bb = outer_func.get_entry_block(ctx);
-        let op_a = Operation::new(
+
+        let func = FuncOp::new(ctx, "f".try_into().unwrap(), func_ty);
+        func.get_operation()
+            .insert_at_back(outer_func.get_entry_block(ctx), ctx);
+
+        let inner_op = Operation::new(
             ctx,
             FuncOp::get_concrete_op_info(),
             vec![],
@@ -767,32 +778,15 @@ mod tests {
             vec![],
             0,
         );
-        op_a.insert_at_back(outer_bb, ctx);
-        let inner_func = FuncOp::new(ctx, "inner".try_into().unwrap(), func_ty);
-        inner_func.get_operation().insert_at_back(outer_bb, ctx);
-        let op_b = Operation::new(
-            ctx,
-            FuncOp::get_concrete_op_info(),
-            vec![],
-            vec![],
-            vec![],
-            0,
-        );
-        op_b.insert_at_back(inner_func.get_entry_block(ctx), ctx);
+        inner_op.insert_at_back(func.get_entry_block(ctx), ctx);
 
-        let dom_trees = build_dom_trees(ctx, &module);
+        let mut dom_info = super::DomInfo::default();
 
-        assert!(super::dominates(
-            ctx,
-            &dom_trees,
-            op_a,
-            inner_func.get_operation()
-        ));
-        assert!(!super::dominates(ctx, &dom_trees, op_a, op_b));
+        assert!(!dom_info.dominates(ctx, func.get_operation(), inner_op));
     }
 
     #[test]
-    fn op_does_not_dominate_own_body() {
+    fn graph_op_dominates_own_body() {
         let ctx = &mut Context::new();
         let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
         let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
@@ -811,18 +805,13 @@ mod tests {
         );
         inner_op.insert_at_back(func.get_entry_block(ctx), ctx);
 
-        let dom_trees = build_dom_trees(ctx, &module);
+        let mut dom_info = super::DomInfo::default();
 
-        assert!(!super::dominates(
-            ctx,
-            &dom_trees,
-            func.get_operation(),
-            inner_op
-        ));
+        assert!(dom_info.dominates(ctx, func.get_operation(), inner_op));
     }
 
     #[test]
-    fn op_dominates_nested_non_isolated_region() {
+    fn op_dominates_nested_region() {
         let ctx = &mut Context::new();
         let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
         let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
@@ -855,15 +844,10 @@ mod tests {
         );
         op_b.insert_at_back(scope.get_entry_block(ctx), ctx);
 
-        let dom_trees = build_dom_trees(ctx, &module);
+        let mut dom_info = super::DomInfo::default();
 
-        assert!(super::dominates(
-            ctx,
-            &dom_trees,
-            op_a,
-            scope.get_operation()
-        ));
-        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
+        assert!(dom_info.dominates(ctx, op_a, scope.get_operation()));
+        assert!(dom_info.dominates(ctx, op_a, op_b));
     }
 
     #[test]
@@ -928,10 +912,10 @@ mod tests {
         );
         op_c.insert_at_back(b2, ctx);
 
-        let dom_trees = build_dom_trees(ctx, &module);
+        let mut dom_info = super::DomInfo::default();
 
-        assert!(super::dominates(ctx, &dom_trees, op_a, op_b));
-        assert!(super::dominates(ctx, &dom_trees, op_a, op_c));
-        assert!(!super::dominates(ctx, &dom_trees, op_b, op_c));
+        assert!(dom_info.dominates(ctx, op_a, op_b));
+        assert!(dom_info.dominates(ctx, op_a, op_c));
+        assert!(!dom_info.dominates(ctx, op_b, op_c));
     }
 }

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -266,20 +266,16 @@ impl DomInfo {
         ctx: &Context,
         region: Ptr<Region>,
     ) -> &DomTree<Ptr<Region>, Context> {
-        if self.0.contains_key(&region) {
-            return &self.0[&region];
-        }
-
-        let dom_tree = compute_dominator_tree(ctx, &region);
-        self.0.insert(region, dom_tree);
-
-        &self.0[&region]
+        self.0
+            .entry(region)
+            .or_insert_with(|| compute_dominator_tree(ctx, &region))
     }
 
-    /// Does `a` dominate `b`? Caches region dominator trees as a side effect.
+    /// Does `a` strictly dominate `b`?
     ///
-    /// Following MLIR-style scoping, assumes that `b` is nested inside `a`'s parent region.
-    pub fn dominates(&mut self, ctx: &Context, a: Ptr<Operation>, b: Ptr<Operation>) -> bool {
+    /// Caches region dominator trees as a side effect. This is an MLIR-specific notion of
+    /// dominance. Operations in graph regions dominate themselves, so it is only "strict" for SSA regions.
+    pub fn strictly_dominates(&mut self, ctx: &Context, a: Ptr<Operation>, b: Ptr<Operation>) -> bool {
         let Some(block_a) = a.deref(ctx).get_parent_block() else {
             return false;
         };
@@ -621,59 +617,21 @@ mod tests {
     /// A test-only terminator operation for setting up CFG edges.
     #[pliron_op(
         name = "test.branch",
+        format = "",
         interfaces = [IsTerminatorInterface],
         verifier = "succ",
     )]
     struct BranchOp;
-    impl crate::printable::Printable for BranchOp {
-        fn fmt(
-            &self,
-            _ctx: &Context,
-            _state: &crate::printable::State,
-            f: &mut core::fmt::Formatter<'_>,
-        ) -> core::fmt::Result {
-            write!(f, "test.branch")
-        }
-    }
-    impl crate::parsable::Parsable for BranchOp {
-        type Arg = Vec<(crate::identifier::Identifier, crate::location::Location)>;
-        type Parsed = crate::op::OpObj;
-        fn parse<'a>(
-            _state_stream: &mut crate::parsable::StateStream<'a>,
-            _results: Self::Arg,
-        ) -> crate::parsable::ParseResult<'a, Self::Parsed> {
-            unimplemented!("TestTerminatorOp parsing not needed for tests")
-        }
-    }
 
     /// A test-only operation with one region that is NOT IsolatedFromAbove.
     /// Represents something like a loop or scope construct.
     #[pliron_op(
         name = "test.scope",
+        format = "`{` region($0) `}`",
         interfaces = [NRegionsInterface<1>, OneRegionInterface],
         verifier = "succ",
     )]
     struct ScopeOp;
-    impl crate::printable::Printable for ScopeOp {
-        fn fmt(
-            &self,
-            _ctx: &Context,
-            _state: &crate::printable::State,
-            f: &mut core::fmt::Formatter<'_>,
-        ) -> core::fmt::Result {
-            write!(f, "test.scope")
-        }
-    }
-    impl crate::parsable::Parsable for ScopeOp {
-        type Arg = Vec<(crate::identifier::Identifier, crate::location::Location)>;
-        type Parsed = crate::op::OpObj;
-        fn parse<'a>(
-            _state_stream: &mut crate::parsable::StateStream<'a>,
-            _results: Self::Arg,
-        ) -> crate::parsable::ParseResult<'a, Self::Parsed> {
-            unimplemented!("ScopeOp parsing not needed for tests")
-        }
-    }
     impl ScopeOp {
         fn new(ctx: &mut Context) -> ScopeOp {
             let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 1);
@@ -722,9 +680,9 @@ mod tests {
 
         let mut dom_info = super::DomInfo::default();
 
-        assert!(dom_info.dominates(ctx, op_a, op_b));
-        assert!(!dom_info.dominates(ctx, op_b, op_a));
-        assert!(!dom_info.dominates(ctx, op_a, op_a));
+        assert!(dom_info.strictly_dominates(ctx, op_a, op_b));
+        assert!(!dom_info.strictly_dominates(ctx, op_b, op_a));
+        assert!(!dom_info.strictly_dominates(ctx, op_a, op_a));
     }
 
     #[test]
@@ -744,8 +702,8 @@ mod tests {
         let op_a = func_a.get_operation();
         let op_b = func_b.get_operation();
 
-        assert!(dom_info.dominates(ctx, op_a, op_b));
-        assert!(dom_info.dominates(ctx, op_b, op_a));
+        assert!(dom_info.strictly_dominates(ctx, op_a, op_b));
+        assert!(dom_info.strictly_dominates(ctx, op_b, op_a));
     }
 
     #[test]
@@ -774,7 +732,7 @@ mod tests {
 
         let mut dom_info = super::DomInfo::default();
 
-        assert!(!dom_info.dominates(ctx, func.get_operation(), inner_op));
+        assert!(!dom_info.strictly_dominates(ctx, func.get_operation(), inner_op));
     }
 
     #[test]
@@ -799,7 +757,22 @@ mod tests {
 
         let mut dom_info = super::DomInfo::default();
 
-        assert!(dom_info.dominates(ctx, func.get_operation(), inner_op));
+        assert!(dom_info.strictly_dominates(ctx, func.get_operation(), inner_op));
+    }
+
+    #[test]
+    fn graph_op_dominates_self() {
+        let ctx = &mut Context::new();
+        let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+        let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+        let module = ModuleOp::new(ctx, "test_mod".try_into().unwrap());
+
+        let func = FuncOp::new(ctx, "f".try_into().unwrap(), func_ty);
+        module.append_operation(ctx, func.get_operation(), 0);
+
+        let mut dom_info = super::DomInfo::default();
+
+        assert!(dom_info.strictly_dominates(ctx, func.get_operation(), func.get_operation()));
     }
 
     #[test]
@@ -838,8 +811,8 @@ mod tests {
 
         let mut dom_info = super::DomInfo::default();
 
-        assert!(dom_info.dominates(ctx, op_a, scope.get_operation()));
-        assert!(dom_info.dominates(ctx, op_a, op_b));
+        assert!(dom_info.strictly_dominates(ctx, op_a, scope.get_operation()));
+        assert!(dom_info.strictly_dominates(ctx, op_a, op_b));
     }
 
     #[test]
@@ -906,8 +879,8 @@ mod tests {
 
         let mut dom_info = super::DomInfo::default();
 
-        assert!(dom_info.dominates(ctx, op_a, op_b));
-        assert!(dom_info.dominates(ctx, op_a, op_c));
-        assert!(!dom_info.dominates(ctx, op_b, op_c));
+        assert!(dom_info.strictly_dominates(ctx, op_a, op_b));
+        assert!(dom_info.strictly_dominates(ctx, op_a, op_c));
+        assert!(!dom_info.strictly_dominates(ctx, op_b, op_c));
     }
 }

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -212,8 +212,8 @@ where
     }
 }
 
-/// Returns the ancestor operation of `op` contained in `region`, or returns `None` if
-/// no ancestor of `op` is in `region`.
+/// Returns the ancestor operation of `op` contained in `target_region`, or returns `None` if
+/// no ancestor of `op` is in `target_region`.
 fn find_ancestor_in_region(
     ctx: &Context,
     op: Ptr<Operation>,

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -273,8 +273,16 @@ impl DomInfo {
 
     /// Does `a` strictly dominate `b`?
     ///
-    /// Caches region dominator trees as a side effect. This is an MLIR-specific notion of
-    /// dominance. Operations in graph regions dominate themselves, so it is only "strict" for SSA regions.
+    /// Caches region dominator trees as a side effect.
+    ///
+    /// Defining `OpB_` as an operation immediately in `OpA`'s region, and either
+    /// 1. contains `OpB` in its (possibly nested) regions, OR
+    /// 2. is the same as `OpB`.
+    ///
+    /// This function returns true when
+    /// 1. `OpA` and `OpB_` are in the same basic block of an SSA region and `OpA` strictly precedes `OpB_`, OR
+    /// 2. `OpA` strictly dominates (in the traditional definition of dominance, for single-region CFGs) `OpB_`, OR
+    /// 3. `OpA` and `OpB_` are in a graph region's sole basic block.
     pub fn strictly_dominates(
         &mut self,
         ctx: &Context,


### PR DESCRIPTION
This PR contains two basic changes:

1. I implemented an operation-to-operation dominance check. It reports that `a` does not dominate `b` whenever `b` is not contained in `a`'s region: this should be fine, since values cannot be used outside of their definition's regions.

2. Gave the `builtin.module` the Graph RegionKind. I used this for testing operation dominance. Previously, the comment mentioned that `builtin.module` used SSA dominance, but I wonder if this was only because RegionKindInterface hadn't been added yet. 