### PR TITLE
Add a pass manager and an analysis manager

### DIFF
--- a/pliron-llvm/llvm-opt/src/main.rs
+++ b/pliron-llvm/llvm-opt/src/main.rs
@@ -7,7 +7,7 @@ use pliron::{
     context::{Context, Ptr},
     op::{Op, verify_op},
     operation::Operation,
-    opts::{dce, mem2reg::Mem2RegPass},
+    opts::{dce::DCEPass, mem2reg::Mem2RegPass},
     pass_manager::{self, OpPass, OpPassManager, Pass, PassGroup},
     printable::Printable,
     result::Result,
@@ -37,7 +37,7 @@ struct Cli {
 
     /// Optimization passes to run in order (comma-separated)
     ///
-    /// Example: --opts mem2reg
+    /// Example: --opts mem2reg,dce
     #[arg(long = "opts", value_name = "PASS1,PASS2", value_delimiter = ',')]
     opts: Option<Vec<OptPass>>,
 }
@@ -71,7 +71,7 @@ fn run_opt_passes(module: Ptr<Operation>, opts: &[OptPass], ctx: &mut Context) -
                 pass_manager.add_pass(OpPass::<Mem2RegPass, FuncOp>::default());
             }
             OptPass::Dce => {
-                pass_manager.add_pass(OpPass::<dce::DCEPass, FuncOp>::default());
+                pass_manager.add_pass(OpPass::<DCEPass, FuncOp>::default());
             }
         }
     }

--- a/pliron-llvm/llvm-opt/src/main.rs
+++ b/pliron-llvm/llvm-opt/src/main.rs
@@ -3,10 +3,12 @@ use std::{path::PathBuf, process::ExitCode, str::FromStr};
 use clap::Parser;
 use pliron::{
     arg_error_noloc,
+    builtin::ops::ModuleOp,
     context::{Context, Ptr},
     op::{Op, verify_op},
     operation::Operation,
-    opts::{dce, mem2reg},
+    opts::{dce, mem2reg::Mem2RegPass},
+    pass_manager::{self, OpPass, OpPassManager, Pass, PassGroup},
     printable::Printable,
     result::Result,
     verify_error_noloc,
@@ -14,6 +16,7 @@ use pliron::{
 use pliron_llvm::{
     from_llvm_ir,
     llvm_sys::core::{LLVMContext, LLVMModule},
+    ops::FuncOp,
     to_llvm_ir,
 };
 
@@ -60,16 +63,21 @@ impl FromStr for OptPass {
 }
 
 fn run_opt_passes(module: Ptr<Operation>, opts: &[OptPass], ctx: &mut Context) -> Result<()> {
+    let mut pass_manager = OpPassManager::<ModuleOp>::default();
+
     for opt in opts {
         match opt {
             OptPass::Mem2Reg => {
-                let _status = mem2reg::mem2reg(module, ctx)?;
+                pass_manager.add_pass(OpPass::<Mem2RegPass, FuncOp>::default());
             }
             OptPass::Dce => {
-                let _status = dce::dce(module, ctx)?;
+                pass_manager.add_pass(OpPass::<dce::DCEPass, FuncOp>::default());
             }
         }
     }
+
+    pass_manager.run(module, ctx, &mut pass_manager::AnalysisManager::default())?;
+
     Ok(())
 }
 

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -9,20 +9,19 @@ use pliron::{
     arg_error_noloc,
     builtin::ops::ModuleOp,
     combine::Parser,
-    context::{Context, Ptr},
-    init_env_logger_for_tests,
-    irbuild::IRStatus,
-    location,
+    context::Context,
+    init_env_logger_for_tests, location,
     op::{Op, verify_op},
     operation::{Operation, verify_operation},
-    opts,
+    opts::{dce::DCEPass, mem2reg::Mem2RegPass},
     parsable::{self, state_stream_from_file},
+    pass_manager::{AnalysisManager, OpPass, OpPassManager, Pass, PassGroup, PassManager},
     printable::Printable,
-    result::Result,
 };
 use pliron_llvm::{
     from_llvm_ir,
     llvm_sys::core::{LLVMContext, LLVMModule, llvm_print_module_to_string},
+    ops::FuncOp,
     to_llvm_ir,
 };
 use tempfile::tempdir;
@@ -82,15 +81,10 @@ static RESOURCES_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
         .collect()
 });
 
-pub(crate) struct OptFn {
-    pub(crate) name: &'static str,
-    pub(crate) r#fn: fn(root: Ptr<Operation>, ctx: &mut Context) -> Result<IRStatus>,
-}
-
 /// Test an LLVM-IR file by executing it and comparing the output.
 /// The input file is `input_file`, which contains LLVM IR / Bitcode.
 /// The expected output is `expected_output`.
-fn test_llvm_ir_via_pliron(input_file: &str, opts: &[OptFn], expected_output: i32) {
+fn test_llvm_ir_via_pliron(input_file: &str, opts: impl Pass, expected_output: i32) {
     let llvm_context = LLVMContext::default();
     let module = match LLVMModule::from_ir_in_file(&llvm_context, input_file) {
         Ok(module) => module,
@@ -161,13 +155,9 @@ fn test_llvm_ir_via_pliron(input_file: &str, opts: &[OptFn], expected_output: i3
         }
     }
 
-    for opt in opts {
-        log::trace!("Running opt {}...", opt.name);
-        if let Err(err) = (opt.r#fn)(parsed_res, ctx) {
-            eprintln!("Error in opt {}: {}", opt.name, err.disp(ctx));
-            panic!("Error in opt {}", opt.name);
-        }
-        log::trace!("Module after opt {}:\n{}", opt.name, parsed_res.disp(ctx));
+    if let Err(err) = opts.run(parsed_res, ctx, &mut AnalysisManager::default()) {
+        eprintln!("Error during optimization: {}", err.disp(ctx));
+        panic!("Error during optimization");
     }
 
     let parsed_module_op = Operation::get_op::<ModuleOp>(parsed_res, ctx)
@@ -217,27 +207,26 @@ fn test_llvm_ir_via_pliron(input_file: &str, opts: &[OptFn], expected_output: i3
     );
 }
 
+fn create_opt_pass_manager() -> OpPassManager<ModuleOp> {
+    let mut pass_manager = OpPassManager::<ModuleOp>::default();
+    pass_manager.add_pass(OpPass::<Mem2RegPass, FuncOp>::default());
+    pass_manager.add_pass(OpPass::<DCEPass, FuncOp>::default());
+    pass_manager
+}
+
 /// Test simple-loop by compiling simple-loop.ll via pliron.
 #[test]
 fn test_simple_loop() {
     init_env_logger_for_tests!();
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("simple-loop.ll").to_str().unwrap(),
-        &[],
+        PassManager::default(),
         15,
     );
+
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("simple-loop.ll").to_str().unwrap(),
-        &[
-            OptFn {
-                name: "mem2reg",
-                r#fn: opts::mem2reg::mem2reg,
-            },
-            OptFn {
-                name: "dce",
-                r#fn: opts::dce::dce,
-            },
-        ],
+        create_opt_pass_manager(),
         15,
     );
 }
