### PR TITLE
Rehaul `Value` and `Use` tracking with global UID and consequent utilities

### DIFF
--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -85,8 +85,8 @@ fn one_result_zero_operands() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.one_result_zero_operands : builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -129,8 +129,8 @@ fn one_result_zero_operands_canonical() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.one_result_zero_operands_canonical () [] []: <() -> (builtin.integer si64)> !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.one_result_zero_operands_canonical () [] []: <() -> (builtin.integer si64)> !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -174,9 +174,9 @@ fn one_result_one_operand() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.one_result_zero_operands : builtin.integer si64 !1;
-            res1_op3v1_res0 = test.one_result_one_operand res0_op2v1_res0:builtin.integer si64 !2;
-            test.return res1_op3v1_res0 !3
+            res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
+            res1_v1 = test.one_result_one_operand res0_v0:builtin.integer si64 !2;
+            test.return res1_v1 !3
         } !4
 
         outlined_attributes:
@@ -220,9 +220,9 @@ fn two_result_two_operands() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.one_result_zero_operands : builtin.integer si64 !1;
-            res1a_op3v1_res0, res1b_op3v1_res1 = test.two_results_two_operands res0_op2v1_res0,res0_op2v1_res0:(builtin.integer si64,builtin.integer si64) !2;
-            test.return res1a_op3v1_res0 !3
+            res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
+            res1a_v1, res1b_v2 = test.two_results_two_operands res0_v0,res0_v0:(builtin.integer si64,builtin.integer si64) !2;
+            test.return res1a_v1 !3
         } !4
 
         outlined_attributes:
@@ -266,9 +266,9 @@ fn two_results_one_operand() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.one_result_zero_operands : builtin.integer si64 !1;
-            res1a_op3v1_res0, res1b_op3v1_res1 = test.two_results_one_operand res0_op2v1_res0: (builtin.integer si64, builtin.integer si64) !2;
-            test.return res1a_op3v1_res0 !3
+            res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
+            res1a_v1, res1b_v2 = test.two_results_one_operand res0_v0: (builtin.integer si64, builtin.integer si64) !2;
+            test.return res1a_v1 !3
         } !4
 
         outlined_attributes:
@@ -313,8 +313,8 @@ fn attr_op() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -359,8 +359,8 @@ fn attr_op2() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op2 "Hello World" :builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.attr_op2 "Hello World" :builtin.integer si64 !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -392,8 +392,8 @@ fn attr_op2() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block2v1() !0:
-            res0_op5v1_res0 = test.attr_op2 "Hello World" <42: si64>:builtin.integer si64 !1;
-            test.return res0_op5v1_res0 !2
+            res0_v1 = test.attr_op2 "Hello World" <42: si64>:builtin.integer si64 !1;
+            test.return res0_v1 !2
         } !3
 
         outlined_attributes:
@@ -438,8 +438,8 @@ fn attr_op2_labeled() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op2_labeled name : "Hello World" :builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.attr_op2_labeled name : "Hello World" :builtin.integer si64 !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -471,8 +471,8 @@ fn attr_op2_labeled() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block2v1() !0:
-            res0_op5v1_res0 = test.attr_op2_labeled name : "Hello World" value : <42: si64>:builtin.integer si64 !1;
-            test.return res0_op5v1_res0 !2
+            res0_v1 = test.attr_op2_labeled name : "Hello World" value : <42: si64>:builtin.integer si64 !1;
+            test.return res0_v1 !2
         } !3
 
         outlined_attributes:
@@ -517,8 +517,8 @@ fn attr_op2_labeled_delimited() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op2_labeled_delimited <name : "Hello World"> :builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.attr_op2_labeled_delimited <name : "Hello World"> :builtin.integer si64 !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -550,8 +550,8 @@ fn attr_op2_labeled_delimited() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block2v1() !0:
-            res0_op5v1_res0 = test.attr_op2_labeled_delimited <name : "Hello World"> <<value : <42: si64>>>:builtin.integer si64 !1;
-            test.return res0_op5v1_res0 !2
+            res0_v1 = test.attr_op2_labeled_delimited <name : "Hello World"> <<value : <42: si64>>>:builtin.integer si64 !1;
+            test.return res0_v1 !2
         } !3
 
         outlined_attributes:
@@ -596,8 +596,8 @@ fn attr_op2_delimited() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op2_delimited <"Hello World"> :builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.attr_op2_delimited <"Hello World"> :builtin.integer si64 !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -629,8 +629,8 @@ fn attr_op2_delimited() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block2v1() !0:
-            res0_op5v1_res0 = test.attr_op2_delimited <"Hello World"> [[<42: si64>]]:builtin.integer si64 !1;
-            test.return res0_op5v1_res0 !2
+            res0_v1 = test.attr_op2_delimited <"Hello World"> [[<42: si64>]]:builtin.integer si64 !1;
+            test.return res0_v1 !2
         } !3
 
         outlined_attributes:
@@ -672,8 +672,8 @@ fn attr_op3() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op3 builtin.integer <0: si64>:builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.attr_op3 builtin.integer <0: si64>:builtin.integer si64 !1;
+            test.return res0_v0 !2
         } !3
 
         outlined_attributes:
@@ -721,14 +721,14 @@ fn if_op() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block2v1() !0:
-            res0_op2v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !1;
-            test.if_op (res0_op2v1_res0)
+            res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
+            test.if_op (res0_v0)
             {
               ^then_block1v1() !2:
-                res1_op4v1_res0 = test.attr_op <1: si64>:builtin.integer si64 !3;
-                test.return res1_op4v1_res0 !4
+                res1_v1 = test.attr_op <1: si64>:builtin.integer si64 !3;
+                test.return res1_v1 !4
             } !5;
-            test.return res0_op2v1_res0 !6
+            test.return res0_v0 !6
         } !7
 
         outlined_attributes:
@@ -784,19 +784,19 @@ fn if_else_op() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block3v1() !0:
-            res0_op2v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !1;
-            test.if_else_op (res0_op2v1_res0)
+            res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
+            test.if_else_op (res0_v0)
             {
               ^then_block1v1() !2:
-                res1_op4v1_res0 = test.attr_op <1: si64>:builtin.integer si64 !3;
-                test.return res1_op4v1_res0 !4
+                res1_v1 = test.attr_op <1: si64>:builtin.integer si64 !3;
+                test.return res1_v1 !4
             }else
             {
               ^else_block2v1() !5:
-                res2_op6v1_res0 = test.attr_op <2: si64>:builtin.integer si64 !6;
-                test.return res2_op6v1_res0 !7
+                res2_v2 = test.attr_op <2: si64>:builtin.integer si64 !6;
+                test.return res2_v2 !7
             } !8;
-            test.return res0_op2v1_res0 !9
+            test.return res0_v0 !9
         } !10
 
         outlined_attributes:
@@ -848,11 +848,11 @@ fn br_op() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block2v1() !0:
-            res0_op2v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !1;
-            test.br ^bb1_block3v1(res0_op2v1_res0) !2
+            res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
+            test.br ^bb1_block3v1(res0_v0) !2
 
-          ^bb1_block3v1(arg0_block3v1_arg0: builtin.integer si64) !3:
-            test.return arg0_block3v1_arg0 !4
+          ^bb1_block3v1(arg0_v2: builtin.integer si64) !3:
+            test.return arg0_v2 !4
         } !5
 
         outlined_attributes:
@@ -901,14 +901,14 @@ fn multiple_successors_op() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block3v1() !0:
-            res0_op2v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !1;
+            res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
             test.multiple_successors [^bb1_block4v1, ^bb2_block1v3] !2
 
           ^bb1_block4v1() !3:
-            test.return res0_op2v1_res0 !4
+            test.return res0_v0 !4
 
           ^bb2_block1v3() !5:
-            test.return res0_op2v1_res0 !6
+            test.return res0_v0 !6
         } !7
 
         outlined_attributes:
@@ -966,19 +966,19 @@ fn multiple_regions_op() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block3v1() !0:
-            res_op2v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !1;
+            res_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
             test.multiple_regions [
             {
               ^reg1_entry_block1v1() !2:
-                res0_op4v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !3;
-                test.return res0_op4v1_res0 !4
+                res0_v1 = test.attr_op <0: si64>:builtin.integer si64 !3;
+                test.return res0_v1 !4
             }, 
             {
               ^reg2_entry_block2v1() !5:
-                res1_op6v1_res0 = test.attr_op <1: si64>:builtin.integer si64 !6;
-                test.return res1_op6v1_res0 !7
+                res1_v2 = test.attr_op <1: si64>:builtin.integer si64 !6;
+                test.return res1_v2 !7
             }] !8;
-            test.return res_op2v1_res0 !9
+            test.return res_v0 !9
         } !10
 
         outlined_attributes:
@@ -1031,9 +1031,9 @@ fn attr_dict_op() {
         builtin.func @testfunc: builtin.function <()->()> 
         {
           ^entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op <3: si64>:builtin.integer si64 !1;
+            res0_v0 = test.attr_op <3: si64>:builtin.integer si64 !1;
             test.attr_dict [attr1: builtin.integer <0: si64>, attr2: builtin.integer <1: si64>] !2;
-            test.return res0_op2v1_res0 !3
+            test.return res0_v0 !3
         } !4
 
         outlined_attributes:
@@ -1158,13 +1158,13 @@ fn multiple_regions4_op() {
         test.multiple_regions4 [
         {
           ^reg1_entry_block1v1() !0:
-            res0_op2v1_res0 = test.attr_op <0: si64>:builtin.integer si64 !1;
-            test.return res0_op2v1_res0 !2
+            res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
+            test.return res0_v0 !2
         }, 
         {
           ^reg2_entry_block2v1() !3:
-            res1_op4v1_res0 = test.attr_op <1: si64>:builtin.integer si64 !4;
-            test.return res1_op4v1_res0 !5
+            res1_v1 = test.attr_op <1: si64>:builtin.integer si64 !4;
+            test.return res1_v1 !5
         }] !6
 
         outlined_attributes:

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -378,7 +378,7 @@ pub enum ConversionErr {
 
 /// If a value is a ConstantOp with integer type, return the value.
 fn get_const_op_as_int(ctx: &Context, val: Value) -> Option<IntegerAttr> {
-    let Value::OpResult { op, res_idx: _ } = val else {
+    let Value::OpResult { op, val_uid: _ } = val else {
         return None;
     };
     Operation::get_op::<ConstantOp>(op, ctx).and_then(|const_op| {
@@ -1305,7 +1305,7 @@ fn convert_block(
     for inst in instruction_iter(block) {
         if llvm_get_instruction_opcode(inst) == LLVMOpcode::LLVMPHI {
             let ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
-            let arg_idx = m_block.deref_mut(ctx).add_argument(ty);
+            let arg_idx = BasicBlock::add_argument(m_block, ctx, ty);
             cctx.value_map
                 .insert(inst, m_block.deref(ctx).get_argument(arg_idx));
         } else {
@@ -1316,7 +1316,7 @@ fn convert_block(
             if let Some(result) = m_inst_result {
                 if let Some(res_name) = llvm_get_value_name(inst).filter(|name| !name.is_empty()) {
                     let res_name = cctx.id_legaliser.legalise(&res_name);
-                    debug_info::set_operation_result_name(ctx, m_inst, 0, res_name);
+                    debug_info::set_operation_result_name(ctx, m_inst, 0, Some(res_name));
                 }
                 cctx.value_map.insert(inst, result);
             }

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -1305,7 +1305,7 @@ fn convert_block(
     for inst in instruction_iter(block) {
         if llvm_get_instruction_opcode(inst) == LLVMOpcode::LLVMPHI {
             let ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
-            let arg_idx = BasicBlock::add_argument(m_block, ctx, ty);
+            let arg_idx = BasicBlock::push_argument(m_block, ctx, ty);
             cctx.value_map
                 .insert(inst, m_block.deref(ctx).get_argument(arg_idx));
         } else {

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -33,7 +33,7 @@ use pliron::{
     result::Result,
     r#type::{Type, TypeObj, TypePtr, type_cast},
     utils::apint::APInt,
-    value::Value,
+    value::{DefEntity, Value},
 };
 use rustc_hash::{FxHashMap, FxHashSet};
 use thiserror::Error;
@@ -378,7 +378,7 @@ pub enum ConversionErr {
 
 /// If a value is a ConstantOp with integer type, return the value.
 fn get_const_op_as_int(ctx: &Context, val: Value) -> Option<IntegerAttr> {
-    let Value::OpResult { op, val_uid: _ } = val else {
+    let DefEntity::OpResult(op) = val.def_entity() else {
         return None;
     };
     Operation::get_op::<ConstantOp>(op, ctx).and_then(|const_op| {

--- a/pliron-llvm/src/function_call_utils.rs
+++ b/pliron-llvm/src/function_call_utils.rs
@@ -242,8 +242,8 @@ mod tests {
 
             define i64 @main() {
             entry_block2v1:
-              %op8v1_res0 = call ptr @malloc(i64 ptrtoint (ptr getelementptr (double, ptr null, i32 1) to i64))
-              call void @free(ptr %op8v1_res0)
+              %v3 = call ptr @malloc(i64 ptrtoint (ptr getelementptr (double, ptr null, i32 1) to i64))
+              call void @free(ptr %v3)
               ret i64 ptrtoint (ptr getelementptr (double, ptr null, i32 1) to i64)
             }
 

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -31,7 +31,7 @@ use pliron::{
     result::Result,
     r#type::{Type, TypeObj, Typed, type_cast},
     utils::apint::APInt,
-    value::Value,
+    value::{DefEntity, Value},
 };
 
 use pliron::derive::{op_interface, op_interface_impl, type_interface, type_interface_impl};
@@ -1907,8 +1907,8 @@ fn convert_to_llvm_const(
     llvm_ctx: &LLVMContext,
     value: Value,
 ) -> Result<LLVMValue> {
-    match value {
-        Value::OpResult { op, val_uid: _ } => {
+    match value.def_entity() {
+        DefEntity::OpResult(op) => {
             let op = Operation::get_op_dyn(op, ctx);
             if let Some(const_trans) = op_cast::<dyn ToLLVMConstValue>(op.as_ref()) {
                 const_trans.convert(ctx, llvm_ctx, cctx)
@@ -1916,7 +1916,7 @@ fn convert_to_llvm_const(
                 input_err!(value.loc(ctx), ToLLVMErr::CannotEvaluateToConst)
             }
         }
-        Value::BlockArgument { .. } => {
+        DefEntity::BlockArgument(_) => {
             input_err!(value.loc(ctx), ToLLVMErr::CannotEvaluateToConst)
         }
     }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -1908,7 +1908,7 @@ fn convert_to_llvm_const(
     value: Value,
 ) -> Result<LLVMValue> {
     match value {
-        Value::OpResult { op, res_idx: _ } => {
+        Value::OpResult { op, val_uid: _ } => {
             let op = Operation::get_op_dyn(op, ctx);
             if let Some(const_trans) = op_cast::<dyn ToLLVMConstValue>(op.as_ref()) {
                 const_trans.convert(ctx, llvm_ctx, cctx)

--- a/src/analyses/liveness.rs
+++ b/src/analyses/liveness.rs
@@ -20,7 +20,7 @@ use crate::{
     irbuild::inserter::OpInsertionPoint,
     linked_list::{ContainsLinkedList, LinkedList},
     region::Region,
-    value::Value,
+    value::{DefEntity, Value},
 };
 
 type BitSet = hi_sparse_bitset::BitSet<hi_sparse_bitset::config::_128bit>;
@@ -287,7 +287,7 @@ impl LivenessTq {
     fn use_blocks_in_region(&self, ctx: &Context, value: Value) -> Option<BitSet> {
         let mut use_blocks = BitSet::default();
         for r#use in value.uses(ctx) {
-            let Some(user_block) = r#use.user_op.deref(ctx).get_parent_block() else {
+            let Some(user_block) = r#use.user_op().deref(ctx).get_parent_block() else {
                 // We don't know where the user op is, hence unanalysable
                 return None;
             };
@@ -493,7 +493,7 @@ impl<T: RegionLiveness> Liveness<T> {
         value
             .uses(ctx)
             .iter()
-            .any(|r#use| find_ancestor_op_of_op_in_region(ctx, r#use.user_op, region).is_some())
+            .any(|r#use| find_ancestor_op_of_op_in_region(ctx, r#use.user_op(), region).is_some())
     }
 
     /// Are there any uses of `value` in the same block after `point`?
@@ -506,7 +506,7 @@ impl<T: RegionLiveness> Liveness<T> {
         let user_ops_in_point_block: FxHashSet<_> = value
             .uses(ctx)
             .iter()
-            .filter_map(|r#use| find_ancestor_op_of_op_in_block(ctx, r#use.user_op, point_block))
+            .filter_map(|r#use| find_ancestor_op_of_op_in_block(ctx, r#use.user_op(), point_block))
             .collect();
 
         let op_iter = match point {
@@ -628,9 +628,7 @@ impl<T: RegionLiveness> Liveness<T> {
                 // dominates the next operation (i.e., OpInsertionPoint::AfterOperation(op)).
                 // Without this extra check, `value_strictly_dominates_op` would return false
                 // and we would end up incorrectly reporting that the value is not live after.
-                if let Value::OpResult {
-                    op: value_def_op, ..
-                } = value
+                if let DefEntity::OpResult(value_def_op) = value.def_entity()
                     && value_def_op != op
                     && !self.dom_info.value_strictly_dominates_op(ctx, value, op)
                 {

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -176,7 +176,7 @@ impl BasicBlock {
         self.args.iter().map(|arg| arg.as_value(self.self_ptr))
     }
 
-    /// Add an argument to the end of the argument list. returing its index.
+    /// Add an argument to the end of the argument list, returning its index.
     pub fn push_argument(block: Ptr<BasicBlock>, ctx: &Context, ty: Ptr<TypeObj>) -> usize {
         let new_block_arg = BlockArgument::new(ctx, ty);
         block.deref_mut(ctx).args.push_back(new_block_arg)
@@ -185,8 +185,9 @@ impl BasicBlock {
     /// Remove the last argument. Panics if there are no arguments or if the argument has uses.
     /// Any [Value] referring to the removed argument is invalidated.
     pub fn pop_argument(block: Ptr<BasicBlock>, ctx: &Context) {
-        let arg_idx = block.deref(ctx).args.len() - 1;
-        Self::remove_argument(block, ctx, arg_idx);
+        let len = block.deref(ctx).args.len();
+        assert!(len > 0, "Can't pop argument from block with no arguments");
+        Self::remove_argument(block, ctx, len - 1);
     }
 
     /// Insert a new argument at `arg_idx`, shifting existing arguments, from `arg_idx`, to the right.

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -12,13 +12,13 @@ use crate::{
     builtin::op_interfaces::{IsTerminatorInterface, NoTerminatorInterface},
     common_traits::{Named, RcShare, Verify},
     context::{Arena, Context, Ptr, private::ArenaObj},
-    debug_info::{get_block_arg_name, set_block_arg_name},
+    debug_info::set_block_arg_name,
     identifier::Identifier,
     indented_block,
     irfmt::{
         outlined::{preprint_outline_block, register_block_for_outline},
         parsers::{delimited_list_parser, location, spaced, type_parser},
-        printers::{iter_with_sep, list_with_sep},
+        printers::iter_with_sep,
     },
     linked_list::{ContainsLinkedList, LinkedList, private},
     location::{Located, Location},
@@ -38,10 +38,8 @@ use crate::{
 pub(crate) struct BlockArgument {
     /// The def containing the list of this argument's uses.
     pub(crate) def: DefNode<Value>,
-    /// A [Ptr] to the [BasicBlock] of which this is an argument.
-    pub(crate) def_block: Ptr<BasicBlock>,
-    /// Index of this argument in the block's list of arguments.
-    pub(crate) arg_idx: usize,
+    /// Unique ID of this value in [Context].
+    pub(crate) val_uid: u64,
     /// The [Type](crate::type::Type) of this argument.
     pub(crate) ty: Ptr<TypeObj>,
 }
@@ -56,48 +54,19 @@ impl BlockArgument {
     pub fn set_type(&mut self, _ctx: &Context, ty: Ptr<TypeObj>) {
         self.ty = ty;
     }
+
+    /// Build a [Value] corresponding to this argument.
+    pub fn as_value(&self, block: Ptr<BasicBlock>) -> Value {
+        Value::BlockArgument {
+            block,
+            val_uid: self.val_uid,
+        }
+    }
 }
 
 impl Typed for BlockArgument {
     fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
         self.get_type(ctx)
-    }
-}
-
-impl Named for BlockArgument {
-    fn given_name(&self, ctx: &Context) -> Option<Identifier> {
-        get_block_arg_name(ctx, self.def_block, self.arg_idx)
-    }
-    fn id(&self, ctx: &Context) -> Identifier {
-        format!("{}_arg{}", self.def_block.deref(ctx).id(ctx), self.arg_idx)
-            .try_into()
-            .unwrap()
-    }
-}
-
-impl From<&BlockArgument> for Value {
-    fn from(value: &BlockArgument) -> Self {
-        Value::BlockArgument {
-            block: value.def_block,
-            arg_idx: value.arg_idx,
-        }
-    }
-}
-
-impl Printable for BlockArgument {
-    fn fmt(
-        &self,
-        ctx: &Context,
-        _state: &printable::State,
-        f: &mut core::fmt::Formatter<'_>,
-    ) -> core::fmt::Result {
-        write!(f, "{}: {}", self.unique_name(ctx), self.ty.disp(ctx))
-    }
-}
-
-impl Verify for BlockArgument {
-    fn verify(&self, ctx: &Context) -> Result<()> {
-        Into::<Value>::into(self).verify(ctx)
     }
 }
 
@@ -164,11 +133,9 @@ impl BasicBlock {
         // Let's update the args of the new block. Easier to do it here than during creation.
         let args = arg_types
             .into_iter()
-            .enumerate()
-            .map(|(arg_idx, ty)| BlockArgument {
+            .map(|ty| BlockArgument {
                 def: DefNode::new(),
-                def_block: newblock,
-                arg_idx,
+                val_uid: ctx.get_new_value_uid(),
                 ty,
             })
             .collect();
@@ -198,37 +165,23 @@ impl BasicBlock {
     pub fn get_argument(&self, arg_idx: usize) -> Value {
         self.args
             .get(arg_idx)
-            .map(|arg| arg.into())
+            .map(|arg| arg.as_value(self.self_ptr))
             .unwrap_or_else(|| panic!("Block argument index {arg_idx} out of bounds"))
     }
 
     /// Get an iterator over the arguments
     pub fn arguments(&self) -> impl Iterator<Item = Value> + '_ {
-        self.args.iter().map(Into::into)
+        self.args.iter().map(|arg| arg.as_value(self.self_ptr))
     }
 
     /// Add a new argument with specified type. Returns idx at which it was added.
-    pub fn add_argument(&mut self, ty: Ptr<TypeObj>) -> usize {
-        self.args.push_back_with(|arg_idx| BlockArgument {
+    pub fn add_argument(block: Ptr<BasicBlock>, ctx: &mut Context, ty: Ptr<TypeObj>) -> usize {
+        let val_uid = ctx.get_new_value_uid();
+        block.deref_mut(ctx).args.push_back(BlockArgument {
             def: DefNode::new(),
-            def_block: self.self_ptr,
-            arg_idx,
+            val_uid,
             ty,
         })
-    }
-
-    /// Get a reference to the idx'th argument.
-    pub(crate) fn get_argument_ref(&self, arg_idx: usize) -> &BlockArgument {
-        self.args
-            .get(arg_idx)
-            .unwrap_or_else(|| panic!("Block argument index {arg_idx} out of bounds"))
-    }
-
-    /// Get a mutable reference to the idx'th argument.
-    pub(crate) fn get_argument_mut(&mut self, arg_idx: usize) -> &mut BlockArgument {
-        self.args
-            .get_mut(arg_idx)
-            .unwrap_or_else(|| panic!("Block argument index {arg_idx} out of bounds"))
     }
 
     /// Get the number of arguments.
@@ -388,7 +341,9 @@ impl Verify for BasicBlock {
                 verify_err!(self.loc(), DefUseVerifyErr::OperandNotUseOfDef)?;
             }
         }
-        self.args.iter().try_for_each(|arg| arg.verify(ctx))?;
+        self.args
+            .iter()
+            .try_for_each(|arg| arg.as_value(self.self_ptr).verify(ctx))?;
         self.iter(ctx).try_for_each(|op| op.deref(ctx).verify(ctx))
     }
 }
@@ -416,7 +371,17 @@ impl Printable for BasicBlock {
             f,
             "^{}({})",
             self.unique_name(ctx),
-            list_with_sep(&self.args, ListSeparator::CharSpace(',')).print(ctx, state),
+            iter_with_sep(
+                self.args.iter().map(|arg| {
+                    format!(
+                        "{}: {}",
+                        arg.as_value(self.self_ptr).disp(ctx),
+                        arg.get_type(ctx).disp(ctx)
+                    )
+                }),
+                ListSeparator::CharSpace(',')
+            )
+            .print(ctx, state),
         )?;
 
         // Print non-outlined attributes inline.
@@ -509,13 +474,13 @@ impl Parsable for BasicBlock {
         }
 
         for (arg_idx, (arg_loc, name)) in arg_names.into_iter().enumerate() {
-            let def: Value = (&block.deref(state_stream.state.ctx).args[arg_idx]).into();
+            let def: Value = block.deref(state_stream.state.ctx).args[arg_idx].as_value(block);
             state_stream.state.name_tracker.ssa_def(
                 state_stream.state.ctx,
                 &(name.clone(), arg_loc),
                 def,
             )?;
-            set_block_arg_name(state_stream.state.ctx, block, arg_idx, name);
+            set_block_arg_name(state_stream.state.ctx, block, arg_idx, Some(name));
         }
 
         // Register in outline parse state if !N was found.

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -30,7 +30,7 @@ use crate::{
     result::Result,
     r#type::{TypeObj, Typed},
     utils::vec_exns::VecExtns,
-    value::{DefNode, Value},
+    value::{DefEntity, DefNode, Value},
     verify_err, verify_error,
 };
 
@@ -66,8 +66,8 @@ impl BlockArgument {
 
     /// Build a [Value] corresponding to this argument.
     pub(crate) fn as_value(&self, block: Ptr<BasicBlock>) -> Value {
-        Value::BlockArgument {
-            block,
+        Value {
+            def_entity: DefEntity::BlockArgument(block),
             val_uid: self.val_uid,
         }
     }
@@ -97,7 +97,7 @@ struct RegionLinks {
     prev_block: Option<Ptr<BasicBlock>>,
 }
 
-/// A basic block contains a list of [Operation]s. It may have [arguments](Value::BlockArgument).
+/// A basic block contains a list of [Operation]s. It may have arguments.
 pub struct BasicBlock {
     pub(crate) self_ptr: Ptr<BasicBlock>,
     pub(crate) label: Option<Identifier>,

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -46,7 +46,7 @@ pub(crate) struct BlockArgument {
 
 impl BlockArgument {
     /// Create a new block argument with the given type and a fresh value UID.
-    pub(crate) fn new(ctx: &mut Context, ty: Ptr<TypeObj>) -> Self {
+    pub(crate) fn new(ctx: &Context, ty: Ptr<TypeObj>) -> Self {
         Self {
             def: DefNode::new(),
             val_uid: ctx.get_new_value_uid(),
@@ -166,12 +166,9 @@ impl BasicBlock {
             .and_then(|op| op.deref(ctx).get_parent_block())
     }
 
-    /// Get idx'th argument as a Value.
+    /// Get idx'th argument as a Value. Panics on invalid index.
     pub fn get_argument(&self, arg_idx: usize) -> Value {
-        self.args
-            .get(arg_idx)
-            .map(|arg| arg.as_value(self.self_ptr))
-            .unwrap_or_else(|| panic!("Block argument index {arg_idx} out of bounds"))
+        self.args[arg_idx].as_value(self.self_ptr)
     }
 
     /// Get an iterator over the arguments
@@ -180,14 +177,14 @@ impl BasicBlock {
     }
 
     /// Add an argument to the end of the argument list. returing its index.
-    pub fn push_argument(block: Ptr<BasicBlock>, ctx: &mut Context, ty: Ptr<TypeObj>) -> usize {
+    pub fn push_argument(block: Ptr<BasicBlock>, ctx: &Context, ty: Ptr<TypeObj>) -> usize {
         let new_block_arg = BlockArgument::new(ctx, ty);
         block.deref_mut(ctx).args.push_back(new_block_arg)
     }
 
     /// Remove the last argument. Panics if there are no arguments or if the argument has uses.
     /// Any [Value] referring to the removed argument is invalidated.
-    pub fn pop_argument(block: Ptr<BasicBlock>, ctx: &mut Context) {
+    pub fn pop_argument(block: Ptr<BasicBlock>, ctx: &Context) {
         let arg_idx = block.deref(ctx).args.len() - 1;
         Self::remove_argument(block, ctx, arg_idx);
     }
@@ -196,7 +193,7 @@ impl BasicBlock {
     /// Panics on invalid index.
     pub fn insert_argument(
         block: Ptr<BasicBlock>,
-        ctx: &mut Context,
+        ctx: &Context,
         arg_idx: usize,
         ty: Ptr<TypeObj>,
     ) {
@@ -207,7 +204,7 @@ impl BasicBlock {
     /// Remove the argument at `arg_idx`, shifting subsequent arguments to the left.
     /// Panics on invalid index or if the argument has uses.
     /// Any [Value] referring to the removed argument is invalidated.
-    pub fn remove_argument(block: Ptr<BasicBlock>, ctx: &mut Context, arg_idx: usize) {
+    pub fn remove_argument(block: Ptr<BasicBlock>, ctx: &Context, arg_idx: usize) {
         let value = block.deref(ctx).get_argument(arg_idx);
         assert!(!value.is_used(ctx), "Can't remove argument with uses");
         block.deref_mut(ctx).args.remove(arg_idx);

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -12,7 +12,7 @@ use crate::{
     builtin::op_interfaces::{IsTerminatorInterface, NoTerminatorInterface},
     common_traits::{Named, RcShare, Verify},
     context::{Arena, Context, Ptr, private::ArenaObj},
-    debug_info::set_block_arg_name,
+    debug_info::{self, set_block_arg_name},
     identifier::Identifier,
     indented_block,
     irfmt::{
@@ -200,6 +200,7 @@ impl BasicBlock {
     ) {
         let new_block_arg = BlockArgument::new(ctx, ty);
         block.deref_mut(ctx).args.insert(arg_idx, new_block_arg);
+        debug_info::insert_block_arg_name(ctx, block, arg_idx, None);
     }
 
     /// Remove the argument at `arg_idx`, shifting subsequent arguments to the left.
@@ -208,6 +209,7 @@ impl BasicBlock {
     pub fn remove_argument(block: Ptr<BasicBlock>, ctx: &Context, arg_idx: usize) {
         let value = block.deref(ctx).get_argument(arg_idx);
         assert!(!value.is_used(ctx), "Can't remove argument with uses");
+        debug_info::remove_block_arg_name(ctx, block, arg_idx);
         block.deref_mut(ctx).args.remove(arg_idx);
     }
 

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -45,18 +45,27 @@ pub(crate) struct BlockArgument {
 }
 
 impl BlockArgument {
+    /// Create a new block argument with the given type and a fresh value UID.
+    pub(crate) fn new(ctx: &mut Context, ty: Ptr<TypeObj>) -> Self {
+        Self {
+            def: DefNode::new(),
+            val_uid: ctx.get_new_value_uid(),
+            ty,
+        }
+    }
+
     /// Get the [Type](crate::type::Type) of this argument.
-    pub fn get_type(&self, _ctx: &Context) -> Ptr<TypeObj> {
+    pub(crate) fn get_type(&self, _ctx: &Context) -> Ptr<TypeObj> {
         self.ty
     }
 
     /// Set the [Type](crate::type::Type) of this argument.
-    pub fn set_type(&mut self, _ctx: &Context, ty: Ptr<TypeObj>) {
+    pub(crate) fn set_type(&mut self, _ctx: &Context, ty: Ptr<TypeObj>) {
         self.ty = ty;
     }
 
     /// Build a [Value] corresponding to this argument.
-    pub fn as_value(&self, block: Ptr<BasicBlock>) -> Value {
+    pub(crate) fn as_value(&self, block: Ptr<BasicBlock>) -> Value {
         Value::BlockArgument {
             block,
             val_uid: self.val_uid,
@@ -133,11 +142,7 @@ impl BasicBlock {
         // Let's update the args of the new block. Easier to do it here than during creation.
         let args = arg_types
             .into_iter()
-            .map(|ty| BlockArgument {
-                def: DefNode::new(),
-                val_uid: ctx.get_new_value_uid(),
-                ty,
-            })
+            .map(|ty| BlockArgument::new(ctx, ty))
             .collect();
         newblock.deref_mut(ctx).args = args;
         // We're done.
@@ -174,14 +179,38 @@ impl BasicBlock {
         self.args.iter().map(|arg| arg.as_value(self.self_ptr))
     }
 
-    /// Add a new argument with specified type. Returns idx at which it was added.
-    pub fn add_argument(block: Ptr<BasicBlock>, ctx: &mut Context, ty: Ptr<TypeObj>) -> usize {
-        let val_uid = ctx.get_new_value_uid();
-        block.deref_mut(ctx).args.push_back(BlockArgument {
-            def: DefNode::new(),
-            val_uid,
-            ty,
-        })
+    /// Add an argument to the end of the argument list. returing its index.
+    pub fn push_argument(block: Ptr<BasicBlock>, ctx: &mut Context, ty: Ptr<TypeObj>) -> usize {
+        let new_block_arg = BlockArgument::new(ctx, ty);
+        block.deref_mut(ctx).args.push_back(new_block_arg)
+    }
+
+    /// Remove the last argument. Panics if there are no arguments or if the argument has uses.
+    /// Any [Value] referring to the removed argument is invalidated.
+    pub fn pop_argument(block: Ptr<BasicBlock>, ctx: &mut Context) {
+        let arg_idx = block.deref(ctx).args.len() - 1;
+        Self::remove_argument(block, ctx, arg_idx);
+    }
+
+    /// Insert a new argument at `arg_idx`, shifting existing arguments, from `arg_idx`, to the right.
+    /// Panics on invalid index.
+    pub fn insert_argument(
+        block: Ptr<BasicBlock>,
+        ctx: &mut Context,
+        arg_idx: usize,
+        ty: Ptr<TypeObj>,
+    ) {
+        let new_block_arg = BlockArgument::new(ctx, ty);
+        block.deref_mut(ctx).args.insert(arg_idx, new_block_arg);
+    }
+
+    /// Remove the argument at `arg_idx`, shifting subsequent arguments to the left.
+    /// Panics on invalid index or if the argument has uses.
+    /// Any [Value] referring to the removed argument is invalidated.
+    pub fn remove_argument(block: Ptr<BasicBlock>, ctx: &mut Context, arg_idx: usize) {
+        let value = block.deref(ctx).get_argument(arg_idx);
+        assert!(!value.is_used(ctx), "Can't remove argument with uses");
+        block.deref_mut(ctx).args.remove(arg_idx);
     }
 
     /// Get the number of arguments.

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,7 +19,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
 use std::{
     any::{Any, TypeId},
-    cell::{Ref, RefCell, RefMut},
+    cell::{Cell, Ref, RefCell, RefMut},
     fmt::{Debug, Display},
     hash::Hash,
     marker::PhantomData,
@@ -47,9 +47,12 @@ pub type Arena<T> = SlotMap<ArenaIndex, RefCell<T>>;
 
 /// A context stores all IR data of this compilation session.
 pub struct Context {
-    /// A unique number for each [Value] in the context.
-    /// Serves as a generation counter against accessing invalid [Value]s.
-    pub(crate) value_counter: u64,
+    /// A unique number for each `Value` in the context.
+    /// Serves as a generation counter against accessing invalid `Value`s.
+    pub(crate) value_counter: Cell<u64>,
+    /// A unique number for each `Use` in the context.
+    /// Serves as a generation counter against accessing invalid `Use`s.
+    pub(crate) use_counter: Cell<u64>,
     /// Allocation pool for [Operation]s.
     pub(crate) operations: Arena<Operation>,
     /// Allocation pool for [BasicBlock]s.
@@ -84,9 +87,16 @@ impl Context {
     }
 
     /// Get a unique number for a new value.
-    pub(crate) fn get_new_value_uid(&mut self) -> u64 {
-        let uid = self.value_counter;
-        self.value_counter += 1;
+    pub(crate) fn get_new_value_uid(&self) -> u64 {
+        let uid = self.value_counter.get();
+        self.value_counter.set(uid + 1);
+        uid
+    }
+
+    /// Get a unique number for a new use.
+    pub(crate) fn get_new_use_uid(&self) -> u64 {
+        let uid = self.use_counter.get();
+        self.use_counter.set(uid + 1);
         uid
     }
 }
@@ -94,7 +104,8 @@ impl Context {
 impl Default for Context {
     fn default() -> Self {
         let mut ctx = Context {
-            value_counter: 0,
+            value_counter: Cell::new(0),
+            use_counter: Cell::new(0),
             operations: Arena::default(),
             basic_blocks: Arena::default(),
             regions: Arena::default(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -47,6 +47,9 @@ pub type Arena<T> = SlotMap<ArenaIndex, RefCell<T>>;
 
 /// A context stores all IR data of this compilation session.
 pub struct Context {
+    /// A unique number for each [Value] in the context.
+    /// Serves as a generation counter against accessing invalid [Value]s.
+    pub(crate) value_counter: u64,
     /// Allocation pool for [Operation]s.
     pub(crate) operations: Arena<Operation>,
     /// Allocation pool for [BasicBlock]s.
@@ -79,11 +82,19 @@ impl Context {
     pub fn is_ir_empty(&self) -> bool {
         self.operations.is_empty() && self.basic_blocks.is_empty() && self.regions.is_empty()
     }
+
+    /// Get a unique number for a new value.
+    pub(crate) fn get_new_value_uid(&mut self) -> u64 {
+        let uid = self.value_counter;
+        self.value_counter += 1;
+        uid
+    }
 }
 
 impl Default for Context {
     fn default() -> Self {
         let mut ctx = Context {
+            value_counter: 0,
             operations: Arena::default(),
             basic_blocks: Arena::default(),
             regions: Arena::default(),

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -15,6 +15,7 @@ use crate::{
     operation::Operation,
     parsable::{Parsable, ParseResult, StateStream},
     printable::{self, Printable},
+    utils::vec_exns::VecExtns,
 };
 
 #[pliron_attr(name = "builtin.debug_info", verifier = "succ")]
@@ -31,17 +32,12 @@ impl DebugInfoAttr {
     }
 
     fn get_name(&self, idx: usize) -> Option<Identifier> {
-        self.names
-            .get(idx)
-            .expect("Index out of range for debug info attribute")
-            .clone()
+        self.names.get(idx).cloned().flatten()
     }
 
-    fn set_name(&mut self, idx: usize, name: Identifier) {
-        *self
-            .names
-            .get_mut(idx)
-            .expect("Index out of range for debug info attribute") = Some(name);
+    fn set_name(&mut self, idx: usize, name: Option<Identifier>) {
+        self.names.grow_to(idx + 1, |_| None);
+        *self.names.get_mut(idx).unwrap() = name;
     }
 }
 
@@ -96,7 +92,7 @@ fn set_name_from_attr_map(
     attributes: &mut AttributeDict,
     idx: usize,
     max_idx: usize,
-    name: Identifier,
+    name: Option<Identifier>,
 ) {
     match attributes.0.entry(ATTR_KEY_DEBUG_INFO.clone()) {
         Entry::Occupied(mut occupied) => {
@@ -126,7 +122,7 @@ pub fn set_operation_result_name(
     ctx: &Context,
     op: Ptr<Operation>,
     res_idx: usize,
-    name: Identifier,
+    name: Option<Identifier>,
 ) {
     let op = &mut *op.deref_mut(ctx);
     let num_results = op.get_num_results();
@@ -145,9 +141,14 @@ pub fn get_operation_result_name(
     get_name_from_attr_map(&op.attributes, res_idx)
 }
 
-/// Set the name for an argumet in a [BasicBlock].
+/// Set the name for an argument in a [BasicBlock].
 /// Panics if the given `arg_idx` is out of range.
-pub fn set_block_arg_name(ctx: &Context, block: Ptr<BasicBlock>, arg_idx: usize, name: Identifier) {
+pub fn set_block_arg_name(
+    ctx: &Context,
+    block: Ptr<BasicBlock>,
+    arg_idx: usize,
+    name: Option<Identifier>,
+) {
     let block = &mut *block.deref_mut(ctx);
     let num_args = block.get_num_arguments();
     assert!(arg_idx < num_args);
@@ -214,7 +215,7 @@ mod tests {
         let mut ctx = Context::new();
         let cop = ZeroOp::new(&mut ctx);
         let op = cop.get_operation();
-        set_operation_result_name(&ctx, op, 0, "foo".try_into().unwrap());
+        set_operation_result_name(&ctx, op, 0, Some("foo".try_into().unwrap()));
         assert_eq!(
             get_operation_result_name(&ctx, op, 0).unwrap(),
             "foo".try_into().unwrap()
@@ -232,7 +233,7 @@ mod tests {
             Some("entry".try_into().unwrap()),
             vec![i64_ty.into()],
         );
-        set_block_arg_name(&ctx, block, 0, "foo".try_into().unwrap());
+        set_block_arg_name(&ctx, block, 0, Some("foo".try_into().unwrap()));
         assert!(get_block_arg_name(&ctx, block, 0).unwrap() == "foo".try_into().unwrap());
         Ok(())
     }

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -19,18 +19,12 @@ use crate::{
 };
 
 #[pliron_attr(name = "builtin.debug_info", verifier = "succ")]
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 struct DebugInfoAttr {
     names: Vec<Option<Identifier>>,
 }
 
 impl DebugInfoAttr {
-    fn new(size: usize) -> Self {
-        Self {
-            names: vec![None; size],
-        }
-    }
-
     fn get_name(&self, idx: usize) -> Option<Identifier> {
         self.names.get(idx).cloned().flatten()
     }
@@ -38,6 +32,17 @@ impl DebugInfoAttr {
     fn set_name(&mut self, idx: usize, name: Option<Identifier>) {
         self.names.grow_to(idx + 1, |_| None);
         *self.names.get_mut(idx).unwrap() = name;
+    }
+
+    fn insert_name(&mut self, idx: usize, name: Option<Identifier>) {
+        self.names.grow_to(idx + 1, |_| None);
+        self.names.insert(idx, name);
+    }
+
+    fn remove_name(&mut self, idx: usize) {
+        if idx < self.names.len() {
+            self.names.remove(idx);
+        }
     }
 }
 
@@ -88,12 +93,7 @@ impl Parsable for DebugInfoAttr {
     }
 }
 
-fn set_name_from_attr_map(
-    attributes: &mut AttributeDict,
-    idx: usize,
-    max_idx: usize,
-    name: Option<Identifier>,
-) {
+fn set_name_in_attr_map(attributes: &mut AttributeDict, idx: usize, name: Option<Identifier>) {
     match attributes.0.entry(ATTR_KEY_DEBUG_INFO.clone()) {
         Entry::Occupied(mut occupied) => {
             let debug_info = occupied
@@ -103,9 +103,46 @@ fn set_name_from_attr_map(
             debug_info.set_name(idx, name);
         }
         Entry::Vacant(vacant) => {
-            let mut debug_info = DebugInfoAttr::new(max_idx);
-            debug_info.set_name(idx, name);
-            vacant.insert(debug_info.into());
+            // Only insert a new debug info attribute if there's actually a name to set.
+            if name.is_some() {
+                let mut debug_info = DebugInfoAttr::default();
+                debug_info.set_name(idx, name);
+                vacant.insert(debug_info.into());
+            }
+        }
+    }
+}
+
+fn insert_name_in_attr_map(attributes: &mut AttributeDict, idx: usize, name: Option<Identifier>) {
+    match attributes.0.entry(ATTR_KEY_DEBUG_INFO.clone()) {
+        Entry::Occupied(mut occupied) => {
+            let debug_info = occupied
+                .get_mut()
+                .downcast_mut::<DebugInfoAttr>()
+                .expect("Existing attribute entry for debug info incorrect");
+            debug_info.insert_name(idx, name);
+        }
+        Entry::Vacant(vacant) => {
+            // Only insert a new debug info attribute if there's actually a name to set.
+            if name.is_some() {
+                let mut debug_info = DebugInfoAttr::default();
+                debug_info.insert_name(idx, name);
+                vacant.insert(debug_info.into());
+            }
+        }
+    }
+}
+
+fn remove_name_from_attr_map(attributes: &mut AttributeDict, idx: usize) {
+    if let Entry::Occupied(mut occupied) = attributes.0.entry(ATTR_KEY_DEBUG_INFO.clone()) {
+        let debug_info = occupied
+            .get_mut()
+            .downcast_mut::<DebugInfoAttr>()
+            .expect("Existing attribute entry for debug info incorrect");
+        debug_info.remove_name(idx);
+        // If the debug info attribute has no more names, remove it from the map.
+        if debug_info.names.iter().all(|name| name.is_none()) {
+            occupied.remove();
         }
     }
 }
@@ -128,7 +165,34 @@ pub fn set_operation_result_name(
     let num_results = op.get_num_results();
     assert!(res_idx < num_results);
 
-    set_name_from_attr_map(&mut op.attributes, res_idx, num_results, name);
+    set_name_in_attr_map(&mut op.attributes, res_idx, name);
+}
+
+/// Insert a name for a result in an [Operation] at the given index,
+/// shifting existing names at that index and beyond to the right.
+/// Panics if the given `res_idx` is out of range (i.e., `res_idx > num_results`).
+pub fn insert_operation_result_name(
+    ctx: &Context,
+    op: Ptr<Operation>,
+    res_idx: usize,
+    name: Option<Identifier>,
+) {
+    let op = &mut *op.deref_mut(ctx);
+    let num_results = op.get_num_results();
+    assert!(res_idx <= num_results);
+
+    insert_name_in_attr_map(&mut op.attributes, res_idx, name);
+}
+
+/// Remove the name for a result in an [Operation] at the given index,
+/// shifting existing names at beyond that index to the left.
+/// Panics if the given `res_idx` is out of range.
+pub fn remove_operation_result_name(ctx: &Context, op: Ptr<Operation>, res_idx: usize) {
+    let op = &mut *op.deref_mut(ctx);
+    let num_results = op.get_num_results();
+    assert!(res_idx < num_results);
+
+    remove_name_from_attr_map(&mut op.attributes, res_idx);
 }
 
 /// Get name for a result in an [Operation].
@@ -153,7 +217,34 @@ pub fn set_block_arg_name(
     let num_args = block.get_num_arguments();
     assert!(arg_idx < num_args);
 
-    set_name_from_attr_map(&mut block.attributes, arg_idx, num_args, name);
+    set_name_in_attr_map(&mut block.attributes, arg_idx, name);
+}
+
+/// Insert a name for an argument in a [BasicBlock] at the given index,
+/// shifting existing names at that index and beyond to the right.
+/// Panics if the given `arg_idx` is out of range (i.e., `arg_idx > num_args`).
+pub fn insert_block_arg_name(
+    ctx: &Context,
+    block: Ptr<BasicBlock>,
+    arg_idx: usize,
+    name: Option<Identifier>,
+) {
+    let block = &mut *block.deref_mut(ctx);
+    let num_args = block.get_num_arguments();
+    assert!(arg_idx <= num_args);
+
+    insert_name_in_attr_map(&mut block.attributes, arg_idx, name);
+}
+
+/// Remove the name for an argument in a [BasicBlock] at the given index,
+/// shifting existing names at beyond that index to the left.
+/// Panics if the given `arg_idx` is out of range.
+pub fn remove_block_arg_name(ctx: &Context, block: Ptr<BasicBlock>, arg_idx: usize) {
+    let block = &mut *block.deref_mut(ctx);
+    let num_args = block.get_num_arguments();
+    assert!(arg_idx < num_args);
+
+    remove_name_from_attr_map(&mut block.attributes, arg_idx);
 }
 
 /// Get name for an argument in a [BasicBlock].
@@ -177,7 +268,11 @@ mod tests {
             types::{IntegerType, Signedness},
         },
         context::Context,
-        debug_info::{get_block_arg_name, set_block_arg_name},
+        debug_info::{
+            get_block_arg_name, get_operation_result_name, insert_block_arg_name,
+            insert_operation_result_name, remove_block_arg_name, remove_operation_result_name,
+            set_block_arg_name, set_operation_result_name,
+        },
         op::Op,
         operation::{Operation, verify_operation},
         result::Result,
@@ -208,8 +303,6 @@ mod tests {
         }
     }
 
-    use super::{get_operation_result_name, set_operation_result_name};
-
     #[test]
     fn test_op_result_name() -> Result<()> {
         let mut ctx = Context::new();
@@ -236,5 +329,206 @@ mod tests {
         set_block_arg_name(&ctx, block, 0, Some("foo".try_into().unwrap()));
         assert!(get_block_arg_name(&ctx, block, 0).unwrap() == "foo".try_into().unwrap());
         Ok(())
+    }
+
+    #[test]
+    fn test_op_result_name_insert_remove_shift() {
+        let mut ctx = Context::new();
+        let i64_ty = IntegerType::get(&mut ctx, 64, Signedness::Signed);
+        let op = Operation::new(
+            &mut ctx,
+            ZeroOp::get_concrete_op_info(),
+            vec![i64_ty.into(), i64_ty.into(), i64_ty.into()],
+            vec![],
+            vec![],
+            0,
+        );
+
+        set_operation_result_name(&ctx, op, 0, Some("r0".try_into().unwrap()));
+        set_operation_result_name(&ctx, op, 1, Some("r1".try_into().unwrap()));
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 0),
+            Some("r0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 1),
+            Some("r1".try_into().unwrap())
+        );
+        assert_eq!(get_operation_result_name(&ctx, op, 2), None);
+
+        // Insert/remove at end should not affect earlier indices.
+        insert_operation_result_name(&ctx, op, 2, Some("tail".try_into().unwrap()));
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 0),
+            Some("r0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 1),
+            Some("r1".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 2),
+            Some("tail".try_into().unwrap())
+        );
+        remove_operation_result_name(&ctx, op, 2);
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 0),
+            Some("r0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 1),
+            Some("r1".try_into().unwrap())
+        );
+        assert_eq!(get_operation_result_name(&ctx, op, 2), None);
+
+        // Insert a placeholder at front, shifting r0 name to index 1.
+        insert_operation_result_name(&ctx, op, 0, None);
+        assert_eq!(get_operation_result_name(&ctx, op, 0), None);
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 1),
+            Some("r0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 2),
+            Some("r1".try_into().unwrap())
+        );
+
+        // Insert a named result at the front.
+        insert_operation_result_name(&ctx, op, 0, Some("ins".try_into().unwrap()));
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 0),
+            Some("ins".try_into().unwrap())
+        );
+        assert_eq!(get_operation_result_name(&ctx, op, 1), None);
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 2),
+            Some("r0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 3),
+            Some("r1".try_into().unwrap())
+        );
+
+        // Remove front name; prior index 1 becomes 0 and index 2 becomes 1.
+        remove_operation_result_name(&ctx, op, 0);
+        assert_eq!(get_operation_result_name(&ctx, op, 0), None);
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 1),
+            Some("r0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 2),
+            Some("r1".try_into().unwrap())
+        );
+
+        // Remove the placeholder, moving r0 back to index 0.
+        remove_operation_result_name(&ctx, op, 0);
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 0),
+            Some("r0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_operation_result_name(&ctx, op, 1),
+            Some("r1".try_into().unwrap())
+        );
+    }
+
+    #[test]
+    fn test_block_arg_name_insert_remove_shift() {
+        let mut ctx = Context::new();
+        let i64_ty = IntegerType::get(&mut ctx, 64, Signedness::Signed);
+        let block = BasicBlock::new(
+            &mut ctx,
+            Some("entry".try_into().unwrap()),
+            vec![i64_ty.into(), i64_ty.into(), i64_ty.into()],
+        );
+
+        set_block_arg_name(&ctx, block, 0, Some("a0".try_into().unwrap()));
+        set_block_arg_name(&ctx, block, 1, Some("a1".try_into().unwrap()));
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 0),
+            Some("a0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 1),
+            Some("a1".try_into().unwrap())
+        );
+        assert_eq!(get_block_arg_name(&ctx, block, 2), None);
+
+        // Insert/remove at end should not affect earlier indices.
+        insert_block_arg_name(&ctx, block, 2, Some("tail".try_into().unwrap()));
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 0),
+            Some("a0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 1),
+            Some("a1".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 2),
+            Some("tail".try_into().unwrap())
+        );
+        remove_block_arg_name(&ctx, block, 2);
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 0),
+            Some("a0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 1),
+            Some("a1".try_into().unwrap())
+        );
+        assert_eq!(get_block_arg_name(&ctx, block, 2), None);
+
+        // Insert a placeholder at front, shifting a0 to index 1.
+        insert_block_arg_name(&ctx, block, 0, None);
+        assert_eq!(get_block_arg_name(&ctx, block, 0), None);
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 1),
+            Some("a0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 2),
+            Some("a1".try_into().unwrap())
+        );
+
+        // Insert a named arg at the front.
+        insert_block_arg_name(&ctx, block, 0, Some("ins".try_into().unwrap()));
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 0),
+            Some("ins".try_into().unwrap())
+        );
+        assert_eq!(get_block_arg_name(&ctx, block, 1), None);
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 2),
+            Some("a0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 3),
+            Some("a1".try_into().unwrap())
+        );
+
+        // Remove front name; prior index 1 becomes 0 and index 2 becomes 1.
+        remove_block_arg_name(&ctx, block, 0);
+        assert_eq!(get_block_arg_name(&ctx, block, 0), None);
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 1),
+            Some("a0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 2),
+            Some("a1".try_into().unwrap())
+        );
+
+        // Remove placeholder, moving a0 back to index 0.
+        remove_block_arg_name(&ctx, block, 0);
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 0),
+            Some("a0".try_into().unwrap())
+        );
+        assert_eq!(
+            get_block_arg_name(&ctx, block, 1),
+            Some("a1".try_into().unwrap())
+        );
     }
 }

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -35,7 +35,7 @@ impl DebugInfoAttr {
     }
 
     fn insert_name(&mut self, idx: usize, name: Option<Identifier>) {
-        self.names.grow_to(idx + 1, |_| None);
+        self.names.grow_to(idx, |_| None);
         self.names.insert(idx, name);
     }
 
@@ -100,7 +100,12 @@ fn set_name_in_attr_map(attributes: &mut AttributeDict, idx: usize, name: Option
                 .get_mut()
                 .downcast_mut::<DebugInfoAttr>()
                 .expect("Existing attribute entry for debug info incorrect");
+            let name_is_none = name.is_none();
             debug_info.set_name(idx, name);
+            // If the debug info attribute has all None entries, remove it from the map.
+            if name_is_none && debug_info.names.iter().all(|name| name.is_none()) {
+                occupied.remove();
+            }
         }
         Entry::Vacant(vacant) => {
             // Only insert a new debug info attribute if there's actually a name to set.
@@ -120,7 +125,12 @@ fn insert_name_in_attr_map(attributes: &mut AttributeDict, idx: usize, name: Opt
                 .get_mut()
                 .downcast_mut::<DebugInfoAttr>()
                 .expect("Existing attribute entry for debug info incorrect");
+            let name_is_none = name.is_none();
             debug_info.insert_name(idx, name);
+            // If the debug info attribute has all None entries, remove it from the map.
+            if name_is_none && debug_info.names.iter().all(|name| name.is_none()) {
+                occupied.remove();
+            }
         }
         Entry::Vacant(vacant) => {
             // Only insert a new debug info attribute if there's actually a name to set.

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     operation::Operation,
     region::Region,
-    value::Value,
+    value::{DefEntity, Value},
 };
 
 /// A node in the dominator tree.
@@ -429,12 +429,9 @@ impl DomInfo {
         a: Value,
         b: Ptr<Operation>,
     ) -> bool {
-        match a {
-            Value::OpResult { op, val_uid: _ } => self.op_strictly_dominates_op(ctx, op, b),
-            Value::BlockArgument {
-                block: a_block,
-                val_uid: _,
-            } => {
+        match a.def_entity() {
+            DefEntity::OpResult(op) => self.op_strictly_dominates_op(ctx, op, b),
+            DefEntity::BlockArgument(a_block) => {
                 if let Some(b_parent_block) = b.deref(ctx).get_parent_block() {
                     let a_block_region = a_block
                         .deref(ctx)

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -430,10 +430,10 @@ impl DomInfo {
         b: Ptr<Operation>,
     ) -> bool {
         match a {
-            Value::OpResult { op, res_idx: _ } => self.op_strictly_dominates_op(ctx, op, b),
+            Value::OpResult { op, val_uid: _ } => self.op_strictly_dominates_op(ctx, op, b),
             Value::BlockArgument {
                 block: a_block,
-                arg_idx: _,
+                val_uid: _,
             } => {
                 if let Some(b_parent_block) = b.deref(ctx).get_parent_block() {
                     let a_block_region = a_block

--- a/src/irbuild/dialect_conversion.rs
+++ b/src/irbuild/dialect_conversion.rs
@@ -22,7 +22,7 @@ use crate::{
     printable::{ListSeparator, Printable},
     result::Result,
     r#type::{Type, TypeObj, Typed},
-    value::Value,
+    value::{DefEntity, Value},
 };
 
 /// A rewriter that uses the [Recorder] listener.
@@ -294,7 +294,7 @@ pub fn apply_dialect_conversion<C: DialectConversion>(
         }
 
         fn convert_block_argument_type(&mut self, ctx: &mut Context, value: Value) -> Result<()> {
-            assert!(matches!(value, Value::BlockArgument { .. }));
+            assert!(matches!(value.def_entity(), DefEntity::BlockArgument(_)));
 
             loop {
                 let current_type = value.get_type(ctx);
@@ -400,14 +400,14 @@ pub fn apply_dialect_conversion<C: DialectConversion>(
             let operands: Vec<_> = op.deref(ctx).operands().collect();
             let mut pending_defs = Vec::new();
             for operand in &operands {
-                match operand {
-                    Value::OpResult { op: def_op, .. } => {
-                        assert_ne!(*def_op, op, "Operation cannot depend on its own result");
-                        if self.op_eligible_for_processing(ctx, *def_op) {
-                            pending_defs.push(*def_op);
+                match operand.def_entity() {
+                    DefEntity::OpResult(def_op) => {
+                        assert_ne!(def_op, op, "Operation cannot depend on its own result");
+                        if self.op_eligible_for_processing(ctx, def_op) {
+                            pending_defs.push(def_op);
                         }
                     }
-                    Value::BlockArgument { .. } => {
+                    DefEntity::BlockArgument(_) => {
                         self.convert_block_argument_type(ctx, *operand)?
                     }
                 }

--- a/src/irbuild/inserter.rs
+++ b/src/irbuild/inserter.rs
@@ -82,14 +82,14 @@ impl Printable for BlockInsertionPoint {
                 write!(
                     f,
                     "At start of Region {}",
-                    region.deref(ctx).get_index_in_parent(ctx)
+                    region.deref(ctx).find_index_in_parent(ctx)
                 )
             }
             BlockInsertionPoint::AtRegionEnd(region) => {
                 write!(
                     f,
                     "At end of Region {}",
-                    region.deref(ctx).get_index_in_parent(ctx)
+                    region.deref(ctx).find_index_in_parent(ctx)
                 )
             }
             BlockInsertionPoint::AfterBlock(block) => {

--- a/src/irbuild/rewriter.rs
+++ b/src/irbuild/rewriter.rs
@@ -295,7 +295,7 @@ impl<L: RewriteListener, I: Inserter<L>> Rewriter<L> for IRRewriter<L, I> {
 
         self.get_listener_mut().notify_region_erasure(ctx, region);
 
-        let index_in_parent = region.deref(ctx).get_index_in_parent(ctx);
+        let index_in_parent = region.deref(ctx).find_index_in_parent(ctx);
         let parent_op = region.deref(ctx).get_parent_op();
         Operation::erase_region(parent_op, ctx, index_in_parent);
         self.set_modified();

--- a/src/irfmt/parsers.rs
+++ b/src/irfmt/parsers.rs
@@ -281,7 +281,7 @@ pub fn process_parsed_ssa_defs(
     for (idx, name_loc) in results.iter().enumerate() {
         let res = op.deref(ctx).get_result(idx);
         name_tracker.ssa_def(ctx, name_loc, res)?;
-        set_operation_result_name(ctx, op, idx, name_loc.0.clone());
+        set_operation_result_name(ctx, op, idx, Some(name_loc.0.clone()));
     }
     Ok(())
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -244,8 +244,9 @@ impl Operation {
     /// Remove the last result. Panics if there are no results or if the result has uses.
     /// Any [Value] referring to the removed result is invalidated.
     pub fn pop_result(this: Ptr<Self>, ctx: &mut Context) {
-        let res_idx = this.deref(ctx).results.len() - 1;
-        Self::remove_result(this, ctx, res_idx);
+        let len = this.deref(ctx).results.len();
+        assert!(len > 0, "Can't pop result from operation with no results");
+        Self::remove_result(this, ctx, len - 1);
     }
 
     /// Insert a new result at `res_idx`, shifting existing results, from `res_idx`, to the right.
@@ -328,8 +329,9 @@ impl Operation {
     /// Any [`Use<Value>`](Use) of the removed operand is invalidated.
     /// The removed [Value] is returned for convenience.
     pub fn pop_operand(this: Ptr<Operation>, ctx: &Context) -> Value {
-        let opd_idx = this.deref(ctx).operands.len() - 1;
-        Self::remove_operand(this, ctx, opd_idx)
+        let len = this.deref(ctx).operands.len();
+        assert!(len > 0, "Can't pop operand from operation with no operands");
+        Self::remove_operand(this, ctx, len - 1)
     }
 
     /// Replace opd_idx'th operand of `this` with `other`. Panics on invalid index.
@@ -396,8 +398,12 @@ impl Operation {
     /// Any [`Use<Ptr<BasicBlock>>`](Use) of the removed successor is invalidated.
     /// The removed `Ptr<BasicBlock>` is returned for convenience.
     pub fn pop_successor(this: Ptr<Operation>, ctx: &Context) -> Ptr<BasicBlock> {
-        let succ_idx = this.deref(ctx).successors.len() - 1;
-        Self::remove_successor(this, ctx, succ_idx)
+        let len = this.deref(ctx).successors.len();
+        assert!(
+            len > 0,
+            "Can't pop successor from operation with no successors"
+        );
+        Self::remove_successor(this, ctx, len - 1)
     }
 
     /// Insert a new successor at `succ_idx`, shifting existing successors, from `succ_idx`,

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -185,14 +185,12 @@ impl Operation {
         // Update the operands (we can't do this easily during creation).
         let operands = operands
             .iter()
-            .enumerate()
-            .map(|(opd_idx, def)| Operand::new(ctx, *def, newop, opd_idx))
+            .map(|def| Operand::new(ctx, *def, newop))
             .collect();
         newop.deref_mut(ctx).operands = operands;
         let successors = successors
             .iter()
-            .enumerate()
-            .map(|(succ_idx, def)| Operand::new(ctx, *def, newop, succ_idx))
+            .map(|def| Operand::new(ctx, *def, newop))
             .collect();
         newop.deref_mut(ctx).successors = successors;
         newop.deref_mut(ctx).regions = Vec::new_init(num_regions, |_| Region::new(ctx, newop));
@@ -280,9 +278,10 @@ impl Operation {
 
     /// Get opd_idx'th operand as a [`Use<Value>`]. Panics on invalid index.
     pub fn get_operand_as_use(&self, opd_idx: usize) -> Use<Value> {
+        let use_uid = self.operands[opd_idx].use_uid;
         Use {
             user_op: self.self_ptr,
-            opd_idx,
+            use_uid,
             _dummy: PhantomData,
         }
     }
@@ -294,17 +293,13 @@ impl Operation {
 
     /// Get an iterator over the operands of this operation as [`Use<Value>`]s.
     pub fn operands_as_uses(&self) -> impl Iterator<Item = Use<Value>> + '_ {
-        (0..self.get_num_operands()).map(move |opd_idx| Use {
-            user_op: self.self_ptr,
-            opd_idx,
-            _dummy: PhantomData,
-        })
+        (0..self.get_num_operands()).map(move |opd_idx| self.get_operand_as_use(opd_idx))
     }
 
     /// Add a new operand to the end of the operand list, returning its index.
     pub fn push_operand(this: Ptr<Operation>, ctx: &Context, new_opd: Value) -> usize {
         let cur_num_operands = this.deref(ctx).get_num_operands();
-        let new_operand = Operand::new(ctx, new_opd, this, cur_num_operands);
+        let new_operand = Operand::new(ctx, new_opd, this);
         this.deref_mut(ctx).operands.push(new_operand);
         cur_num_operands
     }
@@ -319,21 +314,16 @@ impl Operation {
             .pop()
             .expect("Can't pop operand from operation with no operands");
         let removed_value = removed_opd.get_def();
-        removed_opd.drop_use(ctx, this, this.deref(ctx).get_num_operands());
+        removed_opd.drop_use(ctx, this);
         removed_value
     }
 
     /// Replace opd_idx'th operand of `this` with `other`. Panics on invalid index.
-    /// Any [`Use<Value>`](Use) of the replaced operand will henceforth refer to `other`.
+    /// Any [`Use<Value>`](Use) of the replaced operand will be invalidated.
     pub fn replace_operand(this: Ptr<Operation>, ctx: &Context, opd_idx: usize, other: Value) {
-        let (cur_def, cur_use) = {
-            let this_ref = this.deref(ctx);
-            (
-                this_ref.get_operand(opd_idx),
-                this_ref.get_operand_as_use(opd_idx),
-            )
-        };
-        cur_def.replace_use_with(ctx, cur_use, &other);
+        let new_operand = Operand::new(ctx, other, this);
+        std::mem::replace(&mut this.deref_mut(ctx).operands[opd_idx], new_operand)
+            .drop_use(ctx, this);
     }
 
     /// Insert a new operand at `opd_idx`, shifting existing operands, from `opd_idx`,
@@ -395,9 +385,10 @@ impl Operation {
 
     /// Get the opd_idx'th successor as a [`Use<Ptr<BasicBlock>>`]. Panics on invalid index.
     pub fn get_successor_as_use(&self, succ_idx: usize) -> Use<Ptr<BasicBlock>> {
+        let use_uid = self.successors[succ_idx].use_uid;
         Use {
             user_op: self.self_ptr,
-            opd_idx: succ_idx,
+            use_uid,
             _dummy: PhantomData,
         }
     }
@@ -410,20 +401,15 @@ impl Operation {
         succ_idx: usize,
         other: Ptr<BasicBlock>,
     ) {
-        let (cur_target, cur_block_use) = {
-            let this_ref = this.deref(ctx);
-            (
-                this_ref.get_successor(succ_idx),
-                this_ref.get_successor_as_use(succ_idx),
-            )
-        };
-        cur_target.retarget_pred_to(ctx, cur_block_use, other);
+        let new_successor = Operand::new(ctx, other, this);
+        std::mem::replace(&mut this.deref_mut(ctx).successors[succ_idx], new_successor)
+            .drop_use(ctx, this);
     }
 
     /// Add a new successor to the end of the successor list, returning its index.
     pub fn push_successor(this: Ptr<Operation>, ctx: &Context, new_succ: Ptr<BasicBlock>) -> usize {
         let cur_num_successors = this.deref(ctx).get_num_successors();
-        let new_successor = Operand::new(ctx, new_succ, this, cur_num_successors);
+        let new_successor = Operand::new(ctx, new_succ, this);
         this.deref_mut(ctx).successors.push(new_successor);
         cur_num_successors
     }
@@ -438,7 +424,7 @@ impl Operation {
             .pop()
             .expect("Can't pop successor from operation with no successors");
         let removed_block = removed_succ.get_def();
-        removed_succ.drop_use(ctx, this, this.deref(ctx).get_num_successors());
+        removed_succ.drop_use(ctx, this);
         removed_block
     }
 
@@ -502,12 +488,7 @@ impl Operation {
 
     /// Get an iterator over the successors of this operation as [`Use<Ptr<BasicBlock>>`]s.
     pub fn successors_as_uses(&self) -> impl Iterator<Item = Use<Ptr<BasicBlock>>> + '_ {
-        let op = self.self_ptr;
-        (0..self.get_num_successors()).map(move |succ_idx| Use {
-            user_op: op,
-            opd_idx: succ_idx,
-            _dummy: PhantomData,
-        })
+        (0..self.get_num_successors()).map(move |succ_idx| self.get_successor_as_use(succ_idx))
     }
 
     /// Create an [OpObj] corresponding to self.
@@ -564,13 +545,13 @@ impl Operation {
     pub fn drop_all_uses(ptr: Ptr<Self>, ctx: &Context) {
         // The operands cease to be a use of their definitions.
         let operands = std::mem::take(&mut (ptr.deref_mut(ctx).operands));
-        for (opd_idx, opd) in operands.into_iter().enumerate() {
-            opd.drop_use(ctx, ptr, opd_idx);
+        for opd in operands.into_iter() {
+            opd.drop_use(ctx, ptr);
         }
         // The successors cease to be a use of their definitions.
         let successors = std::mem::take(&mut (ptr.deref_mut(ctx).successors));
-        for (succ_idx, succ) in successors.into_iter().enumerate() {
-            succ.drop_use(ctx, ptr, succ_idx);
+        for succ in successors.into_iter() {
+            succ.drop_use(ctx, ptr);
         }
 
         let regions = ptr.deref(ctx).regions.clone();
@@ -614,34 +595,6 @@ impl Operation {
             Self::top_level_parse(parsable_state)
         })
     }
-
-    /// Get a reference to the opd_idx'th operand.
-    pub(crate) fn get_operand_ref(&self, opd_idx: usize) -> &Operand<Value> {
-        self.operands
-            .get(opd_idx)
-            .unwrap_or_else(|| panic!("Operand index {opd_idx} out of bounds"))
-    }
-
-    /// Get a mutable reference to the opd_idx'th operand.
-    pub(crate) fn get_operand_mut(&mut self, opd_idx: usize) -> &mut Operand<Value> {
-        self.operands
-            .get_mut(opd_idx)
-            .unwrap_or_else(|| panic!("Operand index {opd_idx} out of bounds"))
-    }
-
-    /// Get a reference to the succ_idx'th successor.
-    pub(crate) fn get_successor_ref(&self, succ_idx: usize) -> &Operand<Ptr<BasicBlock>> {
-        self.successors
-            .get(succ_idx)
-            .unwrap_or_else(|| panic!("Successor index {succ_idx} out of bounds"))
-    }
-
-    /// Get a mutable reference to the succ_idx'th successor.
-    pub(crate) fn get_successor_mut(&mut self, succ_idx: usize) -> &mut Operand<Ptr<BasicBlock>> {
-        self.successors
-            .get_mut(succ_idx)
-            .unwrap_or_else(|| panic!("Successor index {succ_idx} out of bounds"))
-    }
 }
 
 impl ArenaObj for Operation {
@@ -665,6 +618,7 @@ impl ArenaObj for Operation {
 /// Container for a [Use] in an [Operation].
 pub(crate) struct Operand<T: DefUseParticipant> {
     pub(crate) r#use: UseNode<T>,
+    pub(crate) use_uid: u64,
 }
 
 impl<T: DefUseParticipant + DefTrait> Operand<T> {
@@ -674,34 +628,36 @@ impl<T: DefUseParticipant + DefTrait> Operand<T> {
     }
 
     /// Drop this use, removing self from its definition's uses list.
-    fn drop_use(&self, ctx: &Context, op: Ptr<Operation>, opd_idx: usize) {
+    fn drop_use(&self, ctx: &Context, op: Ptr<Operation>) {
         self.get_def().get_defnode_mut(ctx).remove_use(Use {
             user_op: op,
-            opd_idx,
+            use_uid: self.use_uid,
             _dummy: PhantomData,
         });
     }
 
-    /// As `user_op`'s `opd_idx`'th operand, create a new Operand.
-    fn new(ctx: &Context, def: T, user_op: Ptr<Operation>, opd_idx: usize) -> Operand<T> {
+    /// Create a new Operand in `user_op`.
+    fn new(ctx: &Context, def: T, user_op: Ptr<Operation>) -> Operand<T> {
+        let use_uid = ctx.get_new_use_uid();
         Operand {
             r#use: def.get_defnode_mut(ctx).add_use(
                 def,
                 Use {
                     user_op,
-                    opd_idx,
+                    use_uid,
                     _dummy: PhantomData,
                 },
             ),
+            use_uid,
         }
     }
 
-    /// Verify that self is a valid operand of `user_op` at index `opd_idx`.
-    fn verify(&self, ctx: &Context, user_op: Ptr<Operation>, opd_idx: usize) -> Result<()> {
+    /// Verify that self is a valid operand of `user_op`.
+    fn verify(&self, ctx: &Context, user_op: Ptr<Operation>) -> Result<()> {
         let def = self.get_def();
         let r#use = Use {
             user_op,
-            opd_idx,
+            use_uid: self.use_uid,
             _dummy: PhantomData,
         };
         if !def.get_defnode_ref(ctx).has_use_of(&r#use) {
@@ -813,12 +769,10 @@ impl Verify for Operation {
                 .try_for_each(|attr| verify_attr(&**attr, ctx))?;
             opr.operands
                 .iter()
-                .enumerate()
-                .try_for_each(|(idx, opd)| opd.verify(ctx, opr.self_ptr, idx))?;
+                .try_for_each(|opd| opd.verify(ctx, opr.self_ptr))?;
             opr.successors
                 .iter()
-                .enumerate()
-                .try_for_each(|(idx, succ)| succ.verify(ctx, opr.self_ptr, idx))?;
+                .try_for_each(|succ| succ.verify(ctx, opr.self_ptr))?;
             opr.regions
                 .iter()
                 .try_for_each(|region| region.verify(ctx))?;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -52,18 +52,27 @@ pub(crate) struct OpResult {
 }
 
 impl OpResult {
+    /// Create a new OpResult with the given type and a new unique value ID from the context.
+    pub(crate) fn new(ctx: &mut Context, ty: Ptr<TypeObj>) -> OpResult {
+        OpResult {
+            def: DefNode::new(),
+            val_uid: ctx.get_new_value_uid(),
+            ty,
+        }
+    }
+
     /// Get the [Type](crate::type::Type) of this operation result.
-    pub fn get_type(&self) -> Ptr<TypeObj> {
+    pub(crate) fn get_type(&self) -> Ptr<TypeObj> {
         self.ty
     }
 
     /// Set the [Type](crate::type::Type) of this operation result.
-    pub fn set_type(&mut self, ty: Ptr<TypeObj>) {
+    pub(crate) fn set_type(&mut self, ty: Ptr<TypeObj>) {
         self.ty = ty;
     }
 
     /// Build a [Value] corresponding to this operation result.
-    pub fn as_value(&self, op: Ptr<Operation>) -> Value {
+    pub(crate) fn as_value(&self, op: Ptr<Operation>) -> Value {
         Value::OpResult {
             op,
             val_uid: self.val_uid,
@@ -175,11 +184,7 @@ impl Operation {
         // Update the results (we can't do this easily during creation).
         let results = result_types
             .into_iter()
-            .map(|ty| OpResult {
-                def: DefNode::new(),
-                ty,
-                val_uid: ctx.get_new_value_uid(),
-            })
+            .map(|ty| OpResult::new(ctx, ty))
             .collect();
         newop.deref_mut(ctx).results = results;
         // Update the operands (we can't do this easily during creation).
@@ -233,6 +238,35 @@ impl Operation {
         self.results.iter().map(|res| res.as_value(self.self_ptr))
     }
 
+    /// Add a result to the end of the result list, returning its index.
+    pub fn push_result(this: Ptr<Self>, ctx: &mut Context, ty: Ptr<TypeObj>) -> usize {
+        let new_result = OpResult::new(ctx, ty);
+        this.deref_mut(ctx).results.push_back(new_result)
+    }
+
+    /// Remove the last result. Panics if there are no results or if the result has uses.
+    /// Any [Value] referring to the removed result is invalidated.
+    pub fn pop_result(this: Ptr<Self>, ctx: &mut Context) {
+        let res_idx = this.deref(ctx).results.len() - 1;
+        Self::remove_result(this, ctx, res_idx);
+    }
+
+    /// Insert a new result at `res_idx`, shifting existing results, from `res_idx`, to the right.
+    /// Panics on invalid index.
+    pub fn insert_result(this: Ptr<Self>, ctx: &mut Context, res_idx: usize, ty: Ptr<TypeObj>) {
+        let new_res = OpResult::new(ctx, ty);
+        this.deref_mut(ctx).results.insert(res_idx, new_res);
+    }
+
+    /// Remove the result at `res_idx`, shifting existing results, from `res_idx + 1`, to the left.
+    /// Panics on invalid index or if the removed result has uses.
+    /// Any [Value] referring to the removed result is invalidated.
+    pub fn remove_result(this: Ptr<Self>, ctx: &mut Context, res_idx: usize) {
+        let value = this.deref(ctx).get_result(res_idx);
+        assert!(!value.is_used(ctx), "Can't remove result with uses");
+        this.deref_mut(ctx).results.remove(res_idx);
+    }
+
     /// Does any result of this operation have a use?
     pub fn has_use(&self) -> bool {
         self.results.iter().any(|res| res.def.is_used())
@@ -250,12 +284,9 @@ impl Operation {
         self.results.iter().flat_map(|res| res.def.uses())
     }
 
-    /// Get type of the idx'th result.
+    /// Get type of the idx'th result. Panics on invalid index.
     pub fn get_type(&self, idx: usize) -> Ptr<TypeObj> {
-        self.results
-            .get(idx)
-            .map(|res| res.ty)
-            .unwrap_or_else(|| panic!("Result index {idx} out of bounds"))
+        self.results[idx].ty
     }
 
     /// Get an iterator over the result types of this operation.
@@ -270,10 +301,7 @@ impl Operation {
 
     /// Get opd_idx'th operand of this [Operation]. Panics on invalid index.
     pub fn get_operand(&self, opd_idx: usize) -> Value {
-        self.operands
-            .get(opd_idx)
-            .map(|opd| opd.get_def())
-            .unwrap_or_else(|| panic!("Operand index {opd_idx} out of bounds"))
+        self.operands[opd_idx].get_def()
     }
 
     /// Get opd_idx'th operand as a [`Use<Value>`]. Panics on invalid index.
@@ -298,24 +326,16 @@ impl Operation {
 
     /// Add a new operand to the end of the operand list, returning its index.
     pub fn push_operand(this: Ptr<Operation>, ctx: &Context, new_opd: Value) -> usize {
-        let cur_num_operands = this.deref(ctx).get_num_operands();
         let new_operand = Operand::new(ctx, new_opd, this);
-        this.deref_mut(ctx).operands.push(new_operand);
-        cur_num_operands
+        this.deref_mut(ctx).operands.push_back(new_operand)
     }
 
     /// Remove the last operand. Panics if there are no operands.
     /// Any [`Use<Value>`](Use) of the removed operand is invalidated.
     /// The removed [Value] is returned for convenience.
     pub fn pop_operand(this: Ptr<Operation>, ctx: &Context) -> Value {
-        let removed_opd = this
-            .deref_mut(ctx)
-            .operands
-            .pop()
-            .expect("Can't pop operand from operation with no operands");
-        let removed_value = removed_opd.get_def();
-        removed_opd.drop_use(ctx, this);
-        removed_value
+        let opd_idx = this.deref(ctx).operands.len() - 1;
+        Self::remove_operand(this, ctx, opd_idx)
     }
 
     /// Replace opd_idx'th operand of `this` with `other`. Panics on invalid index.
@@ -328,46 +348,20 @@ impl Operation {
 
     /// Insert a new operand at `opd_idx`, shifting existing operands, from `opd_idx`,
     /// to the right. Panics on invalid index (i.e., `opd_idx` > number of operands).
-    /// Any [`Use<Value>`](Use) of the shifted operands are invalidated.
-    pub fn insert_operand(this: Ptr<Operation>, ctx: &mut Context, opd_idx: usize, new_opd: Value) {
-        let num_operands = this.deref(ctx).get_num_operands();
-        assert!(
-            opd_idx <= num_operands,
-            "Operand index {opd_idx} out of bounds for insertion"
-        );
-        let mut following_operands = Vec::with_capacity(num_operands - opd_idx);
-        for _ in opd_idx..num_operands {
-            following_operands.push(Self::pop_operand(this, ctx));
-        }
-        Self::push_operand(this, ctx, new_opd);
-        while let Some(opd) = following_operands.pop() {
-            Self::push_operand(this, ctx, opd);
-        }
+    pub fn insert_operand(this: Ptr<Operation>, ctx: &Context, opd_idx: usize, new_opd: Value) {
+        let new_opd = Operand::new(ctx, new_opd, this);
+        this.deref_mut(ctx).operands.insert(opd_idx, new_opd);
     }
 
     /// Remove the operand at `opd_idx`, shifting existing operands, from `opd_idx + 1`,
     /// to the left. Panics on invalid index (i.e., `opd_idx` >= number of operands).
-    /// Any [`Use<Value>`](Use) of the removed operand and the shifted operands are invalidated.
+    /// Any [`Use<Value>`](Use) of the removed operand is invalidated.
     /// The removed [Value] is returned for convenience.
-    pub fn remove_operand(this: Ptr<Operation>, ctx: &mut Context, opd_idx: usize) -> Value {
-        let num_operands = this.deref(ctx).get_num_operands();
-        assert!(
-            opd_idx < num_operands,
-            "Operand index {opd_idx} out of bounds for removal"
-        );
-
-        let mut cur_pop = num_operands - 1;
-        let mut following_operands = Vec::with_capacity(num_operands - opd_idx - 1);
-        while cur_pop > opd_idx {
-            following_operands.push(Self::pop_operand(this, ctx));
-            cur_pop -= 1;
-        }
-        // Pop the operand to be removed.
-        let removed_opd = Self::pop_operand(this, ctx);
-        while let Some(opd) = following_operands.pop() {
-            Self::push_operand(this, ctx, opd);
-        }
-        removed_opd
+    pub fn remove_operand(this: Ptr<Operation>, ctx: &Context, opd_idx: usize) -> Value {
+        let removed_opd = this.deref_mut(ctx).operands.remove(opd_idx);
+        let removed_value = removed_opd.get_def();
+        removed_opd.drop_use(ctx, this);
+        removed_value
     }
 
     /// Get number of successors
@@ -377,10 +371,7 @@ impl Operation {
 
     /// Get the opd_idx'th successor of this [Operation]. Panics on invalid index.
     pub fn get_successor(&self, succ_idx: usize) -> Ptr<BasicBlock> {
-        self.successors
-            .get(succ_idx)
-            .map(|succ| succ.get_def())
-            .unwrap_or_else(|| panic!("Successor index {succ_idx} out of bounds"))
+        self.successors[succ_idx].get_def()
     }
 
     /// Get the opd_idx'th successor as a [`Use<Ptr<BasicBlock>>`]. Panics on invalid index.
@@ -394,7 +385,7 @@ impl Operation {
     }
 
     /// Replace opd_idx'th successor of `this` with `other`. Panics on invalid index.
-    /// A [`Use<Ptr<BasicBlock>>`](Use) of the replaced successor will henceforth refer to `other`.
+    /// Any [`Use<Ptr<BasicBlock>>`](Use) of the replaced successor will be invalidated.
     pub fn replace_successor(
         this: Ptr<Operation>,
         ctx: &Context,
@@ -408,77 +399,43 @@ impl Operation {
 
     /// Add a new successor to the end of the successor list, returning its index.
     pub fn push_successor(this: Ptr<Operation>, ctx: &Context, new_succ: Ptr<BasicBlock>) -> usize {
-        let cur_num_successors = this.deref(ctx).get_num_successors();
         let new_successor = Operand::new(ctx, new_succ, this);
-        this.deref_mut(ctx).successors.push(new_successor);
-        cur_num_successors
+        this.deref_mut(ctx).successors.push_back(new_successor)
     }
 
     /// Remove the last successor. Panics if there are no successors.
     /// Any [`Use<Ptr<BasicBlock>>`](Use) of the removed successor is invalidated.
     /// The removed `Ptr<BasicBlock>` is returned for convenience.
     pub fn pop_successor(this: Ptr<Operation>, ctx: &Context) -> Ptr<BasicBlock> {
-        let removed_succ = this
-            .deref_mut(ctx)
-            .successors
-            .pop()
-            .expect("Can't pop successor from operation with no successors");
-        let removed_block = removed_succ.get_def();
-        removed_succ.drop_use(ctx, this);
-        removed_block
+        let succ_idx = this.deref(ctx).successors.len() - 1;
+        Self::remove_successor(this, ctx, succ_idx)
     }
 
     /// Insert a new successor at `succ_idx`, shifting existing successors, from `succ_idx`,
     /// to the right. Panics on invalid index (i.e., `succ_idx` > number of successors).
-    /// Any [`Use<Ptr<BasicBlock>>`](Use) of the shifted successors are invalidated.
     pub fn insert_successor(
         this: Ptr<Operation>,
-        ctx: &mut Context,
+        ctx: &Context,
         succ_idx: usize,
         new_succ: Ptr<BasicBlock>,
     ) {
-        let num_successors = this.deref(ctx).get_num_successors();
-        assert!(
-            succ_idx <= num_successors,
-            "Successor index {succ_idx} out of bounds for insertion"
-        );
-        let mut following_successors = Vec::with_capacity(num_successors - succ_idx);
-        for _ in succ_idx..num_successors {
-            following_successors.push(Self::pop_successor(this, ctx));
-        }
-        Self::push_successor(this, ctx, new_succ);
-        while let Some(succ) = following_successors.pop() {
-            Self::push_successor(this, ctx, succ);
-        }
+        let new_succ = Operand::new(ctx, new_succ, this);
+        this.deref_mut(ctx).successors.insert(succ_idx, new_succ);
     }
 
     /// Remove the successor at `succ_idx`, shifting existing successors, from `succ_idx + 1`,
     /// to the left. Panics on invalid index (i.e., `succ_idx` >= number of successors).
-    /// Any [`Use<Ptr<BasicBlock>>`](Use) of the removed successor and the shifted successors
-    /// are invalidated. The removed `Ptr<BasicBlock>` is returned for convenience.
+    /// Any [`Use<Ptr<BasicBlock>>`](Use) of the removed successor is invalidated.
+    /// The removed `Ptr<BasicBlock>` is returned for convenience.
     pub fn remove_successor(
         this: Ptr<Operation>,
-        ctx: &mut Context,
+        ctx: &Context,
         succ_idx: usize,
     ) -> Ptr<BasicBlock> {
-        let num_successors = this.deref(ctx).get_num_successors();
-        assert!(
-            succ_idx < num_successors,
-            "Successor index {succ_idx} out of bounds for removal"
-        );
-
-        let mut cur_pop = num_successors - 1;
-        let mut following_successors = Vec::with_capacity(num_successors - succ_idx - 1);
-        while cur_pop > succ_idx {
-            following_successors.push(Self::pop_successor(this, ctx));
-            cur_pop -= 1;
-        }
-        // Pop the successor to be removed.
-        let removed_succ = Self::pop_successor(this, ctx);
-        while let Some(succ) = following_successors.pop() {
-            Self::push_successor(this, ctx, succ);
-        }
-        removed_succ
+        let removed_succ = this.deref_mut(ctx).successors.remove(succ_idx);
+        let removed_block = removed_succ.get_def();
+        removed_succ.drop_use(ctx, this);
+        removed_block
     }
 
     /// Get an iterator on the successors.
@@ -510,10 +467,7 @@ impl Operation {
 
     /// Get a [Ptr] to the `reg_idx`th region. Panics on invalid index.
     pub fn get_region(&self, reg_idx: usize) -> Ptr<Region> {
-        self.regions
-            .get(reg_idx)
-            .cloned()
-            .unwrap_or_else(|| panic!("Region index {reg_idx} out of bounds"))
+        self.regions[reg_idx]
     }
 
     /// Number of regions.
@@ -529,8 +483,9 @@ impl Operation {
     }
 
     /// Erase `reg_idx`'th region. Affects the index of all regions after it.
+    /// Panics on invalid index.
     pub fn erase_region(ptr: Ptr<Self>, ctx: &mut Context, reg_idx: usize) {
-        let reg = *ptr.deref(ctx).regions.get(reg_idx).unwrap();
+        let reg = ptr.deref(ctx).regions[reg_idx];
         Region::drop_all_uses(reg, ctx);
         ptr.deref_mut(ctx).regions.remove(reg_idx);
         ArenaObj::dealloc(reg, ctx);

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -13,6 +13,7 @@ use crate::{
     builtin::op_interfaces::{IsTerminatorInterface, SymbolOpInterface},
     common_traits::{Named, RcShare, Verify},
     context::{Arena, Context, Ptr, private::ArenaObj},
+    debug_info,
     graph::{
         self,
         dominance::DomInfo,
@@ -254,6 +255,7 @@ impl Operation {
     pub fn insert_result(this: Ptr<Self>, ctx: &mut Context, res_idx: usize, ty: Ptr<TypeObj>) {
         let new_res = OpResult::new(ctx, ty);
         this.deref_mut(ctx).results.insert(res_idx, new_res);
+        debug_info::insert_operation_result_name(ctx, this, res_idx, None);
     }
 
     /// Remove the result at `res_idx`, shifting existing results, from `res_idx + 1`, to the left.
@@ -262,6 +264,7 @@ impl Operation {
     pub fn remove_result(this: Ptr<Self>, ctx: &mut Context, res_idx: usize) {
         let value = this.deref(ctx).get_result(res_idx);
         assert!(!value.is_used(ctx), "Can't remove result with uses");
+        debug_info::remove_operation_result_name(ctx, this, res_idx);
         this.deref_mut(ctx).results.remove(res_idx);
     }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -53,7 +53,7 @@ pub(crate) struct OpResult {
 
 impl OpResult {
     /// Create a new OpResult with the given type and a new unique value ID from the context.
-    pub(crate) fn new(ctx: &mut Context, ty: Ptr<TypeObj>) -> OpResult {
+    pub(crate) fn new(ctx: &Context, ty: Ptr<TypeObj>) -> OpResult {
         OpResult {
             def: DefNode::new(),
             val_uid: ctx.get_new_value_uid(),
@@ -227,10 +227,7 @@ impl Operation {
 
     /// Get idx'th result as a Value. Panics on invalid index.
     pub fn get_result(&self, idx: usize) -> Value {
-        self.results
-            .get(idx)
-            .map(|res| res.as_value(self.self_ptr))
-            .unwrap_or_else(|| panic!("Result index {idx} out of bounds"))
+        self.results[idx].as_value(self.self_ptr)
     }
 
     /// Get an iterator over the results of this operation.
@@ -306,12 +303,7 @@ impl Operation {
 
     /// Get opd_idx'th operand as a [`Use<Value>`]. Panics on invalid index.
     pub fn get_operand_as_use(&self, opd_idx: usize) -> Use<Value> {
-        let use_uid = self.operands[opd_idx].use_uid;
-        Use {
-            user_op: self.self_ptr,
-            use_uid,
-            _dummy: PhantomData,
-        }
+        self.operands[opd_idx].as_use(self.self_ptr)
     }
 
     /// Get an iterator over the operands of this operation.
@@ -321,7 +313,9 @@ impl Operation {
 
     /// Get an iterator over the operands of this operation as [`Use<Value>`]s.
     pub fn operands_as_uses(&self) -> impl Iterator<Item = Use<Value>> + '_ {
-        (0..self.get_num_operands()).map(move |opd_idx| self.get_operand_as_use(opd_idx))
+        self.operands
+            .iter()
+            .map(move |opd| opd.as_use(self.self_ptr))
     }
 
     /// Add a new operand to the end of the operand list, returning its index.
@@ -376,12 +370,7 @@ impl Operation {
 
     /// Get the opd_idx'th successor as a [`Use<Ptr<BasicBlock>>`]. Panics on invalid index.
     pub fn get_successor_as_use(&self, succ_idx: usize) -> Use<Ptr<BasicBlock>> {
-        let use_uid = self.successors[succ_idx].use_uid;
-        Use {
-            user_op: self.self_ptr,
-            use_uid,
-            _dummy: PhantomData,
-        }
+        self.successors[succ_idx].as_use(self.self_ptr)
     }
 
     /// Replace opd_idx'th successor of `this` with `other`. Panics on invalid index.
@@ -445,7 +434,9 @@ impl Operation {
 
     /// Get an iterator over the successors of this operation as [`Use<Ptr<BasicBlock>>`]s.
     pub fn successors_as_uses(&self) -> impl Iterator<Item = Use<Ptr<BasicBlock>>> + '_ {
-        (0..self.get_num_successors()).map(move |succ_idx| self.get_successor_as_use(succ_idx))
+        self.successors
+            .iter()
+            .map(|succ| succ.as_use(self.self_ptr))
     }
 
     /// Create an [OpObj] corresponding to self.
@@ -620,6 +611,15 @@ impl<T: DefUseParticipant + DefTrait> Operand<T> {
             verify_err!(loc, DefUseVerifyErr::OperandNotUseOfDef)
         } else {
             Ok(())
+        }
+    }
+
+    /// Build a [Use] corresponding to this operand.
+    fn as_use(&self, user_op: Ptr<Operation>) -> Use<T> {
+        Use {
+            user_op,
+            use_uid: self.use_uid,
+            _dummy: PhantomData,
         }
     }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -237,14 +237,14 @@ impl Operation {
     }
 
     /// Add a result to the end of the result list, returning its index.
-    pub fn push_result(this: Ptr<Self>, ctx: &mut Context, ty: Ptr<TypeObj>) -> usize {
+    pub fn push_result(this: Ptr<Self>, ctx: &Context, ty: Ptr<TypeObj>) -> usize {
         let new_result = OpResult::new(ctx, ty);
         this.deref_mut(ctx).results.push_back(new_result)
     }
 
     /// Remove the last result. Panics if there are no results or if the result has uses.
     /// Any [Value] referring to the removed result is invalidated.
-    pub fn pop_result(this: Ptr<Self>, ctx: &mut Context) {
+    pub fn pop_result(this: Ptr<Self>, ctx: &Context) {
         let len = this.deref(ctx).results.len();
         assert!(len > 0, "Can't pop result from operation with no results");
         Self::remove_result(this, ctx, len - 1);
@@ -252,7 +252,7 @@ impl Operation {
 
     /// Insert a new result at `res_idx`, shifting existing results, from `res_idx`, to the right.
     /// Panics on invalid index.
-    pub fn insert_result(this: Ptr<Self>, ctx: &mut Context, res_idx: usize, ty: Ptr<TypeObj>) {
+    pub fn insert_result(this: Ptr<Self>, ctx: &Context, res_idx: usize, ty: Ptr<TypeObj>) {
         let new_res = OpResult::new(ctx, ty);
         this.deref_mut(ctx).results.insert(res_idx, new_res);
         debug_info::insert_operation_result_name(ctx, this, res_idx, None);
@@ -261,7 +261,7 @@ impl Operation {
     /// Remove the result at `res_idx`, shifting existing results, from `res_idx + 1`, to the left.
     /// Panics on invalid index or if the removed result has uses.
     /// Any [Value] referring to the removed result is invalidated.
-    pub fn remove_result(this: Ptr<Self>, ctx: &mut Context, res_idx: usize) {
+    pub fn remove_result(this: Ptr<Self>, ctx: &Context, res_idx: usize) {
         let value = this.deref(ctx).get_result(res_idx);
         assert!(!value.is_used(ctx), "Can't remove result with uses");
         debug_info::remove_operation_result_name(ctx, this, res_idx);

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -13,7 +13,6 @@ use crate::{
     builtin::op_interfaces::{IsTerminatorInterface, SymbolOpInterface},
     common_traits::{Named, RcShare, Verify},
     context::{Arena, Context, Ptr, private::ArenaObj},
-    debug_info,
     graph::{
         self,
         dominance::DomInfo,
@@ -46,12 +45,10 @@ use crate::{
 pub(crate) struct OpResult {
     /// The def containing the list of this result's uses.
     pub(crate) def: DefNode<Value>,
-    /// Get the [Operation] that this is a result of.
-    def_op: Ptr<Operation>,
-    /// Index of this result in the [Operation] that this is part of.
-    res_idx: usize,
+    /// Unique ID of this value in [Context].
+    pub(crate) val_uid: u64,
     /// [Type](crate::type::Type) of this operation result.
-    ty: Ptr<TypeObj>,
+    pub(crate) ty: Ptr<TypeObj>,
 }
 
 impl OpResult {
@@ -64,49 +61,19 @@ impl OpResult {
     pub fn set_type(&mut self, ty: Ptr<TypeObj>) {
         self.ty = ty;
     }
+
+    /// Build a [Value] corresponding to this operation result.
+    pub fn as_value(&self, op: Ptr<Operation>) -> Value {
+        Value::OpResult {
+            op,
+            val_uid: self.val_uid,
+        }
+    }
 }
 
 impl Typed for OpResult {
     fn get_type(&self, _ctx: &Context) -> Ptr<TypeObj> {
         self.get_type()
-    }
-}
-
-impl Printable for OpResult {
-    fn fmt(
-        &self,
-        ctx: &Context,
-        _state: &printable::State,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{}", self.unique_name(ctx))
-    }
-}
-
-impl From<&OpResult> for Value {
-    fn from(value: &OpResult) -> Self {
-        Value::OpResult {
-            op: value.def_op,
-            res_idx: value.res_idx,
-        }
-    }
-}
-
-impl Verify for OpResult {
-    fn verify(&self, ctx: &Context) -> Result<()> {
-        Into::<Value>::into(self).verify(ctx)
-    }
-}
-
-impl Named for OpResult {
-    fn given_name(&self, ctx: &Context) -> Option<Identifier> {
-        debug_info::get_operation_result_name(ctx, self.def_op, self.res_idx)
-    }
-
-    fn id(&self, _ctx: &Context) -> Identifier {
-        format!("{}_res{}", self.def_op.make_name("op"), self.res_idx)
-            .try_into()
-            .unwrap()
     }
 }
 
@@ -134,11 +101,11 @@ pub struct Operation {
     /// For quick creation of an [OpObj] or concrete [Op] from [Self].
     concrete_op: ConcreteOpInfo,
     /// [Results](OpResult) defined by self.
-    results: Vec<OpResult>,
+    pub(crate) results: Vec<OpResult>,
     /// [Operand]s used by self.
-    operands: Vec<Operand<Value>>,
+    pub(crate) operands: Vec<Operand<Value>>,
     /// Control-flow-graph successors.
-    successors: Vec<Operand<Ptr<BasicBlock>>>,
+    pub(crate) successors: Vec<Operand<Ptr<BasicBlock>>>,
     /// Links to the parent [BasicBlock] and
     /// previous and next [Operation]s in the block.
     block_links: BlockLinks,
@@ -208,12 +175,10 @@ impl Operation {
         // Update the results (we can't do this easily during creation).
         let results = result_types
             .into_iter()
-            .enumerate()
-            .map(|(res_idx, ty)| OpResult {
+            .map(|ty| OpResult {
                 def: DefNode::new(),
-                def_op: newop,
                 ty,
-                res_idx,
+                val_uid: ctx.get_new_value_uid(),
             })
             .collect();
         newop.deref_mut(ctx).results = results;
@@ -261,13 +226,13 @@ impl Operation {
     pub fn get_result(&self, idx: usize) -> Value {
         self.results
             .get(idx)
-            .map(|res| res.into())
+            .map(|res| res.as_value(self.self_ptr))
             .unwrap_or_else(|| panic!("Result index {idx} out of bounds"))
     }
 
     /// Get an iterator over the results of this operation.
     pub fn results(&self) -> impl Iterator<Item = Value> + Clone + '_ {
-        self.results.iter().map(Into::into)
+        self.results.iter().map(|res| res.as_value(self.self_ptr))
     }
 
     /// Does any result of this operation have a use?
@@ -650,20 +615,6 @@ impl Operation {
         })
     }
 
-    /// Get a reference to the idx'th result.
-    pub(crate) fn get_result_ref(&self, idx: usize) -> &OpResult {
-        self.results
-            .get(idx)
-            .unwrap_or_else(|| panic!("Result index {idx} out of bounds"))
-    }
-
-    /// Get a mutable reference to the idx'th result.
-    pub(crate) fn get_result_mut(&mut self, idx: usize) -> &mut OpResult {
-        self.results
-            .get_mut(idx)
-            .unwrap_or_else(|| panic!("Result index {idx} out of bounds"))
-    }
-
     /// Get a reference to the opd_idx'th operand.
     pub(crate) fn get_operand_ref(&self, opd_idx: usize) -> &Operand<Value> {
         self.operands
@@ -871,7 +822,9 @@ impl Verify for Operation {
             opr.regions
                 .iter()
                 .try_for_each(|region| region.verify(ctx))?;
-            opr.results.iter().try_for_each(|res| res.verify(ctx))?;
+            opr.results
+                .iter()
+                .try_for_each(|res| res.as_value(opr.self_ptr).verify(ctx))?;
             let op = &*Operation::get_op_dyn(opr.self_ptr, ctx);
             if op_impls::<dyn IsTerminatorInterface>(op) && opr.get_next().is_some() {
                 let loc = opr.loc.clone();
@@ -1019,10 +972,10 @@ pub fn print_dbg(
         None => "".to_string(),
     };
 
-    if opr.get_num_results() == 0 {
-        // Print Ptr representing this operation.
-        write!(f, "{:?} ", opr.get_self_ptr(ctx))?;
-    } else {
+    // Print [Ptr] representing this operation.
+    write!(f, "[{:?}] ", opr.get_self_ptr(ctx))?;
+
+    if opr.get_num_results() > 0 {
         let results = iter_with_sep(opr.results(), sep);
         write!(f, "{} = ", results.disp(ctx))?;
     }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -38,7 +38,7 @@ use crate::{
     result::Result,
     r#type::{TypeObj, Typed},
     utils::vec_exns::VecExtns,
-    value::{DefNode, DefTrait, DefUseParticipant, Use, UseNode, Value},
+    value::{DefEntity, DefNode, DefTrait, DefUseParticipant, Use, UseNode, Value},
     verify_err, verify_error,
 };
 
@@ -74,8 +74,8 @@ impl OpResult {
 
     /// Build a [Value] corresponding to this operation result.
     pub(crate) fn as_value(&self, op: Ptr<Operation>) -> Value {
-        Value::OpResult {
-            op,
+        Value {
+            def_entity: DefEntity::OpResult(op),
             val_uid: self.val_uid,
         }
     }
@@ -456,8 +456,12 @@ impl Operation {
 
     /// Creates the concrete [Op] corresponding to self.
     pub fn get_op<T: Op>(ptr: Ptr<Self>, ctx: &Context) -> Option<T> {
-        (ptr.deref(ctx).concrete_op.1 == T::get_concrete_op_info().1)
-            .then_some(T::from_operation(ptr))
+        Self::is_op::<T>(ptr, ctx).then_some(T::from_operation(ptr))
+    }
+
+    /// Is this operation an instance of the concrete [Op] `T`?
+    pub fn is_op<T: Op>(ptr: Ptr<Self>, ctx: &Context) -> bool {
+        ptr.deref(ctx).concrete_op.1 == T::get_concrete_op_info().1
     }
 
     /// Get the [OpId] this Operation. Builds an intermediate [OpObj].
@@ -669,7 +673,7 @@ pub fn verify_value_dominance(ir: Ptr<Operation>, ctx: &Context) -> Result<()> {
         value: Value,
     ) -> WalkResult<pliron::result::Error> {
         for r#use in value.uses(ctx) {
-            let user_op = r#use.user_op;
+            let user_op = r#use.user_op();
             if !dom_info.value_strictly_dominates_op(ctx, value, user_op) {
                 let loc = user_op.deref(ctx).loc();
                 return walk_break(verify_error!(

--- a/src/opts/dce.rs
+++ b/src/opts/dce.rs
@@ -94,7 +94,7 @@ pub fn dce_with_rewriter<L: RewriteListener>(
             .filter_map(|opd| {
                 if let Value::OpResult {
                     op: def_op,
-                    res_idx: _,
+                    val_uid: _,
                 } = opd
                 {
                     Some(def_op)

--- a/src/opts/dce.rs
+++ b/src/opts/dce.rs
@@ -23,7 +23,7 @@ use crate::{
     operation::{OpDbg, Operation},
     opts::OptStatus,
     result::Result,
-    value::Value,
+    value::DefEntity,
 };
 
 /// Convey the presence of side effects in an operation.
@@ -92,11 +92,7 @@ pub fn dce_with_rewriter<L: RewriteListener>(
             .deref(ctx)
             .operands()
             .filter_map(|opd| {
-                if let Value::OpResult {
-                    op: def_op,
-                    val_uid: _,
-                } = opd
-                {
+                if let DefEntity::OpResult(def_op) = opd.def_entity() {
                     Some(def_op)
                 } else {
                     // We don't eliminate block arguments yet.

--- a/src/opts/mem2reg.rs
+++ b/src/opts/mem2reg.rs
@@ -172,7 +172,7 @@ fn prune_candidates(candidates: &mut Vec<AllocCandidate>, ctx: &Context) {
             .get_parent_region(ctx)
             .expect("Alloc op must be in a region");
         cand.alloc_info.ptr.uses(ctx).iter().all(|r#use| {
-            let user_op = r#use.user_op;
+            let user_op = r#use.user_op();
             let user_op_obj = Operation::get_op_dyn(user_op, ctx);
             op_cast::<dyn PromotableOpInterface>(user_op_obj.as_ref()).is_some_and(|piface| {
                 let user_region = user_op
@@ -205,7 +205,7 @@ fn compute_candidate_live_in_and_defining_blocks(
     // Compute blocks that contain uses of this pointer.
     let mut user_blocks: FxHashSet<Ptr<BasicBlock>> = FxHashSet::default();
     for u in ptr.uses(ctx) {
-        if let Some(block) = u.user_op.deref(ctx).get_parent_block() {
+        if let Some(block) = u.user_op().deref(ctx).get_parent_block() {
             user_blocks.insert(block);
         }
     }

--- a/src/opts/mem2reg.rs
+++ b/src/opts/mem2reg.rs
@@ -549,7 +549,7 @@ pub fn mem2reg(root: Ptr<Operation>, ctx: &mut Context) -> Result<OptStatus> {
             if let Some(needed_blocks) = phi_blocks.get(&ptr) {
                 let needed_blocks: Vec<Ptr<BasicBlock>> = needed_blocks.iter().cloned().collect();
                 for phi_block in needed_blocks {
-                    let arg_idx = BasicBlock::add_argument(phi_block, ctx, cand.alloc_info.ty);
+                    let arg_idx = BasicBlock::push_argument(phi_block, ctx, cand.alloc_info.ty);
                     set_block_arg_name(ctx, phi_block, arg_idx, ptr.given_name(ctx));
                     new_phis_in_block
                         .entry(phi_block)

--- a/src/opts/mem2reg.rs
+++ b/src/opts/mem2reg.rs
@@ -9,7 +9,9 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use crate::{
     basic_block::BasicBlock,
     builtin::op_interfaces::BranchOpInterface,
+    common_traits::Named,
     context::{Context, Ptr},
+    debug_info::set_block_arg_name,
     graph::{
         dominance::{DomFrontierMap, DomTree, compute_dominator_tree},
         walkers::{IRNode, WALKCONFIG_PREORDER_FORWARD, uninterruptible::immutable::walk_op},
@@ -547,7 +549,8 @@ pub fn mem2reg(root: Ptr<Operation>, ctx: &mut Context) -> Result<OptStatus> {
             if let Some(needed_blocks) = phi_blocks.get(&ptr) {
                 let needed_blocks: Vec<Ptr<BasicBlock>> = needed_blocks.iter().cloned().collect();
                 for phi_block in needed_blocks {
-                    let arg_idx = phi_block.deref_mut(ctx).add_argument(cand.alloc_info.ty);
+                    let arg_idx = BasicBlock::add_argument(phi_block, ctx, cand.alloc_info.ty);
+                    set_block_arg_name(ctx, phi_block, arg_idx, ptr.given_name(ctx));
                     new_phis_in_block
                         .entry(phi_block)
                         .or_default()

--- a/src/parsable.rs
+++ b/src/parsable.rs
@@ -16,7 +16,7 @@ use crate::{
     op::op_impls,
     operation::Operation,
     result::{self, Result},
-    value::Value,
+    value::{DefEntity, Value},
 };
 use combine::{
     Parser, Positioned, StreamOnce, choice,
@@ -296,14 +296,14 @@ impl NameTracker {
             .expect("NameTracker doesn't have an active scope.");
 
         match scope.entry(id.0.clone()) {
-            Entry::Occupied(mut occ) => match occ.get_mut() {
-                Value::OpResult { op, val_uid: _ } => {
+            Entry::Occupied(mut occ) => match occ.get_mut().def_entity() {
+                DefEntity::OpResult(op) => {
                     let fref_opt =
-                        Operation::get_op::<ForwardRefOp>(*op, ctx).map(|op| op.get_result(ctx));
+                        Operation::get_op::<ForwardRefOp>(op, ctx).map(|op| op.get_result(ctx));
                     if let Some(fref) = fref_opt {
                         // If there's already a def and its a forward ref, replace that.
                         fref.replace_some_uses_with(ctx, |_, _| true, &def);
-                        Operation::erase(*op, ctx);
+                        Operation::erase(op, ctx);
                         occ.insert(def);
                     } else {
                         // There's another def and it isn't a forward ref.
@@ -313,7 +313,7 @@ impl NameTracker {
                         )?
                     }
                 }
-                Value::BlockArgument { .. } => {
+                DefEntity::BlockArgument(_) => {
                     // There's another def and it isn't a forward ref.
                     input_err!(
                         id.1.clone(),
@@ -414,8 +414,9 @@ impl NameTracker {
                 .ssa_name_scope
                 .pop()
                 .expect("Exiting an isolated-from-above region which wasn't entered into.");
-            for (id, op) in ssa_scope {
-                if matches!(op, Value::OpResult { op, .. } if Operation::get_op::<ForwardRefOp>(op, ctx).is_some())
+            for (id, value) in ssa_scope {
+                if let DefEntity::OpResult(op) = value.def_entity()
+                    && Operation::is_op::<ForwardRefOp>(op, ctx)
                 {
                     input_err!(loc.clone(), UnresolvedReference(id.clone()))?
                 }

--- a/src/parsable.rs
+++ b/src/parsable.rs
@@ -297,7 +297,7 @@ impl NameTracker {
 
         match scope.entry(id.0.clone()) {
             Entry::Occupied(mut occ) => match occ.get_mut() {
-                Value::OpResult { op, res_idx: _ } => {
+                Value::OpResult { op, val_uid: _ } => {
                     let fref_opt =
                         Operation::get_op::<ForwardRefOp>(*op, ctx).map(|op| op.get_result(ctx));
                     if let Some(fref) = fref_opt {

--- a/src/region.rs
+++ b/src/region.rs
@@ -79,8 +79,8 @@ impl Region {
         self.get_parent_op().deref(ctx).get_parent_block()
     }
 
-    /// Get the index of this region in its parent operation.
-    pub fn get_index_in_parent(&self, ctx: &Context) -> usize {
+    /// Find the index of this region in its parent operation.
+    pub fn find_index_in_parent(&self, ctx: &Context) -> usize {
         let parent_op = self.get_parent_op();
         parent_op
             .deref(ctx)
@@ -96,7 +96,7 @@ impl Region {
         let op_dyn = Operation::get_op_dyn(parent_op, ctx);
         match op_cast::<dyn RegionKindInterface>(op_dyn.as_ref()) {
             Some(rki) => {
-                let region_idx = self.get_index_in_parent(ctx);
+                let region_idx = self.find_index_in_parent(ctx);
                 rki.has_ssa_dominance(region_idx)
             }
             None => true,

--- a/src/utils/vec_exns.rs
+++ b/src/utils/vec_exns.rs
@@ -12,6 +12,9 @@ pub trait VecExtns<T> {
 
     /// Create and initialize a new vector.
     fn new_init<U: FnMut(usize) -> T>(size: usize, initf: U) -> Vec<T>;
+
+    /// Grow the vector to the new size, initializing new elements with `initf`.
+    fn grow_to(&mut self, new_size: usize, initf: impl FnMut(usize) -> T);
 }
 
 impl<T> VecExtns<T> for Vec<T> {
@@ -32,5 +35,15 @@ impl<T> VecExtns<T> for Vec<T> {
             v.push(initf(i));
         }
         v
+    }
+
+    fn grow_to(&mut self, new_size: usize, mut initf: impl FnMut(usize) -> T) {
+        let current_size = self.len();
+        if new_size > current_size {
+            self.reserve(new_size - current_size);
+            for i in current_size..new_size {
+                self.push(initf(i));
+            }
+        }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -137,21 +137,19 @@ pub(crate) trait DefTrait: DefUseParticipant {
     fn get_defnode_mut<'a>(&self, ctx: &'a Context) -> RefMut<'a, DefNode<Self>>;
 }
 
+/// The defining entity of a [Value]:
+/// Either an [Operation] result or a [BasicBlock] argument.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DefEntity {
+    OpResult(Ptr<Operation>),
+    BlockArgument(Ptr<BasicBlock>),
+}
+
 /// Describes a value definition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Value {
-    OpResult {
-        /// The defining operation of this value.
-        op: Ptr<Operation>,
-        /// The global (in the context) unique id of the value we're describing.
-        val_uid: u64,
-    },
-    BlockArgument {
-        /// The defining block of this value.
-        block: Ptr<BasicBlock>,
-        /// The global (in the context) unique id of the value we're describing.
-        val_uid: u64,
-    },
+pub struct Value {
+    pub(crate) val_uid: u64,
+    pub(crate) def_entity: DefEntity,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -163,33 +161,38 @@ pub enum ValueError {
 }
 
 impl Value {
-    /// Find the index of this value in its defining operation's results or block's arguments.
-    /// Returns [Err] if this value is not in its defining operation's results or block's arguments.
+    /// Get the definition entity
+    pub fn def_entity(&self) -> DefEntity {
+        self.def_entity
+    }
+
+    /// Find the (result / argument) index of this value in its defining entity.
+    /// Returns [Err] if this value is not currently defined by its defining entity.
     pub fn try_find_index(&self, ctx: &Context) -> Result<usize> {
-        match self {
-            Value::OpResult { op, val_uid } => {
+        match self.def_entity {
+            DefEntity::OpResult(op) => {
                 let op = op.deref(ctx);
                 op.results
                     .iter()
-                    .position(|res| res.val_uid == *val_uid)
+                    .position(|res| res.val_uid == self.val_uid)
                     .ok_or(arg_error!(op.loc(), ValueError::NotInOpResult))
             }
-            Value::BlockArgument { block, val_uid } => {
+            DefEntity::BlockArgument(block) => {
                 let block = block.deref(ctx);
                 block
                     .args
                     .iter()
-                    .position(|arg| arg.val_uid == *val_uid)
+                    .position(|arg| arg.val_uid == self.val_uid)
                     .ok_or(arg_error!(block.loc(), ValueError::NotInBlockArgument))
             }
         }
     }
 
-    /// Find the index of this value in its defining operation's results or block's arguments.
-    /// Panics if this value is not in its defining operation's results or block's arguments.
+    /// Find the (result / argument) index of this value in its defining entity.
+    /// Panics if this value is not currently defined by its defining entity.
     pub fn find_index(&self, ctx: &Context) -> usize {
         self.try_find_index(ctx)
-            .expect("Value is not in its defining operation's results or block's arguments")
+            .expect("Value is not currently defined by its defining entity")
     }
 
     /// How many uses does this definition have?
@@ -239,28 +242,26 @@ impl Value {
 
     /// Get this value's location
     pub fn loc(&self, ctx: &Context) -> Location {
-        match self {
-            Value::OpResult { op, val_uid: _ } => op.deref(ctx).loc(),
-            Value::BlockArgument { block, val_uid: _ } => block.deref(ctx).loc(),
+        match self.def_entity {
+            DefEntity::OpResult(op) => op.deref(ctx).loc(),
+            DefEntity::BlockArgument(block) => block.deref(ctx).loc(),
         }
     }
 
     /// Set this value's type.
     pub fn set_type(&self, ctx: &Context, ty: Ptr<TypeObj>) {
         let index = self.find_index(ctx);
-        match self {
-            Value::OpResult { op, val_uid: _ } => op.deref_mut(ctx).results[index].set_type(ty),
-            Value::BlockArgument { block, val_uid: _ } => {
-                block.deref_mut(ctx).args[index].set_type(ctx, ty)
-            }
+        match self.def_entity {
+            DefEntity::OpResult(op) => op.deref_mut(ctx).results[index].set_type(ty),
+            DefEntity::BlockArgument(block) => block.deref_mut(ctx).args[index].set_type(ctx, ty),
         }
     }
 
     /// Get the defining block of this value.
     pub fn get_defining_block(&self, ctx: &Context) -> Option<Ptr<BasicBlock>> {
-        match self {
-            Value::OpResult { op, val_uid: _ } => op.deref(ctx).get_parent_block(),
-            Value::BlockArgument { block, val_uid: _ } => Some(*block),
+        match self.def_entity {
+            DefEntity::OpResult(op) => op.deref(ctx).get_parent_block(),
+            DefEntity::BlockArgument(block) => Some(block),
         }
     }
 }
@@ -283,11 +284,9 @@ impl Verify for Value {
 impl Typed for Value {
     fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
         let index = self.find_index(ctx);
-        match self {
-            Value::OpResult { op, val_uid: _ } => op.deref(ctx).results[index].get_type(),
-            Value::BlockArgument { block, val_uid: _ } => {
-                block.deref(ctx).args[index].get_type(ctx)
-            }
+        match self.def_entity {
+            DefEntity::OpResult(op) => op.deref(ctx).results[index].get_type(),
+            DefEntity::BlockArgument(block) => block.deref(ctx).args[index].get_type(ctx),
         }
     }
 }
@@ -295,22 +294,14 @@ impl Typed for Value {
 impl Named for Value {
     fn given_name(&self, ctx: &Context) -> Option<Identifier> {
         let index = self.find_index(ctx);
-        match self {
-            Value::OpResult { op, val_uid: _ } => {
-                debug_info::get_operation_result_name(ctx, *op, index)
-            }
-            Value::BlockArgument { block, val_uid: _ } => {
-                debug_info::get_block_arg_name(ctx, *block, index)
-            }
+        match self.def_entity {
+            DefEntity::OpResult(op) => debug_info::get_operation_result_name(ctx, op, index),
+            DefEntity::BlockArgument(block) => debug_info::get_block_arg_name(ctx, block, index),
         }
     }
 
     fn id(&self, _ctx: &Context) -> Identifier {
-        let val_uid = match self {
-            Value::OpResult { op: _, val_uid } => *val_uid,
-            Value::BlockArgument { block: _, val_uid } => *val_uid,
-        };
-        Identifier::try_from(format!("v{}", val_uid)).unwrap()
+        Identifier::try_from(format!("v{}", self.val_uid)).unwrap()
     }
 }
 
@@ -328,12 +319,12 @@ impl Printable for Value {
 impl DefTrait for Value {
     fn get_defnode_ref<'a>(&self, ctx: &'a Context) -> Ref<'a, DefNode<Self>> {
         let index = self.find_index(ctx);
-        match self {
-            Self::OpResult { op, val_uid: _ } => {
+        match self.def_entity {
+            DefEntity::OpResult(op) => {
                 let op = op.deref(ctx);
                 Ref::map(op, |opref| &opref.results[index].def)
             }
-            Self::BlockArgument { block, val_uid: _ } => {
+            DefEntity::BlockArgument(block) => {
                 let block = block.deref(ctx);
                 Ref::map(block, |blockref| &blockref.args[index].def)
             }
@@ -342,12 +333,12 @@ impl DefTrait for Value {
 
     fn get_defnode_mut<'a>(&self, ctx: &'a Context) -> RefMut<'a, DefNode<Self>> {
         let index = self.find_index(ctx);
-        match self {
-            Self::OpResult { op, val_uid: _ } => {
+        match self.def_entity {
+            DefEntity::OpResult(op) => {
                 let op = op.deref_mut(ctx);
                 RefMut::map(op, |opref| &mut opref.results[index].def)
             }
-            Self::BlockArgument { block, val_uid: _ } => {
+            DefEntity::BlockArgument(block) => {
                 let block = block.deref_mut(ctx);
                 RefMut::map(block, |blockref| &mut blockref.args[index].def)
             }
@@ -524,9 +515,9 @@ impl<T: DefUseParticipant> UseNode<T> {
 #[allow(private_bounds)]
 pub struct Use<T: DefUseParticipant> {
     /// Uses of a def can only be in an operation.
-    pub user_op: Ptr<Operation>,
+    pub(crate) user_op: Ptr<Operation>,
     /// The global (in the context) unique id of the use we're describing.
-    pub use_uid: u64,
+    pub(crate) use_uid: u64,
     /// Phantom data to keep track of whether this is a Value use or a BasicBlock use.
     pub(crate) _dummy: PhantomData<T>,
 }
@@ -548,6 +539,11 @@ impl<T: UseTrait> Use<T> {
     /// Get the definition that this is a use of.
     pub fn get_def(&self, ctx: &Context) -> T {
         UseTrait::get_usenode_ref(self, ctx).get_def()
+    }
+
+    /// Get the operation that is the user of this use.
+    pub fn user_op(&self) -> Ptr<Operation> {
+        self.user_op
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -116,16 +116,16 @@ enum UseError {
 pub(crate) trait UseTrait: DefUseParticipant {
     /// Find the index of the operand/successor in the user operation that corresponds to this use.
     /// Returns [Err] if the use is not in its user operation's operands/successors.
-    fn try_get_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize>;
+    fn try_find_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize>;
     /// Find the index of the operand/successor in the user operation that corresponds to this use.
     /// Panics if the use is not in its user operation's operands/successors.
-    fn get_index(r#use: &Use<Self>, ctx: &Context) -> usize {
-        Self::try_get_index(r#use, ctx)
+    fn find(r#use: &Use<Self>, ctx: &Context) -> usize {
+        Self::try_find_index(r#use, ctx)
             .expect("Use is not in its user operation's operands/successors")
     }
     /// Get a reference to the [UseNode] described by this use.
     fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>>;
-    /// Get a mutable reference to the [UseNode] described by this  use.
+    /// Get a mutable reference to the [UseNode] described by this use.
     fn get_usenode_mut<'a>(r#use: &Use<Self>, ctx: &'a Context) -> RefMut<'a, UseNode<Self>>;
 }
 
@@ -165,7 +165,7 @@ pub enum ValueError {
 impl Value {
     /// Find the index of this value in its defining operation's results or block's arguments.
     /// Returns [Err] if this value is not in its defining operation's results or block's arguments.
-    pub fn try_get_index(&self, ctx: &Context) -> Result<usize> {
+    pub fn try_find_index(&self, ctx: &Context) -> Result<usize> {
         match self {
             Value::OpResult { op, val_uid } => {
                 let op = op.deref(ctx);
@@ -187,8 +187,8 @@ impl Value {
 
     /// Find the index of this value in its defining operation's results or block's arguments.
     /// Panics if this value is not in its defining operation's results or block's arguments.
-    pub fn get_index(&self, ctx: &Context) -> usize {
-        self.try_get_index(ctx)
+    pub fn find_index(&self, ctx: &Context) -> usize {
+        self.try_find_index(ctx)
             .expect("Value is not in its defining operation's results or block's arguments")
     }
 
@@ -247,7 +247,7 @@ impl Value {
 
     /// Set this value's type.
     pub fn set_type(&self, ctx: &Context, ty: Ptr<TypeObj>) {
-        let index = self.get_index(ctx);
+        let index = self.find_index(ctx);
         match self {
             Value::OpResult { op, val_uid: _ } => op.deref_mut(ctx).results[index].set_type(ty),
             Value::BlockArgument { block, val_uid: _ } => {
@@ -269,7 +269,7 @@ impl Verify for Value {
     // Check that the value's uses point back to it,
     fn verify(&self, ctx: &Context) -> Result<()> {
         for r#use in self.uses(ctx) {
-            let opd_idx = <Self as UseTrait>::get_index(&r#use, ctx);
+            let opd_idx = <Self as UseTrait>::find(&r#use, ctx);
             let use_operand = r#use.user_op.deref(ctx).get_operand(opd_idx);
             if use_operand != *self {
                 verify_err!(self.loc(ctx), DefUseVerifyErr::OperandNotUseOfDef)?;
@@ -281,7 +281,7 @@ impl Verify for Value {
 
 impl Typed for Value {
     fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
-        let index = self.get_index(ctx);
+        let index = self.find_index(ctx);
         match self {
             Value::OpResult { op, val_uid: _ } => op.deref(ctx).results[index].get_type(),
             Value::BlockArgument { block, val_uid: _ } => {
@@ -293,7 +293,7 @@ impl Typed for Value {
 
 impl Named for Value {
     fn given_name(&self, ctx: &Context) -> Option<Identifier> {
-        let index = self.get_index(ctx);
+        let index = self.find_index(ctx);
         match self {
             Value::OpResult { op, val_uid: _ } => {
                 debug_info::get_operation_result_name(ctx, *op, index)
@@ -326,7 +326,7 @@ impl Printable for Value {
 
 impl DefTrait for Value {
     fn get_defnode_ref<'a>(&self, ctx: &'a Context) -> Ref<'a, DefNode<Self>> {
-        let index = self.get_index(ctx);
+        let index = self.find_index(ctx);
         match self {
             Self::OpResult { op, val_uid: _ } => {
                 let op = op.deref(ctx);
@@ -340,7 +340,7 @@ impl DefTrait for Value {
     }
 
     fn get_defnode_mut<'a>(&self, ctx: &'a Context) -> RefMut<'a, DefNode<Self>> {
-        let index = self.get_index(ctx);
+        let index = self.find_index(ctx);
         match self {
             Self::OpResult { op, val_uid: _ } => {
                 let op = op.deref_mut(ctx);
@@ -355,7 +355,7 @@ impl DefTrait for Value {
 }
 
 impl UseTrait for Value {
-    fn try_get_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize> {
+    fn try_find_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize> {
         let op = r#use.user_op.deref(ctx);
         op.operands
             .iter()
@@ -363,12 +363,12 @@ impl UseTrait for Value {
             .ok_or(arg_error!(op.loc(), UseError::OperandNotInUserOp))
     }
     fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>> {
-        let index = <Self as UseTrait>::get_index(r#use, ctx);
+        let index = <Self as UseTrait>::find(r#use, ctx);
         let op = r#use.user_op.deref(ctx);
         Ref::map(op, |opref| &opref.operands[index].r#use)
     }
     fn get_usenode_mut<'a>(r#use: &Use<Self>, ctx: &'a Context) -> RefMut<'a, UseNode<Value>> {
-        let index = <Self as UseTrait>::get_index(r#use, ctx);
+        let index = <Self as UseTrait>::find(r#use, ctx);
         let op = r#use.user_op.deref_mut(ctx);
         RefMut::map(op, |opref| &mut opref.operands[index].r#use)
     }
@@ -483,7 +483,7 @@ impl DefTrait for Ptr<BasicBlock> {
 }
 
 impl UseTrait for Ptr<BasicBlock> {
-    fn try_get_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize> {
+    fn try_find_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize> {
         let op = r#use.user_op.deref(ctx);
         op.successors
             .iter()
@@ -491,7 +491,7 @@ impl UseTrait for Ptr<BasicBlock> {
             .ok_or(arg_error!(op.loc(), UseError::SuccessorNotInUserOp))
     }
     fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>> {
-        let succ_idx = <Self as UseTrait>::get_index(r#use, ctx);
+        let succ_idx = <Self as UseTrait>::find(r#use, ctx);
         let op = r#use.user_op.deref(ctx);
         Ref::map(op, |opref| &opref.successors[succ_idx].r#use)
     }
@@ -499,7 +499,7 @@ impl UseTrait for Ptr<BasicBlock> {
         r#use: &Use<Ptr<BasicBlock>>,
         ctx: &'a Context,
     ) -> RefMut<'a, UseNode<Ptr<BasicBlock>>> {
-        let succ_idx = <Self as UseTrait>::get_index(r#use, ctx);
+        let succ_idx = <Self as UseTrait>::find(r#use, ctx);
         let op = r#use.user_op.deref_mut(ctx);
         RefMut::map(op, |opref| &mut opref.successors[succ_idx].r#use)
     }
@@ -534,14 +534,14 @@ pub struct Use<T: DefUseParticipant> {
 impl<T: UseTrait> Use<T> {
     /// Find index of the operand/successor in the user operation that corresponds to this [Use].
     /// Returns [Err] if the [Use] is not in its user operation's operands/successors.
-    pub fn try_get_index(&self, ctx: &Context) -> Result<usize> {
-        T::try_get_index(self, ctx)
+    pub fn try_find_index(&self, ctx: &Context) -> Result<usize> {
+        T::try_find_index(self, ctx)
     }
 
     /// Find index of the operand/successor in the user operation that corresponds to this [Use].
     /// Panics if the [Use] is not in its user operation's operands/successors.
-    pub fn get_index(&self, ctx: &Context) -> usize {
-        T::get_index(self, ctx)
+    pub fn find_index(&self, ctx: &Context) -> usize {
+        T::find(self, ctx)
     }
 
     /// Get the definition that this is a use of.

--- a/src/value.rs
+++ b/src/value.rs
@@ -104,8 +104,25 @@ impl<T: DefUseParticipant> DefNode<T> {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+enum UseError {
+    #[error("Use does not correspond to any operand of its user operation")]
+    OperandNotInUserOp,
+    #[error("Use does not correspond to any successor of its user operation")]
+    SuccessorNotInUserOp,
+}
+
 /// Interface for [UseNode] wrappers.
 pub(crate) trait UseTrait: DefUseParticipant {
+    /// Find the index of the operand/successor in the user operation that corresponds to this use.
+    /// Returns [Err] if the use is not in its user operation's operands/successors.
+    fn try_get_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize>;
+    /// Find the index of the operand/successor in the user operation that corresponds to this use.
+    /// Panics if the use is not in its user operation's operands/successors.
+    fn get_index(r#use: &Use<Self>, ctx: &Context) -> usize {
+        Self::try_get_index(r#use, ctx)
+            .expect("Use is not in its user operation's operands/successors")
+    }
     /// Get a reference to the [UseNode] described by this use.
     fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>>;
     /// Get a mutable reference to the [UseNode] described by this  use.
@@ -126,13 +143,13 @@ pub enum Value {
     OpResult {
         /// The defining operation of this value.
         op: Ptr<Operation>,
-        /// The global (in the context) unique id of this value.
+        /// The global (in the context) unique id of the value we're describing.
         val_uid: u64,
     },
     BlockArgument {
         /// The defining block of this value.
         block: Ptr<BasicBlock>,
-        /// The global (in the context) unique id of this value.
+        /// The global (in the context) unique id of the value we're describing.
         val_uid: u64,
     },
 }
@@ -252,7 +269,8 @@ impl Verify for Value {
     // Check that the value's uses point back to it,
     fn verify(&self, ctx: &Context) -> Result<()> {
         for r#use in self.uses(ctx) {
-            let use_operand = r#use.user_op.deref(ctx).get_operand(r#use.opd_idx);
+            let opd_idx = <Self as UseTrait>::get_index(&r#use, ctx);
+            let use_operand = r#use.user_op.deref(ctx).get_operand(opd_idx);
             if use_operand != *self {
                 verify_err!(self.loc(ctx), DefUseVerifyErr::OperandNotUseOfDef)?;
             }
@@ -337,13 +355,22 @@ impl DefTrait for Value {
 }
 
 impl UseTrait for Value {
-    fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>> {
+    fn try_get_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize> {
         let op = r#use.user_op.deref(ctx);
-        Ref::map(op, |opref| &opref.get_operand_ref(r#use.opd_idx).r#use)
+        op.operands
+            .iter()
+            .position(|operand| operand.use_uid == r#use.use_uid)
+            .ok_or(arg_error!(op.loc(), UseError::OperandNotInUserOp))
+    }
+    fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>> {
+        let index = <Self as UseTrait>::get_index(r#use, ctx);
+        let op = r#use.user_op.deref(ctx);
+        Ref::map(op, |opref| &opref.operands[index].r#use)
     }
     fn get_usenode_mut<'a>(r#use: &Use<Self>, ctx: &'a Context) -> RefMut<'a, UseNode<Value>> {
+        let index = <Self as UseTrait>::get_index(r#use, ctx);
         let op = r#use.user_op.deref_mut(ctx);
-        RefMut::map(op, |opref| &mut opref.get_operand_mut(r#use.opd_idx).r#use)
+        RefMut::map(op, |opref| &mut opref.operands[index].r#use)
     }
 }
 
@@ -456,18 +483,25 @@ impl DefTrait for Ptr<BasicBlock> {
 }
 
 impl UseTrait for Ptr<BasicBlock> {
-    fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>> {
+    fn try_get_index(r#use: &Use<Self>, ctx: &Context) -> Result<usize> {
         let op = r#use.user_op.deref(ctx);
-        Ref::map(op, |opref| &opref.get_successor_ref(r#use.opd_idx).r#use)
+        op.successors
+            .iter()
+            .position(|succ| succ.use_uid == r#use.use_uid)
+            .ok_or(arg_error!(op.loc(), UseError::SuccessorNotInUserOp))
+    }
+    fn get_usenode_ref<'a>(r#use: &Use<Self>, ctx: &'a Context) -> Ref<'a, UseNode<Self>> {
+        let succ_idx = <Self as UseTrait>::get_index(r#use, ctx);
+        let op = r#use.user_op.deref(ctx);
+        Ref::map(op, |opref| &opref.successors[succ_idx].r#use)
     }
     fn get_usenode_mut<'a>(
         r#use: &Use<Ptr<BasicBlock>>,
         ctx: &'a Context,
     ) -> RefMut<'a, UseNode<Ptr<BasicBlock>>> {
+        let succ_idx = <Self as UseTrait>::get_index(r#use, ctx);
         let op = r#use.user_op.deref_mut(ctx);
-        RefMut::map(op, |opref| {
-            &mut opref.get_successor_mut(r#use.opd_idx).r#use
-        })
+        RefMut::map(op, |opref| &mut opref.successors[succ_idx].r#use)
     }
 }
 
@@ -490,13 +524,26 @@ impl<T: DefUseParticipant> UseNode<T> {
 pub struct Use<T: DefUseParticipant> {
     /// Uses of a def can only be in an operation.
     pub user_op: Ptr<Operation>,
-    /// Used as the i'th operand or successor of [op](Self::user_op).
-    pub opd_idx: usize,
+    /// The global (in the context) unique id of the use we're describing.
+    pub use_uid: u64,
+    /// Phantom data to keep track of whether this is a Value use or a BasicBlock use.
     pub(crate) _dummy: PhantomData<T>,
 }
 
 #[allow(private_bounds)]
 impl<T: UseTrait> Use<T> {
+    /// Find index of the operand/successor in the user operation that corresponds to this [Use].
+    /// Returns [Err] if the [Use] is not in its user operation's operands/successors.
+    pub fn try_get_index(&self, ctx: &Context) -> Result<usize> {
+        T::try_get_index(self, ctx)
+    }
+
+    /// Find index of the operand/successor in the user operation that corresponds to this [Use].
+    /// Panics if the [Use] is not in its user operation's operands/successors.
+    pub fn get_index(&self, ctx: &Context) -> usize {
+        T::get_index(self, ctx)
+    }
+
     /// Get the definition that this is a use of.
     pub fn get_def(&self, ctx: &Context) -> T {
         UseTrait::get_usenode_ref(self, ctx).get_def()

--- a/src/value.rs
+++ b/src/value.rs
@@ -16,9 +16,11 @@ use std::{
 };
 
 use crate::{
+    arg_error,
     basic_block::BasicBlock,
     common_traits::{Named, Verify},
     context::{Context, Ptr},
+    debug_info,
     identifier::Identifier,
     linked_list::{ContainsLinkedList, LinkedList},
     location::{Located, Location},
@@ -122,16 +124,57 @@ pub(crate) trait DefTrait: DefUseParticipant {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Value {
     OpResult {
+        /// The defining operation of this value.
         op: Ptr<Operation>,
-        res_idx: usize,
+        /// The global (in the context) unique id of this value.
+        val_uid: u64,
     },
     BlockArgument {
+        /// The defining block of this value.
         block: Ptr<BasicBlock>,
-        arg_idx: usize,
+        /// The global (in the context) unique id of this value.
+        val_uid: u64,
     },
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ValueError {
+    #[error("Invalid Value: Defining operation has no result corresponding to this value")]
+    NotInOpResult,
+    #[error("Invalid Value: Defining block has no argument corresponding to this value")]
+    NotInBlockArgument,
+}
+
 impl Value {
+    /// Find the index of this value in its defining operation's results or block's arguments.
+    /// Returns [Err] if this value is not in its defining operation's results or block's arguments.
+    pub fn try_get_index(&self, ctx: &Context) -> Result<usize> {
+        match self {
+            Value::OpResult { op, val_uid } => {
+                let op = op.deref(ctx);
+                op.results
+                    .iter()
+                    .position(|res| res.val_uid == *val_uid)
+                    .ok_or(arg_error!(op.loc(), ValueError::NotInOpResult))
+            }
+            Value::BlockArgument { block, val_uid } => {
+                let block = block.deref(ctx);
+                block
+                    .args
+                    .iter()
+                    .position(|arg| arg.val_uid == *val_uid)
+                    .ok_or(arg_error!(block.loc(), ValueError::NotInBlockArgument))
+            }
+        }
+    }
+
+    /// Find the index of this value in its defining operation's results or block's arguments.
+    /// Panics if this value is not in its defining operation's results or block's arguments.
+    pub fn get_index(&self, ctx: &Context) -> usize {
+        self.try_get_index(ctx)
+            .expect("Value is not in its defining operation's results or block's arguments")
+    }
+
     /// How many uses does this definition have?
     pub fn num_uses(&self, ctx: &Context) -> usize {
         self.get_defnode_ref(ctx).num_uses()
@@ -180,29 +223,27 @@ impl Value {
     /// Get this value's location
     pub fn loc(&self, ctx: &Context) -> Location {
         match self {
-            Value::OpResult { op, res_idx: _ } => op.deref(ctx).loc(),
-            Value::BlockArgument { block, arg_idx: _ } => block.deref(ctx).loc(),
+            Value::OpResult { op, val_uid: _ } => op.deref(ctx).loc(),
+            Value::BlockArgument { block, val_uid: _ } => block.deref(ctx).loc(),
         }
     }
 
     /// Set this value's type.
     pub fn set_type(&self, ctx: &Context, ty: Ptr<TypeObj>) {
+        let index = self.get_index(ctx);
         match self {
-            Value::OpResult { op, res_idx } => {
-                op.deref_mut(ctx).get_result_mut(*res_idx).set_type(ty)
+            Value::OpResult { op, val_uid: _ } => op.deref_mut(ctx).results[index].set_type(ty),
+            Value::BlockArgument { block, val_uid: _ } => {
+                block.deref_mut(ctx).args[index].set_type(ctx, ty)
             }
-            Value::BlockArgument { block, arg_idx } => block
-                .deref_mut(ctx)
-                .get_argument_mut(*arg_idx)
-                .set_type(ctx, ty),
         }
     }
 
     /// Get the defining block of this value.
     pub fn get_defining_block(&self, ctx: &Context) -> Option<Ptr<BasicBlock>> {
         match self {
-            Value::OpResult { op, res_idx: _ } => op.deref(ctx).get_parent_block(),
-            Value::BlockArgument { block, arg_idx: _ } => Some(*block),
+            Value::OpResult { op, val_uid: _ } => op.deref(ctx).get_parent_block(),
+            Value::BlockArgument { block, val_uid: _ } => Some(*block),
         }
     }
 }
@@ -222,10 +263,11 @@ impl Verify for Value {
 
 impl Typed for Value {
     fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
+        let index = self.get_index(ctx);
         match self {
-            Value::OpResult { op, res_idx } => op.deref(ctx).get_result_ref(*res_idx).get_type(),
-            Value::BlockArgument { block, arg_idx } => {
-                block.deref(ctx).get_argument_ref(*arg_idx).get_type(ctx)
+            Value::OpResult { op, val_uid: _ } => op.deref(ctx).results[index].get_type(),
+            Value::BlockArgument { block, val_uid: _ } => {
+                block.deref(ctx).args[index].get_type(ctx)
             }
         }
     }
@@ -233,23 +275,23 @@ impl Typed for Value {
 
 impl Named for Value {
     fn given_name(&self, ctx: &Context) -> Option<Identifier> {
+        let index = self.get_index(ctx);
         match self {
-            Value::OpResult { op, res_idx } => {
-                op.deref(ctx).get_result_ref(*res_idx).given_name(ctx)
+            Value::OpResult { op, val_uid: _ } => {
+                debug_info::get_operation_result_name(ctx, *op, index)
             }
-            Value::BlockArgument { block, arg_idx } => {
-                block.deref(ctx).get_argument_ref(*arg_idx).given_name(ctx)
+            Value::BlockArgument { block, val_uid: _ } => {
+                debug_info::get_block_arg_name(ctx, *block, index)
             }
         }
     }
 
-    fn id(&self, ctx: &Context) -> Identifier {
-        match self {
-            Value::OpResult { op, res_idx } => op.deref(ctx).get_result_ref(*res_idx).id(ctx),
-            Value::BlockArgument { block, arg_idx } => {
-                block.deref(ctx).get_argument_ref(*arg_idx).id(ctx)
-            }
-        }
+    fn id(&self, _ctx: &Context) -> Identifier {
+        let val_uid = match self {
+            Value::OpResult { op: _, val_uid } => *val_uid,
+            Value::BlockArgument { block: _, val_uid } => *val_uid,
+        };
+        Identifier::try_from(format!("v{}", val_uid)).unwrap()
     }
 }
 
@@ -266,29 +308,29 @@ impl Printable for Value {
 
 impl DefTrait for Value {
     fn get_defnode_ref<'a>(&self, ctx: &'a Context) -> Ref<'a, DefNode<Self>> {
+        let index = self.get_index(ctx);
         match self {
-            Self::OpResult { op, res_idx } => {
+            Self::OpResult { op, val_uid: _ } => {
                 let op = op.deref(ctx);
-                Ref::map(op, |opref| &opref.get_result_ref(*res_idx).def)
+                Ref::map(op, |opref| &opref.results[index].def)
             }
-            Self::BlockArgument { block, arg_idx } => {
+            Self::BlockArgument { block, val_uid: _ } => {
                 let block = block.deref(ctx);
-                Ref::map(block, |blockref| &blockref.get_argument_ref(*arg_idx).def)
+                Ref::map(block, |blockref| &blockref.args[index].def)
             }
         }
     }
 
     fn get_defnode_mut<'a>(&self, ctx: &'a Context) -> RefMut<'a, DefNode<Self>> {
+        let index = self.get_index(ctx);
         match self {
-            Self::OpResult { op, res_idx } => {
+            Self::OpResult { op, val_uid: _ } => {
                 let op = op.deref_mut(ctx);
-                RefMut::map(op, |opref| &mut opref.get_result_mut(*res_idx).def)
+                RefMut::map(op, |opref| &mut opref.results[index].def)
             }
-            Self::BlockArgument { block, arg_idx } => {
+            Self::BlockArgument { block, val_uid: _ } => {
                 let block = block.deref_mut(ctx);
-                RefMut::map(block, |blockref| {
-                    &mut blockref.get_argument_mut(*arg_idx).def
-                })
+                RefMut::map(block, |blockref| &mut blockref.args[index].def)
             }
         }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -28,7 +28,7 @@ use crate::{
     printable::Printable,
     result::Result,
     r#type::{TypeObj, Typed},
-    verify_err,
+    verify_err, verify_error,
 };
 
 /// def-use chains are implemented for [Value]s and `Ptr<BasicBlock>`.
@@ -269,7 +269,8 @@ impl Verify for Value {
     // Check that the value's uses point back to it,
     fn verify(&self, ctx: &Context) -> Result<()> {
         for r#use in self.uses(ctx) {
-            let opd_idx = <Self as UseTrait>::find(&r#use, ctx);
+            let opd_idx = <Self as UseTrait>::try_find_index(&r#use, ctx)
+                .map_err(|_| verify_error!(self.loc(ctx), DefUseVerifyErr::OperandNotUseOfDef))?;
             let use_operand = r#use.user_op.deref(ctx).get_operand(opd_idx);
             if use_operand != *self {
                 verify_err!(self.loc(ctx), DefUseVerifyErr::OperandNotUseOfDef)?;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -151,7 +151,12 @@ pub fn const_ret_in_mod(ctx: &mut Context) -> Result<(ModuleOp, FuncOp, Constant
     // Create a `const 0` op and add it to bb.
     let const_op = ConstantOp::new(ctx, 0);
     const_op.get_operation().insert_at_front(bb, ctx);
-    set_operation_result_name(ctx, const_op.get_operation(), 0, "c0".try_into().unwrap());
+    set_operation_result_name(
+        ctx,
+        const_op.get_operation(),
+        0,
+        Some("c0".try_into().unwrap()),
+    );
 
     // Return the constant.
     let ret_op = ReturnOp::new(ctx, const_op.get_result(ctx));

--- a/tests/dialect_conversion.rs
+++ b/tests/dialect_conversion.rs
@@ -410,7 +410,7 @@ fn dialect_conversion_block_arg_type_conversion() -> Result<()> {
     );
     let body = module.get_body(ctx, 0);
     let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed).into();
-    let arg_idx = body.deref_mut(ctx).add_argument(i64_ty);
+    let arg_idx = BasicBlock::add_argument(body, ctx, i64_ty);
     let block_arg = body.deref(ctx).get_argument(arg_idx);
 
     let consumer = ConsumerOp::new(ctx, block_arg);

--- a/tests/dialect_conversion.rs
+++ b/tests/dialect_conversion.rs
@@ -410,7 +410,7 @@ fn dialect_conversion_block_arg_type_conversion() -> Result<()> {
     );
     let body = module.get_body(ctx, 0);
     let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed).into();
-    let arg_idx = BasicBlock::add_argument(body, ctx, i64_ty);
+    let arg_idx = BasicBlock::push_argument(body, ctx, i64_ty);
     let block_arg = body.deref(ctx).get_argument(arg_idx);
 
     let consumer = ConsumerOp::new(ctx, block_arg);

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -919,7 +919,7 @@ fn test_outline_attr() -> Result<()> {
     let printed = op.get_operation().deref(ctx).disp(ctx).to_string();
 
     expect![[r#"
-        op1v1_res0 = test.constant builtin.integer <42: si64> !0
+        v0 = test.constant builtin.integer <42: si64> !0
 
         outlined_attributes:
         !0 = [test_attr = test.outline_test_attr <builtin.integer si32>]
@@ -988,10 +988,10 @@ fn test_outline_printonce_attr() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op5v1_res0 = test.constant builtin.integer <0: si64> !0;
-                op1v1_res0 = test.constant builtin.integer <42: si64> !1;
-                op2v1_res0 = test.constant builtin.integer <44: si64> !2;
-                test.return c0_op5v1_res0
+                c0_v2 = test.constant builtin.integer <0: si64> !0;
+                v0 = test.constant builtin.integer <42: si64> !1;
+                v1 = test.constant builtin.integer <44: si64> !2;
+                test.return c0_v2
             }
         }
 
@@ -1030,10 +1030,10 @@ fn test_outline_printonce_attr() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1_block3v1() !1:
-                c0_op9v1_res0 = test.constant builtin.integer <0: si64> !2;
-                op1v1_res0_op10v1_res0 = test.constant builtin.integer <42: si64> !3;
-                op2v1_res0_op11v1_res0 = test.constant builtin.integer <44: si64> !4;
-                test.return c0_op9v1_res0 !5
+                c0_v3 = test.constant builtin.integer <0: si64> !2;
+                v0_v4 = test.constant builtin.integer <42: si64> !3;
+                v1_v5 = test.constant builtin.integer <44: si64> !4;
+                test.return c0_v3 !5
             } !6
         } !7
 
@@ -1041,8 +1041,8 @@ fn test_outline_printonce_attr() -> Result<()> {
         !0 = @[<in-memory>: line: 3, column: 3], []
         !1 = @[<in-memory>: line: 6, column: 7], []
         !2 = @[<in-memory>: line: 7, column: 9], [builtin_debug_info = builtin.debug_info [c0]]
-        !3 = @["/tmp/test.pliron": line: 1, column: 1], [builtin_debug_info = builtin.debug_info [op1v1_res0], test_print_once_attr = !8]
-        !4 = @[<in-memory>: line: 9, column: 9], [builtin_debug_info = builtin.debug_info [op2v1_res0], test_print_once_attr = !8]
+        !3 = @["/tmp/test.pliron": line: 1, column: 1], [builtin_debug_info = builtin.debug_info [v0], test_print_once_attr = !8]
+        !4 = @[<in-memory>: line: 9, column: 9], [builtin_debug_info = builtin.debug_info [v1], test_print_once_attr = !8]
         !5 = @[<in-memory>: line: 10, column: 9], []
         !6 = @[<in-memory>: line: 4, column: 5], []
         !7 = @[<in-memory>: line: 1, column: 1], []
@@ -1124,8 +1124,8 @@ fn test_outline_attr_on_block() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1() !0:
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !1;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !1;
+                test.return c0_v0
             }
         }
 
@@ -1157,8 +1157,8 @@ fn test_outline_attr_on_block() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1_block3v1() !1:
-                c0_op7v1_res0 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_op7v1_res0 !3
+                c0_v1 = test.constant builtin.integer <0: si64> !2;
+                test.return c0_v1 !3
             } !4
         } !5
 

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -78,7 +78,12 @@ fn replace_c0_with_c1() -> Result<()> {
     const1_op
         .get_operation()
         .insert_after(ctx, const_op.get_operation());
-    set_operation_result_name(ctx, const1_op.get_operation(), 0, "c1".try_into().unwrap());
+    set_operation_result_name(
+        ctx,
+        const1_op.get_operation(),
+        0,
+        Some("c1".try_into().unwrap()),
+    );
     let const0_val = const_op.get_result(ctx);
     const0_val.replace_some_uses_with(ctx, |_, _| true, &const1_op.get_result(ctx));
 
@@ -103,7 +108,12 @@ fn replace_c0_with_c1_operand() -> Result<()> {
     const1_op
         .get_operation()
         .insert_after(ctx, const_op.get_operation());
-    set_operation_result_name(ctx, const1_op.get_operation(), 0, "c1".try_into().unwrap());
+    set_operation_result_name(
+        ctx,
+        const1_op.get_operation(),
+        0,
+        Some("c1".try_into().unwrap()),
+    );
 
     let printed = format!("{}", module_op.get_operation().disp(ctx));
     expect![[r#"
@@ -113,9 +123,9 @@ fn replace_c0_with_c1_operand() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                c1_op5v1_res0 = test.constant builtin.integer <1: si64> !1;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                c1_v1 = test.constant builtin.integer <1: si64> !1;
+                test.return c0_v0
             }
         }
 
@@ -136,8 +146,8 @@ fn replace_c0_with_c1_operand() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c1_op5v1_res0 = test.constant builtin.integer <1: si64> !0;
-                test.return c1_op5v1_res0
+                c1_v1 = test.constant builtin.integer <1: si64> !0;
+                test.return c1_v1
             }
         }
 
@@ -191,9 +201,9 @@ fn test_replace_within_same_def_site() {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op4v1_res0 = test.constant builtin.integer <0: si64> !0;
-                op1v1_res0, op1v1_res1 = test.dual_def () [] []: <() -> (builtin.integer si64, builtin.integer si64)>;
-                test.return op1v1_res1
+                c0_v2 = test.constant builtin.integer <0: si64> !0;
+                v0, v1 = test.dual_def () [] []: <() -> (builtin.integer si64, builtin.integer si64)>;
+                test.return v1
             }
         }
 
@@ -220,12 +230,12 @@ fn test_replace_within_same_def_site() {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op4v1_res0 = test.constant builtin.integer <0: si64> !0;
-                op1v1_res0, op1v1_res1 = test.dual_def () [] []: <() -> (builtin.integer si64, builtin.integer si64)>;
-                test.return op1v1_res1
+                c0_v2 = test.constant builtin.integer <0: si64> !0;
+                v0, v1 = test.dual_def () [] []: <() -> (builtin.integer si64, builtin.integer si64)>;
+                test.return v1
 
-              ^block3v1(block3v1_arg0: builtin.integer si64, block3v1_arg1: builtin.integer si64):
-                test.return block3v1_arg1
+              ^block3v1(v3: builtin.integer si64, v4: builtin.integer si64):
+                test.return v4
             }
         }
 
@@ -552,8 +562,8 @@ fn print_simple() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
             }
         }
 
@@ -622,8 +632,8 @@ fn parse_function_with_attrs() -> Result<()> {
               [test_on_func_value: builtin.string "func_attr_value"]
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
             }
         }
 
@@ -650,8 +660,8 @@ fn parse_function_with_attrs() -> Result<()> {
               [test_on_func_value: builtin.string "func_attr_value"]
             {
               ^entry_block2v1_block3v1() !1:
-                c0_op7v1_res0 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_op7v1_res0 !3
+                c0_v1 = test.constant builtin.integer <0: si64> !2;
+                test.return c0_v1 !3
             } !4
         } !5
 
@@ -810,8 +820,8 @@ fn test_preorder_forward_walk() {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
             }
         }
 
@@ -821,11 +831,11 @@ fn test_preorder_forward_walk() {
         builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
         {
           ^entry_block2v1():
-            c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-            test.return c0_op3v1_res0
+            c0_v0 = test.constant builtin.integer <0: si64> !0;
+            test.return c0_v0
         }
-        c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0
-        test.return c0_op3v1_res0
+        c0_v0 = test.constant builtin.integer <0: si64> !0
+        test.return c0_v0
     "#]]
     .assert_eq(&ops);
 
@@ -890,8 +900,8 @@ fn walker_print() {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
             }
         }
 
@@ -901,11 +911,11 @@ fn walker_print() {
         builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
         {
           ^entry_block2v1():
-            c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-            test.return c0_op3v1_res0
+            c0_v0 = test.constant builtin.integer <0: si64> !0;
+            test.return c0_v0
         }
-        c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0
-        test.return c0_op3v1_res0
+        c0_v0 = test.constant builtin.integer <0: si64> !0
+        test.return c0_v0
     "#]]
     .assert_eq(&printed);
 }
@@ -934,13 +944,13 @@ fn test_postorder_forward_walk() {
         accum + &op.disp(ctx).to_string() + "\n"
     });
     expect![[r#"
-        c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0
-        test.return c0_op3v1_res0
+        c0_v0 = test.constant builtin.integer <0: si64> !0
+        test.return c0_v0
         builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
         {
           ^entry_block2v1():
-            c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-            test.return c0_op3v1_res0
+            c0_v0 = test.constant builtin.integer <0: si64> !0;
+            test.return c0_v0
         }
         builtin.module @bar 
         {
@@ -948,8 +958,8 @@ fn test_postorder_forward_walk() {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
             }
         }
 
@@ -970,7 +980,12 @@ fn test_walker_find_op() {
     const1_op
         .get_operation()
         .insert_after(ctx, const_op.get_operation());
-    set_operation_result_name(ctx, const1_op.get_operation(), 0, "c1".try_into().unwrap());
+    set_operation_result_name(
+        ctx,
+        const1_op.get_operation(),
+        0,
+        Some("c1".try_into().unwrap()),
+    );
 
     // A function to breaks the walk when a [ConstantOp] is found.
     fn finder(ctx: &Context, _: &mut (), node: IRNode) -> interruptible::WalkResult<ConstantOp> {
@@ -1152,8 +1167,8 @@ fn block_inline_attrs_print() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1() [block_test_attr: builtin.string "test_value"]:
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
             }
         }"#]]
     .assert_eq(&printed);
@@ -1231,8 +1246,8 @@ fn block_multiple_inline_attrs() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1() [attr1: builtin.string "value1", attr2: builtin.string "value2"]:
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
             }
         }"#]]
     .assert_eq(&printed);
@@ -1278,8 +1293,8 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block_1_0_block1v1() [block_attr: builtin.string "hello"] !1:
-                c0_op_2_0_res0_op3v1_res0 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_op_2_0_res0_op3v1_res0 !3
+                c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;
+                test.return c0_op_2_0_res0_v0 !3
             } !4
         } !5
 
@@ -1315,8 +1330,8 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block_1_0_block1v1_block1v1() [block_attr: builtin.string "hello"] !1:
-                c0_op_2_0_res0_op3v1_res0 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_op_2_0_res0_op3v1_res0 !3
+                c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;
+                test.return c0_op_2_0_res0_v0 !3
             } !4
         } !5
 

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -277,11 +277,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c1);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -292,7 +292,7 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert!(c1.uses(ctx).is_empty()); // c1 should have no uses now.
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -302,11 +302,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c0);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
     }
     verify_op(&module_op, ctx)?;
 
@@ -317,15 +317,15 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(2), c2);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 2);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 2);
     }
 
     verify_op(&module_op, ctx)?;
@@ -337,11 +337,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c2);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
     }
     verify_op(&module_op, ctx)?;
 
@@ -351,7 +351,7 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(0), c2);
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -362,7 +362,7 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
         assert!(r#use.get_def(ctx) == c2);
         // c2 should now have two uses.
         assert!(
-            r#use.user_op == ret_ptr && (r#use.get_index(ctx) == 0 || r#use.get_index(ctx) == 1)
+            r#use.user_op == ret_ptr && (r#use.find_index(ctx) == 0 || r#use.find_index(ctx) == 1)
         );
     }
 
@@ -373,13 +373,13 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
         // c0 should now have one use.
-        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
         // c2 should still have two uses.
         assert!(
-            r#use.user_op == ret_ptr && (r#use.get_index(ctx) == 0 || r#use.get_index(ctx) == 2)
+            r#use.user_op == ret_ptr && (r#use.find_index(ctx) == 0 || r#use.find_index(ctx) == 2)
         );
     }
 
@@ -408,8 +408,8 @@ fn test_result_push_pop_insert_remove() -> Result<()> {
     let r1 = op.deref(ctx).get_result(1);
 
     assert_eq!(op.deref(ctx).get_num_results(), 2);
-    assert_eq!(r0.get_index(ctx), 0);
-    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(r0.find_index(ctx), 0);
+    assert_eq!(r1.find_index(ctx), 1);
     assert_eq!(op.deref(ctx).get_type(0), i64_ty);
     assert_eq!(op.deref(ctx).get_type(1), i64_ty);
 
@@ -418,56 +418,56 @@ fn test_result_push_pop_insert_remove() -> Result<()> {
     assert_eq!(pushed_idx, 2);
     assert_eq!(op.deref(ctx).get_num_results(), 3);
     // r0 and r1 still have the same indices.
-    assert_eq!(r0.get_index(ctx), 0);
-    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(r0.find_index(ctx), 0);
+    assert_eq!(r1.find_index(ctx), 1);
     let r2 = op.deref(ctx).get_result(2);
-    assert_eq!(r2.get_index(ctx), 2);
+    assert_eq!(r2.find_index(ctx), 2);
     assert_eq!(op.deref(ctx).get_type(2), i32_ty);
 
     // Pop the last result (r2 has no uses).
     Operation::pop_result(op, ctx);
     assert_eq!(op.deref(ctx).get_num_results(), 2);
-    assert_eq!(r0.get_index(ctx), 0);
-    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(r0.find_index(ctx), 0);
+    assert_eq!(r1.find_index(ctx), 1);
 
     // Insert an i32 result at index 0, shifting r0 -> 1 and r1 -> 2.
     Operation::insert_result(op, ctx, 0, i32_ty);
     assert_eq!(op.deref(ctx).get_num_results(), 3);
     assert_eq!(op.deref(ctx).get_type(0), i32_ty);
-    assert_eq!(r0.get_index(ctx), 1);
-    assert_eq!(r1.get_index(ctx), 2);
+    assert_eq!(r0.find_index(ctx), 1);
+    assert_eq!(r1.find_index(ctx), 2);
 
     // Remove index 0 (the freshly inserted i32, which has no uses).
     Operation::remove_result(op, ctx, 0);
     assert_eq!(op.deref(ctx).get_num_results(), 2);
-    assert_eq!(r0.get_index(ctx), 0);
-    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(r0.find_index(ctx), 0);
+    assert_eq!(r1.find_index(ctx), 1);
 
     // Insert an i32 result at index 1 (between r0 and r1), shifting r1 -> 2.
     Operation::insert_result(op, ctx, 1, i32_ty);
     assert_eq!(op.deref(ctx).get_num_results(), 3);
-    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r0.find_index(ctx), 0);
     assert_eq!(op.deref(ctx).get_type(1), i32_ty);
-    assert_eq!(r1.get_index(ctx), 2);
+    assert_eq!(r1.find_index(ctx), 2);
 
     // Remove index 1 (no uses), shifting r1 back to 1.
     Operation::remove_result(op, ctx, 1);
     assert_eq!(op.deref(ctx).get_num_results(), 2);
-    assert_eq!(r0.get_index(ctx), 0);
-    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(r0.find_index(ctx), 0);
+    assert_eq!(r1.find_index(ctx), 1);
 
     // Insert at the end (index 2).
     Operation::insert_result(op, ctx, 2, i32_ty);
     assert_eq!(op.deref(ctx).get_num_results(), 3);
-    assert_eq!(r0.get_index(ctx), 0);
-    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(r0.find_index(ctx), 0);
+    assert_eq!(r1.find_index(ctx), 1);
     assert_eq!(op.deref(ctx).get_type(2), i32_ty);
 
     // Remove from the end.
     Operation::remove_result(op, ctx, 2);
     assert_eq!(op.deref(ctx).get_num_results(), 2);
-    assert_eq!(r0.get_index(ctx), 0);
-    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(r0.find_index(ctx), 0);
+    assert_eq!(r1.find_index(ctx), 1);
 
     Ok(())
 }
@@ -487,60 +487,60 @@ fn test_block_arg_push_pop_insert_remove() -> Result<()> {
     let a1 = block.deref(ctx).get_argument(1);
 
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 1);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 1);
 
     // Push a new i32 argument at the end.
     let pushed_idx = BasicBlock::push_argument(block, ctx, i32_ty);
     assert_eq!(pushed_idx, 2);
     assert_eq!(block.deref(ctx).get_num_arguments(), 3);
     // a0 and a1 retain their indices.
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 1);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 1);
     let a2 = block.deref(ctx).get_argument(2);
-    assert_eq!(a2.get_index(ctx), 2);
+    assert_eq!(a2.find_index(ctx), 2);
 
     // Pop the last argument (a2 has no uses).
     BasicBlock::pop_argument(block, ctx);
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 1);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 1);
 
     // Insert an i32 argument at index 0, shifting a0 -> 1 and a1 -> 2.
     BasicBlock::insert_argument(block, ctx, 0, i32_ty);
     assert_eq!(block.deref(ctx).get_num_arguments(), 3);
-    assert_eq!(a0.get_index(ctx), 1);
-    assert_eq!(a1.get_index(ctx), 2);
+    assert_eq!(a0.find_index(ctx), 1);
+    assert_eq!(a1.find_index(ctx), 2);
 
     // Remove index 0 (no uses), restoring a0 -> 0 and a1 -> 1.
     BasicBlock::remove_argument(block, ctx, 0);
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 1);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 1);
 
     // Insert an i32 argument at index 1 (between a0 and a1), shifting a1 -> 2.
     BasicBlock::insert_argument(block, ctx, 1, i32_ty);
     assert_eq!(block.deref(ctx).get_num_arguments(), 3);
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 2);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 2);
 
     // Remove index 1 (no uses), shifting a1 back to 1.
     BasicBlock::remove_argument(block, ctx, 1);
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 1);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 1);
 
     // Insert at the end (index 2).
     BasicBlock::insert_argument(block, ctx, 2, i32_ty);
     assert_eq!(block.deref(ctx).get_num_arguments(), 3);
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 1);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 1);
 
     // Remove from the end.
     BasicBlock::remove_argument(block, ctx, 2);
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
-    assert_eq!(a0.get_index(ctx), 0);
-    assert_eq!(a1.get_index(ctx), 1);
+    assert_eq!(a0.find_index(ctx), 0);
+    assert_eq!(a1.find_index(ctx), 1);
 
     Ok(())
 }
@@ -576,43 +576,43 @@ fn test_result_index_tracking_with_uses() -> Result<()> {
     // Sanity: operands are r0 and r1; their result indices are 0 and 1.
     assert_eq!(user_op.deref(ctx).get_operand(0), r0);
     assert_eq!(user_op.deref(ctx).get_operand(1), r1);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Insert a new i32 result at index 0 of dual_op, shifting r0 -> 1 and r1 -> 2.
     Operation::insert_result(dual_op, ctx, 0, i32_ty);
     assert_eq!(dual_op.deref(ctx).get_num_results(), 3);
     assert_eq!(user_op.deref(ctx).get_operand(0), r0);
     assert_eq!(user_op.deref(ctx).get_operand(1), r1);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 1);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 2);
 
     // Remove the new result at index 0, restoring r0 -> 0 and r1 -> 1.
     Operation::remove_result(dual_op, ctx, 0);
     assert_eq!(dual_op.deref(ctx).get_num_results(), 2);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Insert a new result between r0 and r1 (at index 1), shifting r1 -> 2.
     Operation::insert_result(dual_op, ctx, 1, i32_ty);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 2);
 
     // Remove at index 1, restoring r1 -> 1.
     Operation::remove_result(dual_op, ctx, 1);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Push a result at the end (after r1); r0 and r1 indices are unchanged.
     let pushed_idx = Operation::push_result(dual_op, ctx, i32_ty);
     assert_eq!(pushed_idx, 2);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Pop the trailing result; indices still unchanged.
     Operation::pop_result(dual_op, ctx);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     Ok(())
 }
@@ -641,43 +641,43 @@ fn test_block_arg_index_tracking_with_uses() -> Result<()> {
     // Sanity: operands are a0 and a1; their argument indices are 0 and 1.
     assert_eq!(user_op.deref(ctx).get_operand(0), a0);
     assert_eq!(user_op.deref(ctx).get_operand(1), a1);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Insert a new i32 argument at index 0, shifting a0 -> 1 and a1 -> 2.
     BasicBlock::insert_argument(block, ctx, 0, i32_ty);
     assert_eq!(block.deref(ctx).get_num_arguments(), 3);
     assert_eq!(user_op.deref(ctx).get_operand(0), a0);
     assert_eq!(user_op.deref(ctx).get_operand(1), a1);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 1);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 2);
 
     // Remove the new argument at index 0, restoring a0 -> 0 and a1 -> 1.
     BasicBlock::remove_argument(block, ctx, 0);
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Insert a new argument between a0 and a1 (at index 1), shifting a1 -> 2.
     BasicBlock::insert_argument(block, ctx, 1, i32_ty);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 2);
 
     // Remove at index 1, restoring a1 -> 1.
     BasicBlock::remove_argument(block, ctx, 1);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Push an argument at the end (after a1); a0 and a1 indices are unchanged.
     let pushed_idx = BasicBlock::push_argument(block, ctx, i32_ty);
     assert_eq!(pushed_idx, 2);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     // Pop the trailing argument; indices still unchanged.
     BasicBlock::pop_argument(block, ctx);
-    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
-    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).find_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).find_index(ctx), 1);
 
     Ok(())
 }

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -18,7 +18,10 @@ use pliron::{
         types::{IntegerType, Signedness},
     },
     context::Context,
-    debug_info::set_operation_result_name,
+    debug_info::{
+        get_block_arg_name, get_operation_result_name, set_block_arg_name,
+        set_operation_result_name,
+    },
     graph::walkers::{
         self, IRNode, WALKCONFIG_POSTORDER_FORWARD, WALKCONFIG_POSTORDER_REVERSE,
         WALKCONFIG_PREORDER_FORWARD,
@@ -407,11 +410,22 @@ fn test_result_push_pop_insert_remove() -> Result<()> {
     let r0 = op.deref(ctx).get_result(0);
     let r1 = op.deref(ctx).get_result(1);
 
+    set_operation_result_name(ctx, op, 0, Some("r0".try_into().unwrap()));
+    set_operation_result_name(ctx, op, 1, Some("r1".try_into().unwrap()));
+
     assert_eq!(op.deref(ctx).get_num_results(), 2);
     assert_eq!(r0.find_index(ctx), 0);
     assert_eq!(r1.find_index(ctx), 1);
     assert_eq!(op.deref(ctx).get_type(0), i64_ty);
     assert_eq!(op.deref(ctx).get_type(1), i64_ty);
+    assert_eq!(
+        get_operation_result_name(ctx, op, 0),
+        Some("r0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_operation_result_name(ctx, op, 1),
+        Some("r1".try_into().unwrap())
+    );
 
     // Push a new i32 result at the end.
     let pushed_idx = Operation::push_result(op, ctx, i32_ty);
@@ -423,12 +437,21 @@ fn test_result_push_pop_insert_remove() -> Result<()> {
     let r2 = op.deref(ctx).get_result(2);
     assert_eq!(r2.find_index(ctx), 2);
     assert_eq!(op.deref(ctx).get_type(2), i32_ty);
+    assert_eq!(get_operation_result_name(ctx, op, 2), None);
 
     // Pop the last result (r2 has no uses).
     Operation::pop_result(op, ctx);
     assert_eq!(op.deref(ctx).get_num_results(), 2);
     assert_eq!(r0.find_index(ctx), 0);
     assert_eq!(r1.find_index(ctx), 1);
+    assert_eq!(
+        get_operation_result_name(ctx, op, 0),
+        Some("r0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_operation_result_name(ctx, op, 1),
+        Some("r1".try_into().unwrap())
+    );
 
     // Insert an i32 result at index 0, shifting r0 -> 1 and r1 -> 2.
     Operation::insert_result(op, ctx, 0, i32_ty);
@@ -436,12 +459,29 @@ fn test_result_push_pop_insert_remove() -> Result<()> {
     assert_eq!(op.deref(ctx).get_type(0), i32_ty);
     assert_eq!(r0.find_index(ctx), 1);
     assert_eq!(r1.find_index(ctx), 2);
+    assert_eq!(get_operation_result_name(ctx, op, 0), None);
+    assert_eq!(
+        get_operation_result_name(ctx, op, 1),
+        Some("r0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_operation_result_name(ctx, op, 2),
+        Some("r1".try_into().unwrap())
+    );
 
     // Remove index 0 (the freshly inserted i32, which has no uses).
     Operation::remove_result(op, ctx, 0);
     assert_eq!(op.deref(ctx).get_num_results(), 2);
     assert_eq!(r0.find_index(ctx), 0);
     assert_eq!(r1.find_index(ctx), 1);
+    assert_eq!(
+        get_operation_result_name(ctx, op, 0),
+        Some("r0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_operation_result_name(ctx, op, 1),
+        Some("r1".try_into().unwrap())
+    );
 
     // Insert an i32 result at index 1 (between r0 and r1), shifting r1 -> 2.
     Operation::insert_result(op, ctx, 1, i32_ty);
@@ -462,12 +502,29 @@ fn test_result_push_pop_insert_remove() -> Result<()> {
     assert_eq!(r0.find_index(ctx), 0);
     assert_eq!(r1.find_index(ctx), 1);
     assert_eq!(op.deref(ctx).get_type(2), i32_ty);
+    assert_eq!(
+        get_operation_result_name(ctx, op, 0),
+        Some("r0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_operation_result_name(ctx, op, 1),
+        Some("r1".try_into().unwrap())
+    );
+    assert_eq!(get_operation_result_name(ctx, op, 2), None);
 
     // Remove from the end.
     Operation::remove_result(op, ctx, 2);
     assert_eq!(op.deref(ctx).get_num_results(), 2);
     assert_eq!(r0.find_index(ctx), 0);
     assert_eq!(r1.find_index(ctx), 1);
+    assert_eq!(
+        get_operation_result_name(ctx, op, 0),
+        Some("r0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_operation_result_name(ctx, op, 1),
+        Some("r1".try_into().unwrap())
+    );
 
     Ok(())
 }
@@ -486,9 +543,20 @@ fn test_block_arg_push_pop_insert_remove() -> Result<()> {
     let a0 = block.deref(ctx).get_argument(0);
     let a1 = block.deref(ctx).get_argument(1);
 
+    set_block_arg_name(ctx, block, 0, Some("a0".try_into().unwrap()));
+    set_block_arg_name(ctx, block, 1, Some("a1".try_into().unwrap()));
+
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
     assert_eq!(a0.find_index(ctx), 0);
     assert_eq!(a1.find_index(ctx), 1);
+    assert_eq!(
+        get_block_arg_name(ctx, block, 0),
+        Some("a0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_block_arg_name(ctx, block, 1),
+        Some("a1".try_into().unwrap())
+    );
 
     // Push a new i32 argument at the end.
     let pushed_idx = BasicBlock::push_argument(block, ctx, i32_ty);
@@ -499,6 +567,7 @@ fn test_block_arg_push_pop_insert_remove() -> Result<()> {
     assert_eq!(a1.find_index(ctx), 1);
     let a2 = block.deref(ctx).get_argument(2);
     assert_eq!(a2.find_index(ctx), 2);
+    assert_eq!(get_block_arg_name(ctx, block, 2), None);
 
     // Pop the last argument (a2 has no uses).
     BasicBlock::pop_argument(block, ctx);
@@ -511,12 +580,29 @@ fn test_block_arg_push_pop_insert_remove() -> Result<()> {
     assert_eq!(block.deref(ctx).get_num_arguments(), 3);
     assert_eq!(a0.find_index(ctx), 1);
     assert_eq!(a1.find_index(ctx), 2);
+    assert_eq!(get_block_arg_name(ctx, block, 0), None);
+    assert_eq!(
+        get_block_arg_name(ctx, block, 1),
+        Some("a0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_block_arg_name(ctx, block, 2),
+        Some("a1".try_into().unwrap())
+    );
 
     // Remove index 0 (no uses), restoring a0 -> 0 and a1 -> 1.
     BasicBlock::remove_argument(block, ctx, 0);
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
     assert_eq!(a0.find_index(ctx), 0);
     assert_eq!(a1.find_index(ctx), 1);
+    assert_eq!(
+        get_block_arg_name(ctx, block, 0),
+        Some("a0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_block_arg_name(ctx, block, 1),
+        Some("a1".try_into().unwrap())
+    );
 
     // Insert an i32 argument at index 1 (between a0 and a1), shifting a1 -> 2.
     BasicBlock::insert_argument(block, ctx, 1, i32_ty);
@@ -535,12 +621,29 @@ fn test_block_arg_push_pop_insert_remove() -> Result<()> {
     assert_eq!(block.deref(ctx).get_num_arguments(), 3);
     assert_eq!(a0.find_index(ctx), 0);
     assert_eq!(a1.find_index(ctx), 1);
+    assert_eq!(
+        get_block_arg_name(ctx, block, 0),
+        Some("a0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_block_arg_name(ctx, block, 1),
+        Some("a1".try_into().unwrap())
+    );
+    assert_eq!(get_block_arg_name(ctx, block, 2), None);
 
     // Remove from the end.
     BasicBlock::remove_argument(block, ctx, 2);
     assert_eq!(block.deref(ctx).get_num_arguments(), 2);
     assert_eq!(a0.find_index(ctx), 0);
     assert_eq!(a1.find_index(ctx), 1);
+    assert_eq!(
+        get_block_arg_name(ctx, block, 0),
+        Some("a0".try_into().unwrap())
+    );
+    assert_eq!(
+        get_block_arg_name(ctx, block, 1),
+        Some("a1".try_into().unwrap())
+    );
 
     Ok(())
 }

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -7,6 +7,7 @@ use pliron::derive::pliron_op;
 use pliron::dict_key;
 use pliron::op::verify_op;
 use pliron::operation::{DefUseVerifyErr, verify_operation};
+use pliron::r#type::TypeObj;
 use pliron::{
     basic_block::BasicBlock,
     builtin::{
@@ -381,6 +382,302 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
             r#use.user_op == ret_ptr && (r#use.get_index(ctx) == 0 || r#use.get_index(ctx) == 2)
         );
     }
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn test_result_push_pop_insert_remove() -> Result<()> {
+    let ctx = &mut Context::new();
+
+    let i64_ty: Ptr<TypeObj> = IntegerType::get(ctx, 64, Signedness::Signed).into();
+    let i32_ty: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Signed).into();
+
+    // Create a DualDefOp with two i64 results.
+    let op = Operation::new(
+        ctx,
+        DualDefOp::get_concrete_op_info(),
+        vec![i64_ty, i64_ty],
+        vec![],
+        vec![],
+        0,
+    );
+
+    let r0 = op.deref(ctx).get_result(0);
+    let r1 = op.deref(ctx).get_result(1);
+
+    assert_eq!(op.deref(ctx).get_num_results(), 2);
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(op.deref(ctx).get_type(0), i64_ty);
+    assert_eq!(op.deref(ctx).get_type(1), i64_ty);
+
+    // Push a new i32 result at the end.
+    let pushed_idx = Operation::push_result(op, ctx, i32_ty);
+    assert_eq!(pushed_idx, 2);
+    assert_eq!(op.deref(ctx).get_num_results(), 3);
+    // r0 and r1 still have the same indices.
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r1.get_index(ctx), 1);
+    let r2 = op.deref(ctx).get_result(2);
+    assert_eq!(r2.get_index(ctx), 2);
+    assert_eq!(op.deref(ctx).get_type(2), i32_ty);
+
+    // Pop the last result (r2 has no uses).
+    Operation::pop_result(op, ctx);
+    assert_eq!(op.deref(ctx).get_num_results(), 2);
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r1.get_index(ctx), 1);
+
+    // Insert an i32 result at index 0, shifting r0 -> 1 and r1 -> 2.
+    Operation::insert_result(op, ctx, 0, i32_ty);
+    assert_eq!(op.deref(ctx).get_num_results(), 3);
+    assert_eq!(op.deref(ctx).get_type(0), i32_ty);
+    assert_eq!(r0.get_index(ctx), 1);
+    assert_eq!(r1.get_index(ctx), 2);
+
+    // Remove index 0 (the freshly inserted i32, which has no uses).
+    Operation::remove_result(op, ctx, 0);
+    assert_eq!(op.deref(ctx).get_num_results(), 2);
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r1.get_index(ctx), 1);
+
+    // Insert an i32 result at index 1 (between r0 and r1), shifting r1 -> 2.
+    Operation::insert_result(op, ctx, 1, i32_ty);
+    assert_eq!(op.deref(ctx).get_num_results(), 3);
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(op.deref(ctx).get_type(1), i32_ty);
+    assert_eq!(r1.get_index(ctx), 2);
+
+    // Remove index 1 (no uses), shifting r1 back to 1.
+    Operation::remove_result(op, ctx, 1);
+    assert_eq!(op.deref(ctx).get_num_results(), 2);
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r1.get_index(ctx), 1);
+
+    // Insert at the end (index 2).
+    Operation::insert_result(op, ctx, 2, i32_ty);
+    assert_eq!(op.deref(ctx).get_num_results(), 3);
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r1.get_index(ctx), 1);
+    assert_eq!(op.deref(ctx).get_type(2), i32_ty);
+
+    // Remove from the end.
+    Operation::remove_result(op, ctx, 2);
+    assert_eq!(op.deref(ctx).get_num_results(), 2);
+    assert_eq!(r0.get_index(ctx), 0);
+    assert_eq!(r1.get_index(ctx), 1);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn test_block_arg_push_pop_insert_remove() -> Result<()> {
+    let ctx = &mut Context::new();
+
+    let i64_ty: Ptr<TypeObj> = IntegerType::get(ctx, 64, Signedness::Signed).into();
+    let i32_ty: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Signed).into();
+
+    // Create a block with two i64 arguments.
+    let block = BasicBlock::new(ctx, None, vec![i64_ty, i64_ty]);
+
+    let a0 = block.deref(ctx).get_argument(0);
+    let a1 = block.deref(ctx).get_argument(1);
+
+    assert_eq!(block.deref(ctx).get_num_arguments(), 2);
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 1);
+
+    // Push a new i32 argument at the end.
+    let pushed_idx = BasicBlock::push_argument(block, ctx, i32_ty);
+    assert_eq!(pushed_idx, 2);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 3);
+    // a0 and a1 retain their indices.
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 1);
+    let a2 = block.deref(ctx).get_argument(2);
+    assert_eq!(a2.get_index(ctx), 2);
+
+    // Pop the last argument (a2 has no uses).
+    BasicBlock::pop_argument(block, ctx);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 2);
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 1);
+
+    // Insert an i32 argument at index 0, shifting a0 -> 1 and a1 -> 2.
+    BasicBlock::insert_argument(block, ctx, 0, i32_ty);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 3);
+    assert_eq!(a0.get_index(ctx), 1);
+    assert_eq!(a1.get_index(ctx), 2);
+
+    // Remove index 0 (no uses), restoring a0 -> 0 and a1 -> 1.
+    BasicBlock::remove_argument(block, ctx, 0);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 2);
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 1);
+
+    // Insert an i32 argument at index 1 (between a0 and a1), shifting a1 -> 2.
+    BasicBlock::insert_argument(block, ctx, 1, i32_ty);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 3);
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 2);
+
+    // Remove index 1 (no uses), shifting a1 back to 1.
+    BasicBlock::remove_argument(block, ctx, 1);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 2);
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 1);
+
+    // Insert at the end (index 2).
+    BasicBlock::insert_argument(block, ctx, 2, i32_ty);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 3);
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 1);
+
+    // Remove from the end.
+    BasicBlock::remove_argument(block, ctx, 2);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 2);
+    assert_eq!(a0.get_index(ctx), 0);
+    assert_eq!(a1.get_index(ctx), 1);
+
+    Ok(())
+}
+
+/// Tests that `Value` objects held as operands correctly track their
+/// index within the defining operation's result list when results are
+/// inserted, removed, pushed, or popped ahead of / behind them.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn test_result_index_tracking_with_uses() -> Result<()> {
+    let ctx = &mut Context::new();
+
+    let i64_ty: Ptr<TypeObj> = IntegerType::get(ctx, 64, Signedness::Signed).into();
+    let i32_ty: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Signed).into();
+
+    // Create a DualDefOp with two i64 results: r0 at index 0, r1 at index 1.
+    let dual_op = Operation::new(
+        ctx,
+        DualDefOp::get_concrete_op_info(),
+        vec![i64_ty, i64_ty],
+        vec![],
+        vec![],
+        0,
+    );
+
+    let r0 = dual_op.deref(ctx).get_result(0);
+    let r1 = dual_op.deref(ctx).get_result(1);
+
+    // Build a user op that holds r0 as its first operand, r1 as its second.
+    let user_op = ReturnOp::new(ctx, r0).get_operation();
+    Operation::push_operand(user_op, ctx, r1);
+
+    // Sanity: operands are r0 and r1; their result indices are 0 and 1.
+    assert_eq!(user_op.deref(ctx).get_operand(0), r0);
+    assert_eq!(user_op.deref(ctx).get_operand(1), r1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Insert a new i32 result at index 0 of dual_op, shifting r0 -> 1 and r1 -> 2.
+    Operation::insert_result(dual_op, ctx, 0, i32_ty);
+    assert_eq!(dual_op.deref(ctx).get_num_results(), 3);
+    assert_eq!(user_op.deref(ctx).get_operand(0), r0);
+    assert_eq!(user_op.deref(ctx).get_operand(1), r1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+
+    // Remove the new result at index 0, restoring r0 -> 0 and r1 -> 1.
+    Operation::remove_result(dual_op, ctx, 0);
+    assert_eq!(dual_op.deref(ctx).get_num_results(), 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Insert a new result between r0 and r1 (at index 1), shifting r1 -> 2.
+    Operation::insert_result(dual_op, ctx, 1, i32_ty);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+
+    // Remove at index 1, restoring r1 -> 1.
+    Operation::remove_result(dual_op, ctx, 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Push a result at the end (after r1); r0 and r1 indices are unchanged.
+    let pushed_idx = Operation::push_result(dual_op, ctx, i32_ty);
+    assert_eq!(pushed_idx, 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Pop the trailing result; indices still unchanged.
+    Operation::pop_result(dual_op, ctx);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    Ok(())
+}
+
+/// Tests that `Value` objects held as operands correctly track their
+/// index within the defining block's argument list when arguments are
+/// inserted, removed, pushed, or popped ahead of / behind them.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn test_block_arg_index_tracking_with_uses() -> Result<()> {
+    let ctx = &mut Context::new();
+
+    let i64_ty: Ptr<TypeObj> = IntegerType::get(ctx, 64, Signedness::Signed).into();
+    let i32_ty: Ptr<TypeObj> = IntegerType::get(ctx, 32, Signedness::Signed).into();
+
+    // Create a block with two i64 arguments: a0 at index 0, a1 at index 1.
+    let block = BasicBlock::new(ctx, None, vec![i64_ty, i64_ty]);
+
+    let a0 = block.deref(ctx).get_argument(0);
+    let a1 = block.deref(ctx).get_argument(1);
+
+    // Build a user op that holds a0 as its first operand, a1 as its second.
+    let user_op = ReturnOp::new(ctx, a0).get_operation();
+    Operation::push_operand(user_op, ctx, a1);
+
+    // Sanity: operands are a0 and a1; their argument indices are 0 and 1.
+    assert_eq!(user_op.deref(ctx).get_operand(0), a0);
+    assert_eq!(user_op.deref(ctx).get_operand(1), a1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Insert a new i32 argument at index 0, shifting a0 -> 1 and a1 -> 2.
+    BasicBlock::insert_argument(block, ctx, 0, i32_ty);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 3);
+    assert_eq!(user_op.deref(ctx).get_operand(0), a0);
+    assert_eq!(user_op.deref(ctx).get_operand(1), a1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 1);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+
+    // Remove the new argument at index 0, restoring a0 -> 0 and a1 -> 1.
+    BasicBlock::remove_argument(block, ctx, 0);
+    assert_eq!(block.deref(ctx).get_num_arguments(), 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Insert a new argument between a0 and a1 (at index 1), shifting a1 -> 2.
+    BasicBlock::insert_argument(block, ctx, 1, i32_ty);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 2);
+
+    // Remove at index 1, restoring a1 -> 1.
+    BasicBlock::remove_argument(block, ctx, 1);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Push an argument at the end (after a1); a0 and a1 indices are unchanged.
+    let pushed_idx = BasicBlock::push_argument(block, ctx, i32_ty);
+    assert_eq!(pushed_idx, 2);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
+
+    // Pop the trailing argument; indices still unchanged.
+    BasicBlock::pop_argument(block, ctx);
+    assert_eq!(user_op.deref(ctx).get_operand(0).get_index(ctx), 0);
+    assert_eq!(user_op.deref(ctx).get_operand(1).get_index(ctx), 1);
 
     Ok(())
 }

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -276,11 +276,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c1);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -291,7 +291,7 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert!(c1.uses(ctx).is_empty()); // c1 should have no uses now.
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -301,11 +301,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c0);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
     }
     verify_op(&module_op, ctx)?;
 
@@ -316,15 +316,15 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(2), c2);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 2);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 2);
     }
 
     verify_op(&module_op, ctx)?;
@@ -336,11 +336,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c2);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
     }
     verify_op(&module_op, ctx)?;
 
@@ -350,7 +350,7 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(0), c2);
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 0);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -360,7 +360,9 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
         // c2 should now have two uses.
-        assert!(r#use.user_op == ret_ptr && (r#use.opd_idx == 0 || r#use.opd_idx == 1));
+        assert!(
+            r#use.user_op == ret_ptr && (r#use.get_index(ctx) == 0 || r#use.get_index(ctx) == 1)
+        );
     }
 
     // Add c0 now
@@ -370,12 +372,14 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
         // c0 should now have one use.
-        assert!(r#use.user_op == ret_ptr && r#use.opd_idx == 1);
+        assert!(r#use.user_op == ret_ptr && r#use.get_index(ctx) == 1);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
         // c2 should still have two uses.
-        assert!(r#use.user_op == ret_ptr && (r#use.opd_idx == 0 || r#use.opd_idx == 2));
+        assert!(
+            r#use.user_op == ret_ptr && (r#use.get_index(ctx) == 0 || r#use.get_index(ctx) == 2)
+        );
     }
 
     Ok(())

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -280,11 +280,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c1);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 1);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -295,7 +295,7 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert!(c1.uses(ctx).is_empty()); // c1 should have no uses now.
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -305,11 +305,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c0);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 0);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 1);
     }
     verify_op(&module_op, ctx)?;
 
@@ -320,15 +320,15 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(2), c2);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 0);
     }
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 1);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 2);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 2);
     }
 
     verify_op(&module_op, ctx)?;
@@ -340,11 +340,11 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(1), c2);
     for r#use in c1.uses(ctx) {
         assert!(r#use.get_def(ctx) == c1);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 0);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 1);
     }
     verify_op(&module_op, ctx)?;
 
@@ -354,7 +354,7 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     assert_eq!(ret_ptr.deref(ctx).get_operand(0), c2);
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 0);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 0);
     }
     verify_op(&module_op, ctx)?;
 
@@ -365,7 +365,8 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
         assert!(r#use.get_def(ctx) == c2);
         // c2 should now have two uses.
         assert!(
-            r#use.user_op == ret_ptr && (r#use.find_index(ctx) == 0 || r#use.find_index(ctx) == 1)
+            r#use.user_op() == ret_ptr
+                && (r#use.find_index(ctx) == 0 || r#use.find_index(ctx) == 1)
         );
     }
 
@@ -376,13 +377,14 @@ fn test_operand_push_pop_insert_remove() -> Result<()> {
     for r#use in c0.uses(ctx) {
         assert!(r#use.get_def(ctx) == c0);
         // c0 should now have one use.
-        assert!(r#use.user_op == ret_ptr && r#use.find_index(ctx) == 1);
+        assert!(r#use.user_op() == ret_ptr && r#use.find_index(ctx) == 1);
     }
     for r#use in c2.uses(ctx) {
         assert!(r#use.get_def(ctx) == c2);
         // c2 should still have two uses.
         assert!(
-            r#use.user_op == ret_ptr && (r#use.find_index(ctx) == 0 || r#use.find_index(ctx) == 2)
+            r#use.user_op() == ret_ptr
+                && (r#use.find_index(ctx) == 0 || r#use.find_index(ctx) == 2)
         );
     }
 

--- a/tests/rewriter.rs
+++ b/tests/rewriter.rs
@@ -104,8 +104,8 @@ fn replace_c0_with_c1() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                op3v3_res0 = test.constant builtin.integer <2: si64>;
-                test.return op3v3_res0
+                v2 = test.constant builtin.integer <2: si64>;
+                test.return v2
             }
         }"#]]
     .assert_eq(&printed);
@@ -236,12 +236,12 @@ fn scoped_rewriter_test() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            op5v1_res0 = test.global () [] [test_global_op_const_val: builtin.integer <0: si64>, sym_name: builtin.identifier global_0]: <() -> (test.ptr )>;
+            v1 = test.global () [] [test_global_op_const_val: builtin.integer <0: si64>, sym_name: builtin.identifier global_0]: <() -> (test.ptr )>;
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                op6v1_res0 = test.load op5v1_res0 ;
-                test.return op6v1_res0
+                v2 = test.load v1 ;
+                test.return v2
             }
         }"#]].assert_eq(&printed);
 
@@ -364,12 +364,12 @@ fn split_block_after_const_zero() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
 
               ^entry_split_block3v1():
-                op5v1_res0 = test.constant builtin.integer <1: si64>;
-                test.return op5v1_res0
+                v1 = test.constant builtin.integer <1: si64>;
+                test.return v1
             }
         }"#]]
     .assert_eq(&printed);
@@ -434,12 +434,12 @@ fn inline_region_on_const_zero() -> Result<()> {
             builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
             {
               ^entry_block2v1():
-                c0_op3v1_res0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_op3v1_res0
+                c0_v0 = test.constant builtin.integer <0: si64> !0;
+                test.return c0_v0
 
               ^entry_block4v1():
-                c0_op7v1_res0 = test.constant builtin.integer <0: si64> !1;
-                test.return c0_op7v1_res0
+                c0_v1 = test.constant builtin.integer <0: si64> !1;
+                test.return c0_v1
             }
         }"#]]
     .assert_eq(&printed);


### PR DESCRIPTION
We did not (so far) have methods to insert/remove results into/from an op or args into/from a block. This was because, for example, adding a new result to an op, at a non-last position, would affect any `Value` that referred to the consequently moved results. The `Value` which stored the `def_op` and `idx` would end up referring to the wrong definition (than what it's supposed to refer to). Similarly with an existing `Use`, which stored `user_op` and `idx` would refer to the wrong operand if we inserted operands anywhere but at the end.

The problem rooted from `Value` and `Use` saving indices. We solve this problem by having a global versioning of `Value`s and `Use`s. The index of a `Value` in its defining op results (or block args) is computed dynamically. Only the `def_op` and `val_uid` is stored in `Value`. The `val_uid` is tagged to every op result (or block arg). This means if we add a new result in between existing results, the `Value` of an existing result is not affected (it's dynamically computed index might change). If a result is removed and another one added in it's place, a `Value` referring to an old one gets invalidated, and will lead to a panic if `find_index` is called (because it's global value id isn't there in the op's results list anymore). (this is similar to how our generation arena based `Ptr` works). It all works same for block args too.

Similarly, `Use`s have a global `use_uid`, and adding / removing operands either keep existing `Use`s valid or invalid, with invalidity clearly leading to panics.

With our previous scheme, invalidation of `Value` or `Use` would go undetected if a new result / arg / operand had taken the same position as a removed one, leading to subtle, hard to debug bugs. Now it's a clear panic.

While in most cases, `find_index` on an invalid `Value` or `Use` leading to a panic is the right behaviour (because you shouldn't be "dereferencing" a "dangling pointer"), there may be situations where one might want to check if it's invalid. That can be done by the `try_find_index` methods, which return a `Result`.

### Syntax of `Value`s

A prominently visible consequence of this change is that our printing / naming of op results and block args now just use `v201`, for example, where `201` is the `val_uid` of that value, which is always deterministically unique. Previously this was `op2v1_res0`, for example, where `2v1` came from the generational arena index + generation.

### Memory impact:

1. Removes the `def_op` field from `OpResult` and `def_block` field from `BlockArgument`.
2. Adds `use_uid : u64` field to `Operand`.
Typically the number of operands is more than the number of results, so there is an increase in memory consumed by the IR.

### Performance:

Operations such as `value.get_type(...)` are now linear in the number of operation results / block arguments rather than the constant time previously. Similarly, when you want to replace the uses of a definition (value), the replacement will search among all operands (`find_index(...)`)of the `user_op` to find the right one.
Typically the number of results / operands is single-digit. This linear search may be okay.

The trade-off for the memory/performance we lost is convenience (of being able to add results / arguments / operands) with safety (panic on accessing stale `Value`s or `Use`s).