@@ -251,7 +240,7 @@ fn test_insert_extract_value() {
             .join("insert_extract_value.ll")
             .to_str()
             .unwrap(),
-        &[],
+        create_opt_pass_manager(),
         103,
     );
 }
@@ -260,54 +249,69 @@ fn test_insert_extract_value() {
 #[test]
 fn test_select() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("select.ll").to_str().unwrap(), &[], 100);
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("select.ll").to_str().unwrap(),
+        PassManager::default(),
+        100,
+    );
 }
 
 /// Test SwitchOp by compiling switch.ll via pliron.
 #[test]
 fn test_switch() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("switch.ll").to_str().unwrap(), &[], 68);
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("switch.ll").to_str().unwrap(),
+        PassManager::default(),
+        68,
+    );
 }
 
 /// Test const structs and arrays
 #[test]
 fn test_consts() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("consts.ll").to_str().unwrap(), &[], 203);
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("consts.ll").to_str().unwrap(),
+        PassManager::default(),
+        203,
+    );
 }
 
 /// Test globals
 #[test]
 fn test_globals() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("globals.ll").to_str().unwrap(), &[], 59);
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("globals.ll").to_str().unwrap(),
+        PassManager::default(),
+        59,
+    );
 }
 
 /// Test casts
 #[test]
 fn test_casts() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("casts.ll").to_str().unwrap(), &[], 88);
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("casts.ll").to_str().unwrap(),
+        PassManager::default(),
+        88,
+    );
 }
 
 /// Test fib by compiling fib.ll via pliron.
 #[test]
 fn test_fib() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("fib.ll").to_str().unwrap(), &[], 3);
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("fib.ll").to_str().unwrap(),
-        &[
-            OptFn {
-                name: "mem2reg",
-                r#fn: opts::mem2reg::mem2reg,
-            },
-            OptFn {
-                name: "dce",
-                r#fn: opts::dce::dce,
-            },
-        ],
+        PassManager::default(),
+        3,
+    );
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("fib.ll").to_str().unwrap(),
+        create_opt_pass_manager(),
         3,
     );
 }
@@ -318,7 +322,7 @@ fn test_fib_mem2reg() {
     init_env_logger_for_tests!();
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("fib.mem2reg.ll").to_str().unwrap(),
-        &[],
+        PassManager::default(),
         5,
     );
 }
@@ -327,7 +331,11 @@ fn test_fib_mem2reg() {
 #[test]
 fn test_fpops() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("fpops.ll").to_str().unwrap(), &[], 45);
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("fpops.ll").to_str().unwrap(),
+        PassManager::default(),
+        45,
+    );
 }
 
 /// Test intrinsics by compiling intrinsics.ll via pliron
@@ -336,7 +344,7 @@ fn test_intrinsics() {
     init_env_logger_for_tests!();
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("intrinsics.ll").to_str().unwrap(),
-        &[],
+        PassManager::default(),
         66,
     );
 }
@@ -348,7 +356,11 @@ fn test_intrinsics() {
 #[test]
 fn test_va_arg() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(RESOURCES_DIR.join("va_arg.ll").to_str().unwrap(), &[], 75);
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("va_arg.ll").to_str().unwrap(),
+        PassManager::default(),
+        75,
+    );
 }
 
 /// Test indirect-call by compiling indirect_call.ll via pliron
@@ -357,7 +369,7 @@ fn test_indirect_call() {
     init_env_logger_for_tests!();
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("indirect_call.ll").to_str().unwrap(),
-        &[],
+        PassManager::default(),
         84,
     );
 }
@@ -368,7 +380,7 @@ fn test_vector_ops() {
     init_env_logger_for_tests!();
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("vector_ops.ll").to_str().unwrap(),
-        &[],
+        PassManager::default(),
         0,
     );
 }

--- a/src/analyses/liveness.rs
+++ b/src/analyses/liveness.rs
@@ -19,7 +19,9 @@ use crate::{
     },
     irbuild::inserter::OpInsertionPoint,
     linked_list::{ContainsLinkedList, LinkedList},
+    pass_manager::{Analysis, AnalysisManager},
     region::Region,
+    result::Result,
     value::{DefiningEntity, Value},
 };
 
@@ -469,21 +471,47 @@ pub trait RegionLiveness {
 /// Fast answers liveness queries, caching liveness pre-computation for regions.
 pub struct Liveness<T: RegionLiveness> {
     regions: FxHashMap<Ptr<Region>, T>,
-    dom_info: DomInfo,
 }
 
 impl<T: RegionLiveness> Default for Liveness<T> {
     fn default() -> Self {
         Self {
             regions: FxHashMap::default(),
-            dom_info: DomInfo::default(),
         }
     }
 }
 
+impl<T: RegionLiveness + 'static> Analysis for Liveness<T> {
+    fn name(&self) -> &str {
+        "liveness"
+    }
+
+    fn compute(
+        op: Ptr<crate::operation::Operation>,
+        ctx: &Context,
+        analyses: &mut AnalysisManager,
+    ) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut liveness = Self::default();
+        let mut dom_info = analyses.get_analysis_mut::<DomInfo>(op, ctx)?;
+        // Precompute liveness for the top-level regions of the operation.
+        for region in op.deref(ctx).regions() {
+            liveness.get_region_info(ctx, &mut dom_info, region);
+        }
+        Ok(liveness)
+    }
+}
+
 impl<T: RegionLiveness> Liveness<T> {
-    fn get_region_info(&mut self, ctx: &Context, region: Ptr<Region>) -> &T {
-        let dom_tree = self.dom_info.get_dom_tree(ctx, region);
+    fn get_region_info(
+        &mut self,
+        ctx: &Context,
+        dom_info: &mut DomInfo,
+        region: Ptr<Region>,
+    ) -> &T {
+        let dom_tree = dom_info.get_dom_tree(ctx, region);
         self.regions
             .entry(region)
             .or_insert_with(|| T::precompute(ctx, region, dom_tree))
@@ -525,6 +553,7 @@ impl<T: RegionLiveness> Liveness<T> {
     pub fn is_live_at_point(
         &mut self,
         ctx: &Context,
+        dom_info: &mut DomInfo,
         value: Value,
         point: OpInsertionPoint,
     ) -> bool {
@@ -600,15 +629,15 @@ impl<T: RegionLiveness> Liveness<T> {
         match point_in_def_region {
             OpInsertionPoint::Unset => panic!("Insertion point must be set for liveness query"),
             OpInsertionPoint::AtBlockStart(query_block) => {
-                let info = self.get_region_info(ctx, def_region);
+                let info = self.get_region_info(ctx, dom_info, def_region);
                 info.is_live_in_at_block(ctx, value, query_block)
             }
             OpInsertionPoint::AtBlockEnd(query_block) => {
-                let info = self.get_region_info(ctx, def_region);
+                let info = self.get_region_info(ctx, dom_info, def_region);
                 info.is_live_out_of_block(ctx, value, query_block)
             }
             OpInsertionPoint::BeforeOperation(op) => {
-                if !self.dom_info.value_strictly_dominates_op(ctx, value, op) {
+                if !dom_info.value_strictly_dominates_op(ctx, value, op) {
                     // If the value doesn't dominate the operation, it can't be live before it
                     return false;
                 }
@@ -616,7 +645,7 @@ impl<T: RegionLiveness> Liveness<T> {
                     return true;
                 }
                 // It isn't used locally in this block, check for after the block.
-                let info = self.get_region_info(ctx, def_region);
+                let info = self.get_region_info(ctx, dom_info, def_region);
                 let query_block = op.deref(ctx).get_parent_block().expect(
                     "Operations in the definition region must be in blocks for liveness queries",
                 );
@@ -630,7 +659,7 @@ impl<T: RegionLiveness> Liveness<T> {
                 // and we would end up incorrectly reporting that the value is not live after.
                 if let DefiningEntity::Op(value_def_op) = value.defining_entity()
                     && value_def_op != op
-                    && !self.dom_info.value_strictly_dominates_op(ctx, value, op)
+                    && !dom_info.value_strictly_dominates_op(ctx, value, op)
                 {
                     // If the value doesn't dominate the operation, it can't be live after it
                     return false;
@@ -639,7 +668,7 @@ impl<T: RegionLiveness> Liveness<T> {
                     return true;
                 }
                 // It isn't used locally in this block, check for after the block.
-                let info = self.get_region_info(ctx, def_region);
+                let info = self.get_region_info(ctx, dom_info, def_region);
                 let query_block = op.deref(ctx).get_parent_block().expect(
                     "Operations in the definition region must be in blocks for liveness queries",
                 );
@@ -664,9 +693,11 @@ mod tests {
         },
         context::{Context, Ptr},
         derive::pliron_op,
+        graph::dominance::DomInfo,
         irbuild::inserter::OpInsertionPoint,
         op::Op,
         operation::Operation,
+        pass_manager::AnalysisManager,
         region::Region,
         value::Value,
     };
@@ -767,32 +798,94 @@ mod tests {
         insert_br(ctx, header, vec![body, exit]);
         insert_br(ctx, body, vec![header]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(header)));
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(header)));
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(exit)));
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
+
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(header)
+        ));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(header)
+        ));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(exit)
+        ));
     }
 
     #[test]
     fn liveness_insertion_points_and_def_block_live_out() {
         // Single block with local use only.
         let ctx = &mut Context::new();
-        let (_func, entry) = new_test_func(ctx, "single_block_local_use");
+        let (func, entry) = new_test_func(ctx, "single_block_local_use");
 
         let (def_op, val) = insert_def(ctx, entry);
         let use_op = insert_use(ctx, entry, val);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
 
         // Special-case in Algorithm 2: live-out at def block only if used outside def block.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(entry)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(entry)
+        ));
 
         // Before defining op is never live; after defining op it is live because of local use.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::BeforeOperation(def_op),));
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(def_op),));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::BeforeOperation(def_op),
+        ));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(def_op),
+        ));
 
         // Before use in same block, the value should be live.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::BeforeOperation(use_op),));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::BeforeOperation(use_op),
+        ));
     }
 
     #[test]
@@ -817,14 +910,42 @@ mod tests {
         insert_br(ctx, b, vec![c]);
         insert_br(ctx, c, vec![a, exit]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
 
         // Dominated by entry and reaches use through irreducible SCC.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(b)));
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(b)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(b)
+        ));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(b)
+        ));
 
         // Use is not reachable from exit.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(exit)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(exit)
+        ));
     }
 
     #[test]
@@ -844,16 +965,39 @@ mod tests {
         insert_br(ctx, entry, vec![header]);
         insert_br(ctx, header, vec![header, exit]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
 
         // val is defined in entry and used in header, so it is live-in at header.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(header)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(header)
+        ));
         // Not live past header (no use in exit).
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(exit)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(exit)
+        ));
 
         // Verify the CFG was treated as reducible (fast path exercised).
         let def_region = entry.deref(ctx).get_parent_region().unwrap();
-        let info = liveness.get_region_info(ctx, def_region);
+        let info = liveness.get_region_info(ctx, &mut dom_info, def_region);
         assert!(
             info.is_reducible,
             "Self-loop CFG must be classified as reducible"
@@ -874,11 +1018,35 @@ mod tests {
 
         insert_br(ctx, entry, vec![successor]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
+
         // query block is dominated by def block — exercises use_blocks.is_empty() path.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(successor)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(successor)
+        ));
         // def == query block, no uses anywhere.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(entry)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(entry)
+        ));
     }
 
     #[test]
@@ -901,14 +1069,48 @@ mod tests {
         insert_br(ctx, left, vec![merge]);
         insert_br(ctx, right, vec![merge]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
+
         // `left` does not dominate `right` — early exit fires, must be false.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(right)));
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(right)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(right)
+        ));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(right)
+        ));
         // `left` does not dominate `entry` — early exit fires, must be false.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(entry)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(entry)
+        ));
         // Local use only in `left`, not live-out past `left`.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(left)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(left)
+        ));
     }
 
     #[test]
@@ -928,12 +1130,41 @@ mod tests {
         insert_br(ctx, entry, vec![a]);
         insert_br(ctx, a, vec![exit]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(a)));
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
+
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(a)
+        ));
         // Only use is in `a` itself — not live-out past the end of `a`.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(a)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(a)
+        ));
         // Also live-out at entry since `a` (a different block) uses it.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(entry)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(entry)
+        ));
     }
 
     #[test]
@@ -957,20 +1188,54 @@ mod tests {
         insert_br(ctx, header, vec![body, exit]);
         insert_br(ctx, body, vec![header]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(header)));
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
+
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(header)
+        ));
         // val is live-in at body because body -> header and header uses val.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(body)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(body)
+        ));
         // header is a back-edge target: live-out because the loop can re-execute header.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(header)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(header)
+        ));
         // val is NOT live-in at exit since there's no use reachable from exit.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(exit)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(exit)
+        ));
     }
 
     #[test]
     fn liveness_nested_region_use_is_live_throughout_that_region() {
         let ctx = &mut Context::new();
-        let (_func, entry) = new_test_func(ctx, "nested_region_use_live_throughout");
+        let (func, entry) = new_test_func(ctx, "nested_region_use_live_throughout");
 
         let (_def_op, val) = insert_def(ctx, entry);
 
@@ -979,16 +1244,54 @@ mod tests {
 
         let inner_use = insert_use(ctx, inner_1, val);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
 
         // Querying inside the nested region that contains a use should report live throughout.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(inner_1)));
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(inner_1)));
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::BeforeOperation(inner_use)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(inner_1)
+        ));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(inner_1)
+        ));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::BeforeOperation(inner_use)
+        ));
 
         // A sibling nested region with no uses should not be forced live.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(inner_2)));
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(inner_2)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(inner_2)
+        ));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(inner_2)
+        ));
     }
 
     #[test]
@@ -1007,18 +1310,56 @@ mod tests {
         let later_op = insert_use(ctx, entry, val); // a second use after the holder, so there's something to query against
         insert_br(ctx, entry, vec![exit]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
 
         // Before the holder: val is live because the nested use is in the suffix.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::BeforeOperation(holder_op)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::BeforeOperation(holder_op)
+        ));
         // After def_op: val is live (nested use ahead).
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(def_op)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(def_op)
+        ));
         // Before def_op: val is not yet defined, never live.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::BeforeOperation(def_op)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::BeforeOperation(def_op)
+        ));
         // After holder_op: nested use has been consumed, but later_op still uses val directly.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(holder_op)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(holder_op)
+        ));
         // After later_op (the last use): val is dead.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(later_op)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(later_op)
+        ));
     }
 
     #[test]
@@ -1040,23 +1381,57 @@ mod tests {
         insert_br(ctx, entry, vec![a]);
         insert_br(ctx, a, vec![exit]);
 
-        let mut liveness = Liveness::<LivenessTq>::default();
+        let mut analysis_manager = AnalysisManager::default();
+        analysis_manager
+            .compute_analysis::<Liveness<LivenessTq>>(func.get_operation(), ctx)
+            .expect("Liveness analysis must compute successfully");
+        analysis_manager
+            .compute_analysis::<DomInfo>(func.get_operation(), ctx)
+            .expect("DomInfo analysis must compute successfully");
+
+        let mut liveness = analysis_manager
+            .try_get_analysis_mut::<Liveness<LivenessTq>>(func.get_operation())
+            .unwrap();
+        let mut dom_info = analysis_manager
+            .try_get_analysis_mut::<DomInfo>(func.get_operation())
+            .unwrap();
 
         // Live at start of `a` (uses exist in `a`'s subtree).
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(a)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(a)
+        ));
         // Before holder: nested use is still in the suffix, so val is live.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::BeforeOperation(holder_op)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::BeforeOperation(holder_op)
+        ));
         // After op_before_holder: nested use (inside holder) is still ahead.
         assert!(liveness.is_live_at_point(
             ctx,
+            &mut dom_info,
             val,
             OpInsertionPoint::AfterOperation(op_before_holder)
         ));
         // After holder: the nested use (and the direct use in op_before_holder) are both
         // consumed; no further uses in `a`. val is dead.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(holder_op)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(holder_op)
+        ));
         // val is not live at start of exit (no reachable use from exit).
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(exit)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(exit)
+        ));
     }
 
     #[test]
@@ -1073,13 +1448,29 @@ mod tests {
         insert_use(ctx, inner_block, val);
 
         let mut liveness = Liveness::<LivenessTq>::default();
+        let mut dom_info = DomInfo::default();
 
         // After def_op: holder_op (with its nested use) is still ahead.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(def_op)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(def_op)
+        ));
         // Before holder_op: nested use is in the suffix.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::BeforeOperation(holder_op)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::BeforeOperation(holder_op)
+        ));
         // After holder_op: the only use has been consumed; val is dead.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(holder_op)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(holder_op)
+        ));
     }
 
     #[test]
@@ -1098,17 +1489,43 @@ mod tests {
         insert_use(ctx, inner_2, val);
 
         let mut liveness = Liveness::<LivenessTq>::default();
+        let mut dom_info = DomInfo::default();
 
         // Query inside inner_1: val is live because holder_2's nested use comes after holder_1
         // in the orphan block, so `has_local_use_after_point(BeforeOperation(holder_1))` fires.
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(inner_1)));
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(inner_1)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(inner_1)
+        ));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(inner_1)
+        ));
 
         // Query inside inner_2: val is live (use is inside this very nested region).
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockStart(inner_2)));
-        assert!(liveness.is_live_at_point(ctx, val, OpInsertionPoint::AtBlockEnd(inner_2)));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockStart(inner_2)
+        ));
+        assert!(liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AtBlockEnd(inner_2)
+        ));
 
         // Sibling check: after holder_2 in the orphan block, val is dead.
-        assert!(!liveness.is_live_at_point(ctx, val, OpInsertionPoint::AfterOperation(_holder_2)));
+        assert!(!liveness.is_live_at_point(
+            ctx,
+            &mut dom_info,
+            val,
+            OpInsertionPoint::AfterOperation(_holder_2)
+        ));
     }
 }

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -8,7 +8,9 @@ use crate::{
         strictly_precedes_in_block, traversals,
     },
     operation::Operation,
+    pass_manager::{Analysis, AnalysisManager},
     region::Region,
+    result::Result,
     value::{DefiningEntity, Value},
 };
 
@@ -477,6 +479,23 @@ impl DomInfo {
             .expect("A block must be in a region");
         let dom_tree = self.get_dom_tree(ctx, region);
         Some(dom_tree.nearest_common_dominator(&a, &b))
+    }
+}
+
+impl Analysis for DomInfo {
+    fn name(&self) -> &'static str {
+        "dom_info"
+    }
+
+    fn compute(op: Ptr<Operation>, ctx: &Context, _analyses: &mut AnalysisManager) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut dom_info = DomInfo::default();
+        for region in op.deref(ctx).regions() {
+            dom_info.get_dom_tree(ctx, region);
+        }
+        Ok(dom_info)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub mod op;
 pub mod operation;
 pub mod opts;
 pub mod parsable;
+pub mod pass_manager;
 pub mod printable;
 pub mod region;
 pub mod result;

--- a/src/opts/dce.rs
+++ b/src/opts/dce.rs
@@ -23,15 +23,17 @@ use crate::{
     context::{Context, Ptr},
     graph::{
         HasLabel,
+        dominance::DomInfo,
         walkers::{IRNode, WALKCONFIG_PREORDER_FORWARD, uninterruptible::mutable::walk_op},
     },
-    irbuild::IRStatus,
     irbuild::{
+        IRStatus,
         listener::{Recorder, RecorderEvent},
         rewriter::{IRRewriter, Rewriter},
     },
     op::{Op, op_cast, op_impls},
     operation::{OpDbg, Operation},
+    pass_manager::{AnalysisManager, Pass, PassResult},
     printable::Printable,
     result::Result,
     value::{DefiningEntity, Value},
@@ -284,4 +286,28 @@ pub fn dce(op: Ptr<Operation>, ctx: &mut Context) -> Result<IRStatus> {
     }
 
     Ok(modified)
+}
+
+#[derive(Default)]
+/// A [Pass] that performs dead code elimination as described in the module-level documentation.
+pub struct DCEPass;
+
+impl Pass for DCEPass {
+    fn run(
+        &self,
+        op: Ptr<Operation>,
+        ctx: &mut Context,
+        _analyses: &mut AnalysisManager,
+    ) -> Result<PassResult> {
+        let mut pass_res = PassResult::default();
+        // Run DCE on the entire operation tree rooted at `op`
+        pass_res.ir_changed |= dce(op, ctx)?;
+        // DCE does not touch the CFG structure, so we can preserve dominator info if it exists.
+        pass_res.set_preserved::<DomInfo>();
+        Ok(pass_res)
+    }
+
+    fn name(&self) -> &str {
+        "dce"
+    }
 }

--- a/src/opts/mem2reg.rs
+++ b/src/opts/mem2reg.rs
@@ -13,7 +13,7 @@ use crate::{
     context::{Context, Ptr},
     debug_info::set_block_arg_name,
     graph::{
-        dominance::{DomFrontierMap, DomTree, compute_dominator_tree},
+        dominance::{DomFrontierMap, DomInfo, DomTree},
         walkers::{IRNode, WALKCONFIG_PREORDER_FORWARD, uninterruptible::immutable::walk_op},
     },
     irbuild::{
@@ -25,6 +25,7 @@ use crate::{
     linked_list::ContainsLinkedList,
     op::{Op, op_cast, op_impls},
     operation::{OpDbg, Operation},
+    pass_manager::{AnalysisManager, Pass, PassResult},
     region::Region,
     result::Result,
     r#type::TypeObj,
@@ -494,7 +495,11 @@ fn rename_block(
 }
 
 /// Perform memory to register promotion on regions (recursively) within root.
-pub fn mem2reg(root: Ptr<Operation>, ctx: &mut Context) -> Result<IRStatus> {
+pub fn mem2reg(
+    root: Ptr<Operation>,
+    ctx: &mut Context,
+    analyses: &mut AnalysisManager,
+) -> Result<IRStatus> {
     // Collect allocations that implement the promotable allocation interface.
     let mut candidates = collect_alloc_candidates(root, ctx);
     // Prune candidates that we cannot promote based on their uses.
@@ -517,11 +522,13 @@ pub fn mem2reg(root: Ptr<Operation>, ctx: &mut Context) -> Result<IRStatus> {
         by_region.entry(region).or_default().push(cand);
     }
 
+    let dom_info = &mut *analyses.get_analysis_mut::<DomInfo>(root, ctx)?;
+
     let mut opt_status = IRStatus::Unchanged;
     for (region, mut alloc_candidates) in by_region {
         // Dominator tree and dominance frontier, once per region.
-        let dom_tree: DomTree<Ptr<Region>, Context> = compute_dominator_tree(ctx, &region);
-        let df_map = DomFrontierMap::new(ctx, &region, &dom_tree);
+        let dom_tree = dom_info.get_dom_tree(ctx, region);
+        let df_map = DomFrontierMap::new(ctx, &region, dom_tree);
 
         // Compute liveness and phi-placement per candidate.
         let mut phi_blocks: FxHashMap<Value, FxHashSet<Ptr<BasicBlock>>> = FxHashMap::default();
@@ -574,7 +581,7 @@ pub fn mem2reg(root: Ptr<Operation>, ctx: &mut Context) -> Result<IRStatus> {
         rename_block(
             ctx,
             entry_block,
-            &dom_tree,
+            dom_tree,
             &new_phis_in_block,
             &reaching_def_map,
             &mut default_def_map,
@@ -615,4 +622,28 @@ pub fn mem2reg(root: Ptr<Operation>, ctx: &mut Context) -> Result<IRStatus> {
     }
 
     Ok(opt_status)
+}
+
+#[derive(Default)]
+/// The mem2reg pass, which promotes memory allocations to SSA registers where possible.
+pub struct Mem2RegPass;
+
+impl Pass for Mem2RegPass {
+    fn name(&self) -> &str {
+        "mem2reg"
+    }
+
+    fn run(
+        &self,
+        op: Ptr<Operation>,
+        ctx: &mut Context,
+        analyses: &mut AnalysisManager,
+    ) -> Result<PassResult> {
+        let mut pass_res = PassResult::default();
+        // Run mem2reg on the entire operation tree rooted at `op`
+        pass_res.ir_changed |= mem2reg(op, ctx, analyses)?;
+        // mem2reg does not touch the CFG structure, so we can preserve dominator info if it exists.
+        pass_res.set_preserved::<DomInfo>();
+        Ok(pass_res)
+    }
 }

--- a/src/pass_manager.rs
+++ b/src/pass_manager.rs
@@ -78,8 +78,7 @@
 //!     pass_manager::{AnalysisManager, PassGroup, OpPass, OpPassManager, Pass, PassResult},
 //!     result::Result,
 //! };
-//! use pliron::builtin::ops::ModuleOp;
-//! use pliron_llvm::ops::FuncOp;
+//! use pliron::builtin::ops::{FuncOp, ModuleOp};
 //!
 //! #[derive(Default)]
 //! struct MyFuncPass;

--- a/src/pass_manager.rs
+++ b/src/pass_manager.rs
@@ -9,7 +9,7 @@
 //! 4. [`Analysis`] and [`AnalysisManager`]: cached analyses with preservation
 //!    and invalidation support.
 //!
-//! # Mental model
+//! # Usage
 //!
 //! A pass receives three inputs:
 //! * The operation it should process,
@@ -25,7 +25,7 @@
 //!
 //! **NOTE**: A pass must not modify the IR outside of the operation it is applied to.
 //!
-//! # Example: Define and run a simple pass
+//! ## Example: Define and run a simple pass
 //!
 //! ```rust
 //! use pliron::{
@@ -65,7 +65,7 @@
 //! }
 //! ```
 //!
-//! # Example: Restrict a pass to a specific op kind.
+//! ## Example: Restrict a pass to a specific op kind.
 //! [OpPassManager] is a convenient wrapper around [GuardedPass] that allows
 //! you to run a pass only on operations of a specific [Op]. Similarly, [OpPass]
 //! allows you to run any pass on operations of a specific [Op].
@@ -105,7 +105,7 @@
 //! module_pm.add_pass(OpPass::<MyFuncPass, FuncOp>::default());
 //! ```
 //!
-//! # Example: Analysis caching and preservation
+//! ## Example: Analysis caching and preservation
 //!
 //! ```rust
 //! use pliron::{
@@ -149,10 +149,7 @@
 //! }
 //! ```
 
-use std::{
-    cell::{Ref, RefCell, RefMut},
-    rc::Rc,
-};
+use std::cell::{Ref, RefCell, RefMut};
 
 use downcast_rs::{Downcast, impl_downcast};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -372,7 +369,7 @@ type AnalysisManagerKey = (std::any::TypeId, Ptr<Operation>);
 #[derive(Default)]
 /// A manager for analyses, responsible for caching and invalidating them.
 pub struct AnalysisManager {
-    analyses: FxHashMap<AnalysisManagerKey, Rc<RefCell<dyn Analysis>>>,
+    analyses: FxHashMap<AnalysisManagerKey, Box<RefCell<dyn Analysis>>>,
 }
 
 impl AnalysisManager {
@@ -385,7 +382,7 @@ impl AnalysisManager {
         let key = (std::any::TypeId::of::<A>(), op);
         if !self.analyses.contains_key(&key) {
             let analysis = A::compute(op, ctx, self)?;
-            self.analyses.insert(key, Rc::new(RefCell::new(analysis)));
+            self.analyses.insert(key, Box::new(RefCell::new(analysis)));
         }
         Ok(())
     }

--- a/src/pass_manager.rs
+++ b/src/pass_manager.rs
@@ -1,0 +1,456 @@
+//! A pass manager and analysis framework.
+//!
+//! This module provides:
+//! 1. [`Pass`]: a transformation or utility that runs on an operation.
+//! 2. [`PassManager`]: runs a pipeline of nested passes on each immediately
+//!    nested operation.
+//! 3. [`GuardedPass`], [`OpPass`], and [`OpInterfacePass`]: wrappers that
+//!    constrain where a pass is allowed to run.
+//! 4. [`Analysis`] and [`AnalysisManager`]: cached analyses with preservation
+//!    and invalidation support.
+//!
+//! # Mental model
+//!
+//! A pass receives three inputs:
+//! * The operation it should process,
+//! * A mutable reference to the context
+//! * An analysis cache.
+//!
+//! It returns a [`PassResult`] indicating whether IR changed and which analyses
+//! are preserved.
+//!
+//! If a pass reports [`IRStatus::Unchanged`], all analyses are treated as
+//! preserved. If it reports changes, analyses not explicitly preserved are
+//! invalidated.
+//!
+//! **NOTE**: A pass must not modify the IR outside of the operation it is applied to.
+//!
+//! # Example: Define and run a simple pass
+//!
+//! ```rust
+//! use pliron::{
+//!     context::Context,
+//!     operation::Operation,
+//!     pass_manager::{AnalysisManager, Pass, PassResult, PassManager},
+//!     result::Result,
+//!     irbuild::IRStatus,
+//! };
+//!
+//! #[derive(Default)]
+//! struct NoOpPass;
+//!
+//! impl Pass for NoOpPass {
+//!     fn name(&self) -> &str { "noop" }
+//!
+//!     fn run(
+//!         &self,
+//!         _op: pliron::context::Ptr<Operation>,
+//!         _ctx: &mut Context,
+//!         _analyses: &mut AnalysisManager,
+//!     ) -> Result<PassResult> {
+//!         let mut result = PassResult::default();
+//!         result.ir_changed = IRStatus::Unchanged;
+//!         Ok(result)
+//!     }
+//! }
+//!
+//! fn run_pipeline(
+//!     root: pliron::context::Ptr<Operation>,
+//!     ctx: &mut Context,
+//! ) -> Result<()> {
+//!     let mut pm = PassManager::default();
+//!     pm.add_pass(NoOpPass);
+//!     let _ = pm.run(root, ctx, &mut AnalysisManager::default())?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Example: Restrict a pass to a specific op kind.
+//! [OpPassManager] is a convenient wrapper around [GuardedPass] that allows
+//! you to run a pass only on operations of a specific [Op]. Similarly, [OpPass]
+//! allows you to run any pass on operations of a specific [Op].
+//!
+//! ```rust
+//! use pliron::{
+//!     context::Context,
+//!     irbuild::IRStatus,
+//!     operation::Operation,
+//!     pass_manager::{AnalysisManager, PassGroup, OpPass, OpPassManager, Pass, PassResult},
+//!     result::Result,
+//! };
+//! use pliron::builtin::ops::ModuleOp;
+//! use pliron_llvm::ops::FuncOp;
+//!
+//! #[derive(Default)]
+//! struct MyFuncPass;
+//!
+//! impl Pass for MyFuncPass {
+//!     fn name(&self) -> &str { "my_func_pass" }
+//!
+//!     fn run(
+//!         &self,
+//!         _op: pliron::context::Ptr<Operation>,
+//!         _ctx: &mut Context,
+//!         _analyses: &mut AnalysisManager,
+//!     ) -> Result<PassResult> {
+//!         let mut result = PassResult::default();
+//!         result.ir_changed = IRStatus::Unchanged;
+//!         Ok(result)
+//!     }
+//! }
+//!
+//! // Run a pass manager only when the root op is ModuleOp.
+//! let mut module_pm = OpPassManager::<ModuleOp>::default();
+//! // Add a pass that runs only on nested FuncOp operations.
+//! module_pm.add_pass(OpPass::<MyFuncPass, FuncOp>::default());
+//! ```
+//!
+//! # Example: Analysis caching and preservation
+//!
+//! ```rust
+//! use pliron::{
+//!     context::Context,
+//!     operation::Operation,
+//!     pass_manager::{Analysis, AnalysisManager, Pass, PassResult},
+//!     result::Result,
+//! };
+//!
+//! struct MyAnalysis;
+//!
+//! impl Analysis for MyAnalysis {
+//!     fn name(&self) -> &str { "my_analysis" }
+//!     fn compute(
+//!         _op: pliron::context::Ptr<Operation>,
+//!         _ctx: &Context,
+//!         _analyses: &mut AnalysisManager,
+//!     ) -> Result<Self> {
+//!         Ok(Self)
+//!     }
+//! }
+//!
+//! struct UsesMyAnalysis;
+//!
+//! impl Pass for UsesMyAnalysis {
+//!     fn name(&self) -> &str { "uses_my_analysis" }
+//!
+//!     fn run(
+//!         &self,
+//!         op: pliron::context::Ptr<Operation>,
+//!         ctx: &mut Context,
+//!         analyses: &mut AnalysisManager,
+//!     ) -> Result<PassResult> {
+//!         let _analysis = analyses.get_analysis::<MyAnalysis>(op, ctx)?;
+//!         let mut result = PassResult::default();
+//!         // If this pass mutates IR but does not invalidate MyAnalysis,
+//!         // explicitly preserve it.
+//!         result.set_preserved::<MyAnalysis>();
+//!         Ok(result)
+//!     }
+//! }
+//! ```
+
+use std::{
+    cell::{Ref, RefCell, RefMut},
+    rc::Rc,
+};
+
+use downcast_rs::{Downcast, impl_downcast};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+    context::{Context, Ptr},
+    irbuild::IRStatus,
+    op::{Op, OpInterfaceMarker, op_impls},
+    operation::Operation,
+    result::Result,
+};
+
+#[derive(Default)]
+/// The result of running a [Pass].
+///
+/// 1. [IRStatus]: Whether the IR was changed or not.
+/// 2. A list of preserved analyses.
+///
+/// [IRStatus::Unchanged] implies all analyses are preserved.
+pub struct PassResult {
+    pub ir_changed: IRStatus,
+    preserved_analyses: FxHashSet<std::any::TypeId>,
+}
+
+impl PassResult {
+    pub fn set_preserved<A: Analysis + 'static>(&mut self) {
+        self.preserved_analyses.insert(std::any::TypeId::of::<A>());
+    }
+}
+
+/// A pass is any code that runs on an [Operation].
+/// Typically a transformation or a nested pass manager.
+///
+/// Transformations must not modify the IR outside of the [Operation] they are applied to.
+pub trait Pass {
+    /// Name of the pass.
+    fn name(&self) -> &str;
+    /// Run the pass and return whether the IR changed and which analyses are preserved.
+    fn run(
+        &self,
+        op: Ptr<Operation>,
+        ctx: &mut Context,
+        analyses: &mut AnalysisManager,
+    ) -> Result<PassResult>;
+}
+
+/// A [Pass] that contains a group of nested passes.
+pub trait PassGroup: Pass {
+    fn add_pass(&mut self, pass: impl Pass + 'static);
+}
+
+#[derive(Default)]
+/// A [Pass] that manages its [PassGroup].
+/// i.e., it runs the passes in the group on each immediately nested operation.
+pub struct PassManager {
+    passes: Vec<Box<dyn Pass>>,
+}
+
+impl Pass for PassManager {
+    fn name(&self) -> &str {
+        "pass_manager"
+    }
+
+    fn run(
+        &self,
+        op: Ptr<Operation>,
+        ctx: &mut Context,
+        analyses: &mut AnalysisManager,
+    ) -> Result<PassResult> {
+        use crate::linked_list::ContainsLinkedList;
+
+        let mut pass_res = PassResult::default();
+
+        let regions = op.deref(ctx).regions().collect::<Vec<_>>();
+        for region in regions {
+            let blocks = region.deref(ctx).iter(ctx).collect::<Vec<_>>();
+            for block in blocks {
+                let ops = block.deref(ctx).iter(ctx).collect::<Vec<_>>();
+                for nested_op in ops {
+                    for pass in &self.passes {
+                        let res = pass.run(nested_op, ctx, analyses)?;
+                        pass_res.ir_changed |= res.ir_changed;
+                        // Invalidate analyses that are not preserved.
+                        analyses.retain_preserved(&res);
+                    }
+                }
+            }
+        }
+
+        // Since we invalidate analyses after each pass,
+        // all remaining analyses are preserved.
+        let preserved_analyses = analyses.list_analyses();
+        pass_res.preserved_analyses = preserved_analyses;
+
+        Ok(pass_res)
+    }
+}
+
+impl PassManager {
+    /// Add a [Pass] to the pipeline.
+    pub fn add_pass(&mut self, pass: impl Pass + 'static) {
+        self.passes.push(Box::new(pass));
+    }
+}
+
+impl PassGroup for PassManager {
+    fn add_pass(&mut self, pass: impl Pass + 'static) {
+        self.add_pass(pass);
+    }
+}
+
+/// A `Guard` determines whether a [Pass] is applicable to a given [Operation].
+pub trait Guard {
+    /// Applicability of a [Pass] for a given [Operation].
+    fn is_allowed(&self, op: Ptr<Operation>, ctx: &Context) -> bool;
+}
+
+/// Allow [Operation]s of a specific `Op`.
+pub struct OpGuard<T: Op> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: Op> Default for OpGuard<T> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: Op> Guard for OpGuard<T> {
+    fn is_allowed(&self, op: Ptr<Operation>, ctx: &Context) -> bool {
+        Operation::is_op::<T>(op, ctx)
+    }
+}
+
+/// Allow [Operation]s that implement a specific `OpInterface`.
+pub struct OpInterfaceGuard<T: ?Sized + OpInterfaceMarker + 'static> {
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: ?Sized + OpInterfaceMarker + 'static> Default for OpInterfaceGuard<T> {
+    fn default() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T: ?Sized + OpInterfaceMarker + 'static> Guard for OpInterfaceGuard<T> {
+    fn is_allowed(&self, op: Ptr<Operation>, ctx: &Context) -> bool {
+        let op = Operation::get_op_dyn(op, ctx);
+        op_impls::<T>(&*op)
+    }
+}
+
+/// Adds a [Guard] to a [Pass], making it run only on [Operation]s that the [Guard] allows.
+#[derive(Default)]
+pub struct GuardedPass<P: Pass, G: Guard> {
+    pass: P,
+    guard: G,
+}
+
+impl<P: Pass, G: Guard> Pass for GuardedPass<P, G> {
+    fn name(&self) -> &str {
+        self.pass.name()
+    }
+
+    fn run(
+        &self,
+        op: Ptr<Operation>,
+        ctx: &mut Context,
+        analyses: &mut AnalysisManager,
+    ) -> Result<PassResult> {
+        if self.guard.is_allowed(op, ctx) {
+            self.pass.run(op, ctx, analyses)
+        } else {
+            Ok(PassResult::default())
+        }
+    }
+}
+
+impl<P: Pass + PassGroup, G: Guard> PassGroup for GuardedPass<P, G> {
+    fn add_pass(&mut self, pass: impl Pass + 'static) {
+        self.pass.add_pass(pass);
+    }
+}
+
+/// A [GuardedPass] that allows [Operation]s of a specific [Op].
+pub type OpPass<P, T> = GuardedPass<P, OpGuard<T>>;
+
+/// A [GuardedPass] that allows [Operation]s that implement a specific `OpInterface`.
+pub type OpInterfacePass<P, T> = GuardedPass<P, OpInterfaceGuard<T>>;
+
+/// A [PassManager] that runs on [Operation]s of a specific [Op].
+pub type OpPassManager<T> = OpPass<PassManager, T>;
+
+/// A [PassManager] that runs on [Operation]s that implement a specific `OpInterface`.
+pub type OpInterfacePassManager<T> = OpInterfacePass<PassManager, T>;
+
+/// An analysis is any code that computes information
+/// about an [Operation] without modifying the IR.
+pub trait Analysis: Downcast {
+    /// Name of the analysis.
+    fn name(&self) -> &str;
+    /// Compute the analysis for a given [Operation].
+    fn compute(op: Ptr<Operation>, ctx: &Context, analyses: &mut AnalysisManager) -> Result<Self>
+    where
+        Self: Sized;
+}
+impl_downcast!(Analysis);
+
+/// An [Analysis] together with the [Operation] it is computed for
+/// is used as a key in the [AnalysisManager] cache.
+type AnalysisManagerKey = (std::any::TypeId, Ptr<Operation>);
+
+#[derive(Default)]
+/// A manager for analyses, responsible for caching and invalidating them.
+pub struct AnalysisManager {
+    analyses: FxHashMap<AnalysisManagerKey, Rc<RefCell<dyn Analysis>>>,
+}
+
+impl AnalysisManager {
+    /// Compute (if not already cached) and cache an analysis `A` for [Operation] `op`.
+    pub fn compute_analysis<A: Analysis + 'static>(
+        &mut self,
+        op: Ptr<Operation>,
+        ctx: &Context,
+    ) -> Result<()> {
+        let key = (std::any::TypeId::of::<A>(), op);
+        if !self.analyses.contains_key(&key) {
+            let analysis = A::compute(op, ctx, self)?;
+            self.analyses.insert(key, Rc::new(RefCell::new(analysis)));
+        }
+        Ok(())
+    }
+
+    /// Get [RefMut] for analysis `A`, computing it if not cached.
+    pub fn get_analysis_mut<'a, A: Analysis + 'static>(
+        &'a mut self,
+        op: Ptr<Operation>,
+        ctx: &Context,
+    ) -> Result<RefMut<'a, A>> {
+        self.compute_analysis::<A>(op, ctx)?;
+        let key = (std::any::TypeId::of::<A>(), op);
+        let analysis = self.analyses.get(&key).unwrap();
+        Ok(RefMut::map(analysis.borrow_mut(), |a| {
+            a.downcast_mut::<A>().unwrap()
+        }))
+    }
+
+    /// Get [Ref] for analysis `A`, computing it if not cached.
+    pub fn get_analysis<'a, A: Analysis + 'static>(
+        &'a mut self,
+        op: Ptr<Operation>,
+        ctx: &Context,
+    ) -> Result<Ref<'a, A>> {
+        self.compute_analysis::<A>(op, ctx)?;
+        let key = (std::any::TypeId::of::<A>(), op);
+        let analysis = self.analyses.get(&key).unwrap();
+        Ok(Ref::map(analysis.borrow(), |a| {
+            a.downcast_ref::<A>().unwrap()
+        }))
+    }
+
+    /// Get, if cached, [Ref] for analysis `A`.
+    pub fn try_get_analysis<'a, A: Analysis + 'static>(
+        &'a self,
+        op: Ptr<Operation>,
+    ) -> Option<Ref<'a, A>> {
+        let key = (std::any::TypeId::of::<A>(), op);
+        self.analyses
+            .get(&key)
+            .map(|analysis| Ref::map(analysis.borrow(), |a| a.downcast_ref::<A>().unwrap()))
+    }
+
+    /// Get, if cached, [RefMut] for analysis `A`.
+    pub fn try_get_analysis_mut<'a, A: Analysis + 'static>(
+        &'a self,
+        op: Ptr<Operation>,
+    ) -> Option<RefMut<'a, A>> {
+        let key = (std::any::TypeId::of::<A>(), op);
+        self.analyses
+            .get(&key)
+            .map(|analysis| RefMut::map(analysis.borrow_mut(), |a| a.downcast_mut::<A>().unwrap()))
+    }
+
+    /// Retain only analyses that are preserved by a [PassResult].
+    pub fn retain_preserved(&mut self, pass_res: &PassResult) {
+        if pass_res.ir_changed == IRStatus::Unchanged {
+            return;
+        }
+        self.analyses
+            .retain(|(type_id, _), _| pass_res.preserved_analyses.contains(type_id));
+    }
+
+    /// Get a list of all analyses currently cached.
+    fn list_analyses(&self) -> FxHashSet<std::any::TypeId> {
+        self.analyses.keys().map(|(type_id, _)| *type_id).collect()
+    }
+}

--- a/src/pass_manager.rs
+++ b/src/pass_manager.rs
@@ -352,17 +352,17 @@ pub type OpInterfacePassManager<T> = OpInterfacePass<PassManager, T>;
 /// An analysis is any code that computes information
 /// about an [Operation] without modifying the IR.
 pub trait Analysis: Downcast {
-    /// Name of the analysis.
+    /// Name of this analysis.
     fn name(&self) -> &str;
-    /// Compute the analysis for a given [Operation].
+    /// Compute this analysis for a given [Operation].
     fn compute(op: Ptr<Operation>, ctx: &Context, analyses: &mut AnalysisManager) -> Result<Self>
     where
         Self: Sized;
 }
 impl_downcast!(Analysis);
 
-/// An [Analysis] together with the [Operation] it is computed for
-/// is used as a key in the [AnalysisManager] cache.
+/// An [Analysis] together with the [Operation] it is computed for.
+/// Used as a key in the [AnalysisManager] cache.
 type AnalysisManagerKey = (std::any::TypeId, Ptr<Operation>);
 
 #[derive(Default)]

--- a/tests/opts/mem2reg.rs
+++ b/tests/opts/mem2reg.rs
@@ -11,6 +11,7 @@ use pliron::{
     operation::{Operation, verify_operation},
     opts::mem2reg::{AllocInfo, PromotableOpInterface, PromotableOpKind, mem2reg},
     parsable::{self, state_stream_from_iterator},
+    pass_manager::AnalysisManager,
     printable::Printable,
     result::Result,
 };
@@ -82,7 +83,8 @@ fn run_mem2reg(input: &str) -> Result<(IRStatus, String, String)> {
     log::trace!("Before mem2reg:\n{}", before);
     verify_operation(op, ctx)?;
 
-    let status = mem2reg(op, ctx)?;
+    let mut analyses = AnalysisManager::default();
+    let status = mem2reg(op, ctx, &mut analyses)?;
 
     let after = op.disp(ctx).to_string();
     log::trace!("After mem2reg:\n{}", after);


### PR DESCRIPTION
This PR introduces a pass manager and an analysis cache to accompany it.

The module doc explains it all, with examples.

**Note**: 
1. A mutable reference to the `AnalysisManager` is available for all passes (so that they can use and update analyses as required)
2. A mutable reference to the `AnalysisManager` is also available to the `compute` method of an `Analysis`, so that it can use other analyses (and also update them if necessary, such as for when there's internal caching in the other analysis).

    However, when a query method `Q` of an analysis `A1` requires, another analysis `A2`, it becomes tricky. This is because `A1` itself is obtained from its `AnalysisManager`. So we'll require multiple mutable borrows from the `AnalysisManager`. To accommodate this, each analysis in the `AnalysisManager` is inside a `RefCell`. An example of how to manage analyses in this situation is seen in `Liveness::is_live_at_point`, which requires `&mut DomInfo` for it to work. The updated tests show how to handle the situation.

Also note that `PassManager` is really just another pass, whose job is to run the `PassGroup` it contains on each immediately nested operation.

To restrict a pass to a specific kind of operation (based on opcode / interface impl etc), the `GuardedPass` utility is provided, with convenient type aliases for restricting based on `Op` or `OpInterface`

At the outset, the usage / model is similar to that of [MLIR](https://mlir.llvm.org/docs/PassManagement/#pass-manager). The internals differ.