### PR TITLE
Address spaces, atomics, inline asm, FP16, and an llvm-sys round-trip bridge

### DIFF
--- a/examples/kaleidoscope/dialect.rs
+++ b/examples/kaleidoscope/dialect.rs
@@ -106,7 +106,7 @@ impl DeclOp {
     /// The op result is always a pointer slot, and the variable type
     /// is stored in the `var_type` attribute.
     pub fn new(ctx: &mut Context, var_ty: Ptr<TypeObj>) -> Self {
-        let ptr_ty = PointerType::get(ctx).into();
+        let ptr_ty = PointerType::get(ctx, 0).into();
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -235,6 +235,39 @@ pub struct AlignmentAttr(pub u32);
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct AddressSpaceAttr(pub u32);
 
+/// Memory ordering for an atomic operation (`atomicrmw` / `cmpxchg` / `fence` /
+/// atomic `load` / `store`).
+#[pliron_attr(name = "llvm.atomic_ordering", verifier = "succ", format)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+pub enum AtomicOrderingAttr {
+    Monotonic,
+    Acquire,
+    Release,
+    AcqRel,
+    SeqCst,
+}
+
+/// The kind of an LLVM `atomicrmw` operation.
+#[pliron_attr(name = "llvm.atomic_rmw_kind", verifier = "succ", format)]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+pub enum AtomicRmwKindAttr {
+    Xchg,
+    Add,
+    Sub,
+    And,
+    Nand,
+    Or,
+    Xor,
+    Max,
+    Min,
+    UMax,
+    UMin,
+    FAdd,
+    FSub,
+    FMax,
+    FMin,
+}
+
 #[pliron_attr(
     name = "llvm.shuffle_vector_mask",
     format = "`[` vec($0, CharSpace(`,`)) `]`",

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -230,6 +230,11 @@ pub struct InsertExtractValueIndicesAttr(pub Vec<u32>);
 #[derive(PartialEq, Eq, Clone, Debug, Hash)]
 pub struct AlignmentAttr(pub u32);
 
+/// Address space of a pointer or global, corresponding to LLVM's `addrspace(N)`.
+#[pliron_attr(name = "llvm.addrspace", format = "$0", verifier = "succ")]
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+pub struct AddressSpaceAttr(pub u32);
+
 #[pliron_attr(
     name = "llvm.shuffle_vector_mask",
     format = "`[` vec($0, CharSpace(`,`)) `]`",

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -385,4 +385,63 @@ mod tests {
             }
         }
     }
+
+    fn assert_attr_roundtrips<A>(ctx: &mut Context, attr: A)
+    where
+        A: Parsable<Arg = (), Parsed = A> + Printable + PartialEq + std::fmt::Debug,
+    {
+        let printed = attr.disp(ctx).to_string();
+        let mut state_stream = state_stream_from_iterator(
+            printed.chars(),
+            parsable::State::new(ctx, location::Source::InMemory),
+        );
+        let (parsed, _) = A::parse(&mut state_stream, ()).unwrap();
+        assert_eq!(parsed, attr, "round-trip mismatch for `{printed}`");
+    }
+
+    #[test]
+    fn test_atomic_ordering_attr_roundtrip() {
+        let ctx = &mut Context::default();
+        for ordering in [
+            AtomicOrderingAttr::Monotonic,
+            AtomicOrderingAttr::Acquire,
+            AtomicOrderingAttr::Release,
+            AtomicOrderingAttr::AcqRel,
+            AtomicOrderingAttr::SeqCst,
+        ] {
+            assert_attr_roundtrips(ctx, ordering);
+        }
+    }
+
+    #[test]
+    fn test_atomic_rmw_kind_attr_roundtrip() {
+        let ctx = &mut Context::default();
+        for kind in [
+            AtomicRmwKindAttr::Xchg,
+            AtomicRmwKindAttr::Add,
+            AtomicRmwKindAttr::Sub,
+            AtomicRmwKindAttr::And,
+            AtomicRmwKindAttr::Nand,
+            AtomicRmwKindAttr::Or,
+            AtomicRmwKindAttr::Xor,
+            AtomicRmwKindAttr::Max,
+            AtomicRmwKindAttr::Min,
+            AtomicRmwKindAttr::UMax,
+            AtomicRmwKindAttr::UMin,
+            AtomicRmwKindAttr::FAdd,
+            AtomicRmwKindAttr::FSub,
+            AtomicRmwKindAttr::FMax,
+            AtomicRmwKindAttr::FMin,
+        ] {
+            assert_attr_roundtrips(ctx, kind);
+        }
+    }
+
+    #[test]
+    fn test_address_space_attr_roundtrip() {
+        let ctx = &mut Context::default();
+        for n in [0u32, 1, 3, 5, 7] {
+            assert_attr_roundtrips(ctx, AddressSpaceAttr(n));
+        }
+    }
 }

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -444,4 +444,15 @@ mod tests {
             assert_attr_roundtrips(ctx, AddressSpaceAttr(n));
         }
     }
+
+    #[test]
+    fn test_fp_half_attr_roundtrip() {
+        use pliron::builtin::attributes::FPHalfAttr;
+        use pliron::utils::apfloat::Half;
+        let ctx = &mut Context::default();
+        for s in ["0.0", "1.5", "-2.25"] {
+            let value: Half = s.parse().expect("valid half literal");
+            assert_attr_roundtrips(ctx, FPHalfAttr(value));
+        }
+    }
 }

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -56,25 +56,25 @@ use crate::{
         llvm_get_int_type_width, llvm_get_linkage, llvm_get_mask_value, llvm_get_module_identifier,
         llvm_get_nneg, llvm_get_nsw, llvm_get_num_arg_operands, llvm_get_num_mask_elements,
         llvm_get_num_operands, llvm_get_nuw, llvm_get_operand, llvm_get_param_types,
-        llvm_get_return_type, llvm_get_struct_element_types, llvm_get_struct_name,
-        llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind, llvm_get_value_name,
-        llvm_get_vector_size, llvm_global_get_value_type, llvm_is_a, llvm_is_declaration,
-        llvm_is_function_type_var_arg, llvm_is_opaque_struct, llvm_lookup_intrinsic_id,
-        llvm_print_value_to_string, llvm_type_of, llvm_value_as_basic_block,
-        llvm_value_is_basic_block, param_iter,
+        llvm_get_pointer_address_space, llvm_get_return_type, llvm_get_struct_element_types,
+        llvm_get_struct_name, llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind,
+        llvm_get_value_name, llvm_get_vector_size, llvm_global_get_value_type, llvm_is_a,
+        llvm_is_declaration, llvm_is_function_type_var_arg, llvm_is_opaque_struct,
+        llvm_lookup_intrinsic_id, llvm_print_value_to_string, llvm_type_of,
+        llvm_value_as_basic_block, llvm_value_is_basic_block, param_iter,
     },
     op_interfaces::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
         FloatBinArithOpWithFastMathFlags, IntBinArithOpWithOverflowFlag, LlvmSymbolName,
     },
     ops::{
-        AShrOp, AddOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp, CallIntrinsicOp, CallOp,
-        CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp, FNegOp,
-        FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FreezeOp, FuncOp, GepIndex,
-        GetElementPtrOp, GlobalOp, ICmpOp, InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp,
-        LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp,
-        SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchCase, SwitchOp, TruncOp, UDivOp,
-        UIToFPOp, URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
+        AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp,
+        CallIntrinsicOp, CallOp, CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp,
+        FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FreezeOp,
+        FuncOp, GepIndex, GetElementPtrOp, GlobalOp, ICmpOp, InsertElementOp, InsertValueOp,
+        IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp,
+        SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchCase, SwitchOp,
+        TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
     },
     types::{
         ArrayType, FuncType, PointerType, StructErr, StructType, VectorType, VectorTypeKind,
@@ -137,7 +137,9 @@ fn convert_type(
             let bit_width = llvm_get_int_type_width(ty);
             Ok(IntegerType::get(ctx, bit_width, Signedness::Signless).into())
         }
-        LLVMTypeKind::LLVMPointerTypeKind => Ok(PointerType::get(ctx).into()),
+        LLVMTypeKind::LLVMPointerTypeKind => {
+            Ok(PointerType::get(ctx, llvm_get_pointer_address_space(ty)).into())
+        }
         LLVMTypeKind::LLVMStructTypeKind => {
             let name_opt: Option<Identifier> =
                 llvm_get_struct_name(ty).map(|str| cctx.id_legaliser.legalise(&str));
@@ -876,7 +878,11 @@ fn convert_instruction(
                     .get_operation(),
             )
         }
-        LLVMOpcode::LLVMAddrSpaceCast => todo!(),
+        LLVMOpcode::LLVMAddrSpaceCast => {
+            let arg = get_operand(opds, 0)?;
+            let res_ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
+            Ok(AddrSpaceCastOp::new(ctx, arg, res_ty).get_operation())
+        }
         LLVMOpcode::LLVMAlloca => {
             let elem_type = convert_type(ctx, cctx, llvm_get_allocated_type(inst))?;
             let size = get_operand(opds, 0)?;
@@ -1408,6 +1414,11 @@ fn convert_global(
     )?;
 
     let op = GlobalOp::new(ctx, name.clone(), ty);
+
+    let addr_space = llvm_get_pointer_address_space(llvm_type_of(global));
+    if addr_space != 0 {
+        op.set_address_space(ctx, addr_space);
+    }
 
     if <Identifier as Into<String>>::into(name) != llvm_name {
         op.set_llvm_symbol_name(ctx, llvm_name);

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -3,7 +3,8 @@
 use std::num::NonZero;
 
 use llvm_sys::{
-    LLVMIntPredicate, LLVMLinkage, LLVMOpcode, LLVMRealPredicate, LLVMTypeKind, LLVMValueKind,
+    LLVMAtomicOrdering, LLVMAtomicRMWBinOp, LLVMIntPredicate, LLVMLinkage, LLVMOpcode,
+    LLVMRealPredicate, LLVMTypeKind, LLVMValueKind,
 };
 use pliron::{
     attribute::AttrObj,
@@ -40,22 +41,25 @@ use thiserror::Error;
 
 use crate::{
     attributes::{
-        FCmpPredicateAttr, FastmathFlagsAttr, ICmpPredicateAttr, IntegerOverflowFlagsAttr,
-        LinkageAttr,
+        AtomicOrderingAttr, AtomicRmwKindAttr, FCmpPredicateAttr, FastmathFlagsAttr,
+        ICmpPredicateAttr, IntegerOverflowFlagsAttr, LinkageAttr,
     },
     llvm_sys::core::{
         LLVMBasicBlock, LLVMModule, LLVMType, LLVMValue, basic_block_iter, function_iter,
         global_iter, incoming_iter, instruction_iter, llvm_can_value_use_fast_math_flags,
         llvm_const_int_get_zext_value, llvm_const_real_get_double, llvm_count_struct_element_types,
         llvm_get_aggregate_element, llvm_get_alignment, llvm_get_allocated_type,
-        llvm_get_array_length2, llvm_get_basic_block_name, llvm_get_basic_block_terminator,
-        llvm_get_called_function_type, llvm_get_called_value, llvm_get_const_opcode,
-        llvm_get_element_type, llvm_get_fast_math_flags, llvm_get_fcmp_predicate,
-        llvm_get_gep_source_element_type, llvm_get_icmp_predicate, llvm_get_indices,
-        llvm_get_initializer, llvm_get_instruction_opcode, llvm_get_instruction_parent,
-        llvm_get_int_type_width, llvm_get_linkage, llvm_get_mask_value, llvm_get_module_identifier,
-        llvm_get_nneg, llvm_get_nsw, llvm_get_num_arg_operands, llvm_get_num_mask_elements,
-        llvm_get_num_operands, llvm_get_nuw, llvm_get_operand, llvm_get_param_types,
+        llvm_get_array_length2, llvm_get_atomic_rmw_bin_op, llvm_get_atomic_sync_scope_id,
+        llvm_get_basic_block_name, llvm_get_basic_block_terminator, llvm_get_called_function_type,
+        llvm_get_called_value, llvm_get_cmpxchg_failure_ordering,
+        llvm_get_cmpxchg_success_ordering, llvm_get_const_opcode, llvm_get_element_type,
+        llvm_get_fast_math_flags, llvm_get_fcmp_predicate, llvm_get_gep_source_element_type,
+        llvm_get_icmp_predicate, llvm_get_indices, llvm_get_initializer,
+        llvm_get_inline_asm_asm_string, llvm_get_inline_asm_constraint_string,
+        llvm_get_instruction_opcode, llvm_get_instruction_parent, llvm_get_int_type_width,
+        llvm_get_linkage, llvm_get_mask_value, llvm_get_module_identifier, llvm_get_nneg,
+        llvm_get_nsw, llvm_get_num_arg_operands, llvm_get_num_mask_elements, llvm_get_num_operands,
+        llvm_get_nuw, llvm_get_operand, llvm_get_ordering, llvm_get_param_types,
         llvm_get_pointer_address_space, llvm_get_return_type, llvm_get_struct_element_types,
         llvm_get_struct_name, llvm_get_switch_case_value, llvm_get_type_kind, llvm_get_value_kind,
         llvm_get_value_name, llvm_get_vector_size, llvm_global_get_value_type, llvm_is_a,
@@ -68,10 +72,11 @@ use crate::{
         FloatBinArithOpWithFastMathFlags, IntBinArithOpWithOverflowFlag, LlvmSymbolName,
     },
     ops::{
-        AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp,
-        CallIntrinsicOp, CallOp, CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp,
-        FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FreezeOp,
-        FuncOp, GepIndex, GetElementPtrOp, GlobalOp, ICmpOp, InsertElementOp, InsertValueOp,
+        AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,
+        AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BrOp, CallIntrinsicOp, CallOp,
+        CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp, FNegOp,
+        FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FenceOp, FreezeOp, FuncOp,
+        GepIndex, GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp, InsertElementOp, InsertValueOp,
         IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp,
         SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchCase, SwitchOp,
         TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
@@ -791,6 +796,54 @@ fn convert_branch_args(
     Ok(args)
 }
 
+/// Map an LLVM-C [LLVMAtomicOrdering] to a pliron [AtomicOrderingAttr].
+fn convert_ordering_from_llvm(o: LLVMAtomicOrdering) -> AtomicOrderingAttr {
+    match o {
+        LLVMAtomicOrdering::LLVMAtomicOrderingMonotonic => AtomicOrderingAttr::Monotonic,
+        LLVMAtomicOrdering::LLVMAtomicOrderingAcquire => AtomicOrderingAttr::Acquire,
+        LLVMAtomicOrdering::LLVMAtomicOrderingRelease => AtomicOrderingAttr::Release,
+        LLVMAtomicOrdering::LLVMAtomicOrderingAcquireRelease => AtomicOrderingAttr::AcqRel,
+        LLVMAtomicOrdering::LLVMAtomicOrderingSequentiallyConsistent => AtomicOrderingAttr::SeqCst,
+        other => panic!("unsupported atomic ordering from LLVM: {other:?}"),
+    }
+}
+
+/// Map an LLVM-C [LLVMAtomicRMWBinOp] to a pliron [AtomicRmwKindAttr].
+fn convert_rmw_kind_from_llvm(k: LLVMAtomicRMWBinOp) -> AtomicRmwKindAttr {
+    match k {
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXchg => AtomicRmwKindAttr::Xchg,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpAdd => AtomicRmwKindAttr::Add,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpSub => AtomicRmwKindAttr::Sub,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpAnd => AtomicRmwKindAttr::And,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpNand => AtomicRmwKindAttr::Nand,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpOr => AtomicRmwKindAttr::Or,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXor => AtomicRmwKindAttr::Xor,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMax => AtomicRmwKindAttr::Max,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMin => AtomicRmwKindAttr::Min,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMax => AtomicRmwKindAttr::UMax,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMin => AtomicRmwKindAttr::UMin,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFAdd => AtomicRmwKindAttr::FAdd,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFSub => AtomicRmwKindAttr::FSub,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMax => AtomicRmwKindAttr::FMax,
+        LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMin => AtomicRmwKindAttr::FMin,
+        other => panic!("unsupported atomicrmw binop from LLVM: {other:?}"),
+    }
+}
+
+/// Recover pliron syncscope (`None` = system) from an atomic instruction.
+///
+/// LLVM's built-in `SyncScope` ids are `SingleThread = 0` and `System = 1`;
+/// any named scope (e.g. NVVM "device"/"block") is assigned an id >= 2. LLVM-C
+/// exposes the id but not its name, so only the two built-in scopes round-trip;
+/// named scopes cannot be mapped back to a name and fall back to the system
+/// scope.
+fn syncscope_from_llvm(inst: LLVMValue) -> Option<String> {
+    match llvm_get_atomic_sync_scope_id(inst) {
+        0 => Some("singlethread".to_string()),
+        _ => None,
+    }
+}
+
 fn convert_call(
     ctx: &mut Context,
     cctx: &mut ConversionContext,
@@ -802,6 +855,17 @@ fn convert_call(
     let (args, _) = convert_operands(ctx, cctx, &llvm_operands)?;
 
     let callee = llvm_get_called_value(inst);
+
+    // Inline asm: the callee is an inline-asm value rather than a function.
+    if llvm_get_value_kind(callee) == LLVMValueKind::LLVMInlineAsmValueKind {
+        let asm = llvm_get_inline_asm_asm_string(callee);
+        let constraints = llvm_get_inline_asm_constraint_string(callee);
+        let result_ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
+        // `convergent` is a call-site attribute, not recoverable through LLVM-C here.
+        return Ok(
+            InlineAsmOp::new(ctx, result_ty, args, &asm, &constraints, false).get_operation(),
+        );
+    }
 
     enum Callee {
         FnCall(CallOpCallable),
@@ -909,8 +973,27 @@ fn convert_instruction(
             let (lhs, rhs) = (get_operand(opds, 0)?, get_operand(opds, 1)?);
             Ok(AShrOp::new(ctx, lhs, rhs).get_operation())
         }
-        LLVMOpcode::LLVMAtomicCmpXchg => todo!(),
-        LLVMOpcode::LLVMAtomicRMW => todo!(),
+        LLVMOpcode::LLVMAtomicCmpXchg => {
+            let (ptr, cmp, new) = (
+                get_operand(opds, 0)?,
+                get_operand(opds, 1)?,
+                get_operand(opds, 2)?,
+            );
+            let success = convert_ordering_from_llvm(llvm_get_cmpxchg_success_ordering(inst));
+            let failure = convert_ordering_from_llvm(llvm_get_cmpxchg_failure_ordering(inst));
+            let syncscope = syncscope_from_llvm(inst);
+            Ok(
+                AtomicCmpxchgOp::new(ctx, ptr, cmp, new, success, failure, syncscope)
+                    .get_operation(),
+            )
+        }
+        LLVMOpcode::LLVMAtomicRMW => {
+            let (ptr, val) = (get_operand(opds, 0)?, get_operand(opds, 1)?);
+            let kind = convert_rmw_kind_from_llvm(llvm_get_atomic_rmw_bin_op(inst));
+            let ordering = convert_ordering_from_llvm(llvm_get_ordering(inst));
+            let syncscope = syncscope_from_llvm(inst);
+            Ok(AtomicRmwOp::new(ctx, ptr, val, kind, ordering, syncscope).get_operation())
+        }
         LLVMOpcode::LLVMBitCast => {
             let arg = get_operand(opds, 0)?;
             let res_ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
@@ -1062,7 +1145,11 @@ fn convert_instruction(
             let nneg = llvm_get_nneg(inst);
             Ok(UIToFPOp::new_with_nneg(ctx, arg, res_ty, nneg).get_operation())
         }
-        LLVMOpcode::LLVMFence => todo!(),
+        LLVMOpcode::LLVMFence => {
+            let ordering = convert_ordering_from_llvm(llvm_get_ordering(inst));
+            let syncscope = syncscope_from_llvm(inst);
+            Ok(FenceOp::new(ctx, ordering, syncscope).get_operation())
+        }
         LLVMOpcode::LLVMFreeze => {
             let arg = get_operand(opds, 0)?;
             Ok(FreezeOp::new(ctx, arg).get_operation())
@@ -1131,12 +1218,28 @@ fn convert_instruction(
         LLVMOpcode::LLVMLandingPad => todo!(),
         LLVMOpcode::LLVMLoad => {
             let res_ty = convert_type(ctx, cctx, llvm_type_of(inst))?;
-            let load_op = LoadOp::new(ctx, get_operand(opds, 0)?, res_ty);
+            let ptr = get_operand(opds, 0)?;
             let alignment = llvm_get_alignment(inst);
-            if alignment != 0 {
-                load_op.set_alignment(ctx, alignment);
+            let ordering = llvm_get_ordering(inst);
+            if matches!(ordering, LLVMAtomicOrdering::LLVMAtomicOrderingNotAtomic) {
+                let load_op = LoadOp::new(ctx, ptr, res_ty);
+                if alignment != 0 {
+                    load_op.set_alignment(ctx, alignment);
+                }
+                Ok(load_op.get_operation())
+            } else {
+                let load_op = AtomicLoadOp::new(
+                    ctx,
+                    ptr,
+                    res_ty,
+                    convert_ordering_from_llvm(ordering),
+                    syncscope_from_llvm(inst),
+                );
+                if alignment != 0 {
+                    load_op.set_alignment(ctx, alignment);
+                }
+                Ok(load_op.get_operation())
             }
-            Ok(load_op.get_operation())
         }
         LLVMOpcode::LLVMLShr => {
             let (lhs, rhs) = (get_operand(opds, 0)?, get_operand(opds, 1)?);
@@ -1214,12 +1317,27 @@ fn convert_instruction(
         }
         LLVMOpcode::LLVMStore => {
             let (value_opd, ptr_opd) = (get_operand(opds, 0)?, get_operand(opds, 1)?);
-            let store_op = StoreOp::new(ctx, value_opd, ptr_opd);
             let alignment = llvm_get_alignment(inst);
-            if alignment != 0 {
-                store_op.set_alignment(ctx, alignment);
+            let ordering = llvm_get_ordering(inst);
+            if matches!(ordering, LLVMAtomicOrdering::LLVMAtomicOrderingNotAtomic) {
+                let store_op = StoreOp::new(ctx, value_opd, ptr_opd);
+                if alignment != 0 {
+                    store_op.set_alignment(ctx, alignment);
+                }
+                Ok(store_op.get_operation())
+            } else {
+                let store_op = AtomicStoreOp::new(
+                    ctx,
+                    value_opd,
+                    ptr_opd,
+                    convert_ordering_from_llvm(ordering),
+                    syncscope_from_llvm(inst),
+                );
+                if alignment != 0 {
+                    store_op.set_alignment(ctx, alignment);
+                }
+                Ok(store_op.get_operation())
             }
-            Ok(store_op.get_operation())
         }
         LLVMOpcode::LLVMSub => {
             let (lhs, rhs) = (get_operand(opds, 0)?, get_operand(opds, 1)?);

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -16,7 +16,7 @@ use pliron::{
         },
         ops::{ConstantOp, ModuleOp},
         type_interfaces::FloatTypeInterface,
-        types::{FP32Type, FP64Type, IntegerType, Signedness},
+        types::{FP16Type, FP32Type, FP64Type, IntegerType, Signedness},
     },
     context::{Context, Ptr},
     debug_info,
@@ -175,7 +175,7 @@ fn convert_type(
             };
             Ok(VectorType::get(ctx, elem_ty, num_elements, kind).into())
         }
-        LLVMTypeKind::LLVMHalfTypeKind => todo!(),
+        LLVMTypeKind::LLVMHalfTypeKind => Ok(FP16Type::get(ctx).into()),
         LLVMTypeKind::LLVMX86_FP80TypeKind => todo!(),
         LLVMTypeKind::LLVMFP128TypeKind => todo!(),
         LLVMTypeKind::LLVMPPC_FP128TypeKind => todo!(),

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -639,14 +639,22 @@ fn process_constant(ctx: &mut Context, cctx: &mut ConversionContext, val: LLVMVa
         LLVMValueKind::LLVMGlobalVariableValueKind => {
             let global_name = llvm_get_value_name(val).unwrap_or_default();
             let global_name = cctx.id_legaliser.legalise(&global_name);
-            let global_op = AddressOfOp::new(ctx, global_name);
+            let global_op = AddressOfOp::new(
+                ctx,
+                global_name,
+                llvm_get_pointer_address_space(llvm_type_of(val)),
+            );
             insert_const_inst(ctx, cctx, global_op.get_operation());
             cctx.value_map.insert(val, global_op.get_result(ctx));
         }
         LLVMValueKind::LLVMFunctionValueKind => {
             let fn_name = llvm_get_value_name(val).unwrap_or_default();
             let fn_name = cctx.id_legaliser.legalise(&fn_name);
-            let func_op = AddressOfOp::new(ctx, fn_name);
+            let func_op = AddressOfOp::new(
+                ctx,
+                fn_name,
+                llvm_get_pointer_address_space(llvm_type_of(val)),
+            );
             insert_const_inst(ctx, cctx, func_op.get_operation());
             cctx.value_map.insert(val, func_op.get_result(ctx));
         }

--- a/pliron-llvm/src/function_call_utils.rs
+++ b/pliron-llvm/src/function_call_utils.rs
@@ -74,12 +74,13 @@ pub fn lookup_or_create_malloc_fn(
     symbol_table_op: Box<dyn SymbolTableInterface>,
 ) -> Result<FuncOp> {
     let size_ty = get_size_type(ctx);
+    let ret_ty = PointerType::get(ctx, 0).into();
     lookup_or_insert_function(
         ctx,
         symbol_table_collection,
         symbol_table_op,
         "malloc".try_into().unwrap(),
-        PointerType::get(ctx).into(),
+        ret_ty,
         vec![size_ty],
         false,
     )
@@ -92,7 +93,7 @@ pub fn lookup_or_create_free_fn(
     symbol_table_collection: &mut SymbolTableCollection,
     symbol_table_op: Box<dyn SymbolTableInterface>,
 ) -> Result<FuncOp> {
-    let ptr_ty = PointerType::get(ctx).into();
+    let ptr_ty = PointerType::get(ctx, 0).into();
     lookup_or_insert_function(
         ctx,
         symbol_table_collection,
@@ -115,7 +116,7 @@ pub fn compute_type_size_in_bytes(
     //   %0 = getelementptr %ty* null, %sizeType 1
     //   %1 = ptrtoint %ty* %0 to %sizeType
     let size_ty = get_size_type(ctx);
-    let pointer_ty = PointerType::get(ctx).into();
+    let pointer_ty = PointerType::get(ctx, 0).into();
     let zero_op = ZeroOp::new(ctx, pointer_ty);
     inserter.append_op(ctx, &zero_op);
     let gep_op = GetElementPtrOp::new(

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -14,13 +14,13 @@ use llvm_sys::{
     analysis::LLVMVerifyModule,
     bit_writer::LLVMWriteBitcodeToFile,
     core::{
-        LLVMAddCase, LLVMAddFunction, LLVMAddGlobal, LLVMAddIncoming,
+        LLVMAddCase, LLVMAddFunction, LLVMAddGlobal, LLVMAddGlobalInAddressSpace, LLVMAddIncoming,
         LLVMAppendBasicBlockInContext, LLVMArrayType2, LLVMBasicBlockAsValue, LLVMBuildAShr,
-        LLVMBuildAdd, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildBitCast, LLVMBuildBr,
-        LLVMBuildCall2, LLVMBuildCondBr, LLVMBuildExtractElement, LLVMBuildExtractValue,
-        LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul, LLVMBuildFPExt,
-        LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub,
-        LLVMBuildFreeze, LLVMBuildGEP2, LLVMBuildICmp, LLVMBuildInsertElement,
+        LLVMBuildAdd, LLVMBuildAddrSpaceCast, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildBitCast,
+        LLVMBuildBr, LLVMBuildCall2, LLVMBuildCondBr, LLVMBuildExtractElement,
+        LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
+        LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc, LLVMBuildFRem,
+        LLVMBuildFSub, LLVMBuildFreeze, LLVMBuildGEP2, LLVMBuildICmp, LLVMBuildInsertElement,
         LLVMBuildInsertValue, LLVMBuildIntToPtr, LLVMBuildLShr, LLVMBuildLoad2, LLVMBuildMul,
         LLVMBuildOr, LLVMBuildPhi, LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid,
         LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect,
@@ -47,18 +47,18 @@ use llvm_sys::{
         LLVMGetNamedFunction, LLVMGetNamedGlobal, LLVMGetNextBasicBlock, LLVMGetNextFunction,
         LLVMGetNextGlobal, LLVMGetNextInstruction, LLVMGetNextParam, LLVMGetNumArgOperands,
         LLVMGetNumIndices, LLVMGetNumMaskElements, LLVMGetNumOperands, LLVMGetOperand,
-        LLVMGetParam, LLVMGetParamTypes, LLVMGetPoison, LLVMGetPreviousBasicBlock,
-        LLVMGetPreviousFunction, LLVMGetPreviousGlobal, LLVMGetPreviousInstruction,
-        LLVMGetPreviousParam, LLVMGetReturnType, LLVMGetStructElementTypes, LLVMGetStructName,
-        LLVMGetSwitchCaseValue, LLVMGetTypeKind, LLVMGetUndef, LLVMGetUndefMaskElem,
-        LLVMGetValueKind, LLVMGetValueName2, LLVMGetVectorSize, LLVMGlobalGetValueType,
-        LLVMIntTypeInContext, LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst,
-        LLVMIsAUser, LLVMIsDeclaration, LLVMIsFunctionVarArg, LLVMIsOpaqueStruct,
-        LLVMLookupIntrinsicID, LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext,
-        LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMPrintModuleToFile,
-        LLVMPrintModuleToString, LLVMPrintTypeToString, LLVMPrintValueToString,
-        LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags, LLVMSetInitializer,
-        LLVMSetLinkage, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
+        LLVMGetParam, LLVMGetParamTypes, LLVMGetPointerAddressSpace, LLVMGetPoison,
+        LLVMGetPreviousBasicBlock, LLVMGetPreviousFunction, LLVMGetPreviousGlobal,
+        LLVMGetPreviousInstruction, LLVMGetPreviousParam, LLVMGetReturnType,
+        LLVMGetStructElementTypes, LLVMGetStructName, LLVMGetSwitchCaseValue, LLVMGetTypeKind,
+        LLVMGetUndef, LLVMGetUndefMaskElem, LLVMGetValueKind, LLVMGetValueName2, LLVMGetVectorSize,
+        LLVMGlobalGetValueType, LLVMIntTypeInContext, LLVMIntrinsicIsOverloaded, LLVMIsAFunction,
+        LLVMIsATerminatorInst, LLVMIsAUser, LLVMIsDeclaration, LLVMIsFunctionVarArg,
+        LLVMIsOpaqueStruct, LLVMLookupIntrinsicID, LLVMModuleCreateWithNameInContext,
+        LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore,
+        LLVMPrintModuleToFile, LLVMPrintModuleToString, LLVMPrintTypeToString,
+        LLVMPrintValueToString, LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags,
+        LLVMSetInitializer, LLVMSetLinkage, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
         LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf, LLVMValueAsBasicBlock,
         LLVMValueIsBasicBlock, LLVMVectorType, LLVMVoidTypeInContext,
     },
@@ -635,6 +635,12 @@ pub fn llvm_get_int_type_width(ty: LLVMType) -> u32 {
     unsafe { LLVMGetIntTypeWidth(ty.into()) }
 }
 
+/// LLVMGetPointerAddressSpace
+pub fn llvm_get_pointer_address_space(ty: LLVMType) -> u32 {
+    assert!(llvm_get_type_kind(ty) == LLVMTypeKind::LLVMPointerTypeKind);
+    unsafe { LLVMGetPointerAddressSpace(ty.into()) }
+}
+
 /// LLVMIsOpaqueStruct
 pub fn llvm_is_opaque_struct(ty: LLVMType) -> bool {
     assert!(llvm_get_type_kind(ty) == LLVMTypeKind::LLVMStructTypeKind);
@@ -1193,6 +1199,24 @@ pub fn llvm_add_global(module: &LLVMModule, ty: LLVMType, name: &str) -> LLVMVal
     unsafe { LLVMAddGlobal(module.inner_ref(), ty.into(), to_c_str(name).as_ptr()).into() }
 }
 
+/// LLVMAddGlobalInAddressSpace
+pub fn llvm_add_global_in_address_space(
+    module: &LLVMModule,
+    ty: LLVMType,
+    name: &str,
+    addr_space: u32,
+) -> LLVMValue {
+    unsafe {
+        LLVMAddGlobalInAddressSpace(
+            module.inner_ref(),
+            ty.into(),
+            to_c_str(name).as_ptr(),
+            addr_space,
+        )
+        .into()
+    }
+}
+
 /// LLVMGetInsertBlock
 pub fn llvm_get_insert_block(builder: &LLVMBuilder) -> Option<LLVMBasicBlock> {
     unsafe {
@@ -1639,6 +1663,25 @@ pub fn llvm_build_bitcast(
     assert!(llvm_get_insert_block(builder).is_some());
     unsafe {
         LLVMBuildBitCast(
+            builder.inner_ref(),
+            val.into(),
+            dest_ty.into(),
+            to_c_str(name).as_ptr(),
+        )
+        .into()
+    }
+}
+
+/// LLVMBuildAddrSpaceCast
+pub fn llvm_build_addrspacecast(
+    builder: &LLVMBuilder,
+    val: LLVMValue,
+    dest_ty: LLVMType,
+    name: &str,
+) -> LLVMValue {
+    assert!(llvm_get_insert_block(builder).is_some());
+    unsafe {
+        LLVMBuildAddrSpaceCast(
             builder.inner_ref(),
             val.into(),
             dest_ty.into(),

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -2756,3 +2756,191 @@ pub(super) fn handle_err(err: LLVMErrorRef) -> Result<(), String> {
         }
     }
 }
+
+// =============================================================================
+// Atomics + inline assembly.
+//
+// Wrappers for the LLVM-C atomic and inline-asm builders/accessors, used by the
+// to_llvm_ir / from_llvm_ir bridge for `llvm.atomicrmw`, `llvm.cmpxchg`,
+// `llvm.fence`, `llvm.atomic_load`, `llvm.atomic_store` and `llvm.inline_asm`.
+// =============================================================================
+
+// llvm-sys 221's binding for `LLVMGetSyncScopeID` is missing its return type
+// (it is declared as returning `()`), so we re-declare the correct signature.
+// The real LLVM-C symbol returns the `unsigned` synchronization-scope id.
+unsafe extern "C" {
+    fn LLVMGetSyncScopeID(
+        c: llvm_sys::prelude::LLVMContextRef,
+        name: *const core::ffi::c_char,
+        slen: usize,
+    ) -> core::ffi::c_uint;
+}
+
+/// Resolve a synchronization-scope id by name within `ctx`. The empty string is
+/// the system scope (id 1); `"singlethread"` is the single-thread scope (id 0).
+pub fn llvm_get_sync_scope_id(ctx: &LLVMContext, name: &str) -> u32 {
+    unsafe {
+        LLVMGetSyncScopeID(
+            ctx.inner_ref(),
+            name.as_ptr() as *const core::ffi::c_char,
+            name.len(),
+        )
+    }
+}
+
+/// LLVMBuildAtomicRMWSyncScope
+pub fn llvm_build_atomic_rmw(
+    builder: &LLVMBuilder,
+    op: llvm_sys::LLVMAtomicRMWBinOp,
+    ptr: LLVMValue,
+    val: LLVMValue,
+    ordering: llvm_sys::LLVMAtomicOrdering,
+    ssid: u32,
+) -> LLVMValue {
+    assert!(llvm_get_insert_block(builder).is_some());
+    unsafe {
+        llvm_sys::core::LLVMBuildAtomicRMWSyncScope(
+            builder.inner_ref(),
+            op,
+            ptr.into(),
+            val.into(),
+            ordering,
+            ssid,
+        )
+        .into()
+    }
+}
+
+/// LLVMBuildAtomicCmpXchgSyncScope (result is the `{ T, i1 }` pair).
+pub fn llvm_build_atomic_cmpxchg(
+    builder: &LLVMBuilder,
+    ptr: LLVMValue,
+    cmp: LLVMValue,
+    new: LLVMValue,
+    success: llvm_sys::LLVMAtomicOrdering,
+    failure: llvm_sys::LLVMAtomicOrdering,
+    ssid: u32,
+) -> LLVMValue {
+    assert!(llvm_get_insert_block(builder).is_some());
+    unsafe {
+        llvm_sys::core::LLVMBuildAtomicCmpXchgSyncScope(
+            builder.inner_ref(),
+            ptr.into(),
+            cmp.into(),
+            new.into(),
+            success,
+            failure,
+            ssid,
+        )
+        .into()
+    }
+}
+
+/// LLVMBuildFenceSyncScope
+pub fn llvm_build_fence(
+    builder: &LLVMBuilder,
+    ordering: llvm_sys::LLVMAtomicOrdering,
+    ssid: u32,
+    name: &str,
+) -> LLVMValue {
+    assert!(llvm_get_insert_block(builder).is_some());
+    unsafe {
+        llvm_sys::core::LLVMBuildFenceSyncScope(
+            builder.inner_ref(),
+            ordering,
+            ssid,
+            to_c_str(name).as_ptr(),
+        )
+        .into()
+    }
+}
+
+/// LLVMSetOrdering: turn a plain load/store into an atomic one.
+pub fn llvm_set_ordering(inst: LLVMValue, ordering: llvm_sys::LLVMAtomicOrdering) {
+    unsafe { llvm_sys::core::LLVMSetOrdering(inst.into(), ordering) }
+}
+
+/// LLVMGetOrdering
+pub fn llvm_get_ordering(inst: LLVMValue) -> llvm_sys::LLVMAtomicOrdering {
+    unsafe { llvm_sys::core::LLVMGetOrdering(inst.into()) }
+}
+
+/// LLVMSetAtomicSyncScopeID
+pub fn llvm_set_atomic_sync_scope_id(inst: LLVMValue, ssid: u32) {
+    unsafe { llvm_sys::core::LLVMSetAtomicSyncScopeID(inst.into(), ssid) }
+}
+
+/// LLVMGetAtomicSyncScopeID
+pub fn llvm_get_atomic_sync_scope_id(inst: LLVMValue) -> u32 {
+    unsafe { llvm_sys::core::LLVMGetAtomicSyncScopeID(inst.into()) }
+}
+
+/// LLVMGetAtomicRMWBinOp
+pub fn llvm_get_atomic_rmw_bin_op(inst: LLVMValue) -> llvm_sys::LLVMAtomicRMWBinOp {
+    unsafe { llvm_sys::core::LLVMGetAtomicRMWBinOp(inst.into()) }
+}
+
+/// LLVMGetCmpXchgSuccessOrdering
+pub fn llvm_get_cmpxchg_success_ordering(inst: LLVMValue) -> llvm_sys::LLVMAtomicOrdering {
+    unsafe { llvm_sys::core::LLVMGetCmpXchgSuccessOrdering(inst.into()) }
+}
+
+/// LLVMGetCmpXchgFailureOrdering
+pub fn llvm_get_cmpxchg_failure_ordering(inst: LLVMValue) -> llvm_sys::LLVMAtomicOrdering {
+    unsafe { llvm_sys::core::LLVMGetCmpXchgFailureOrdering(inst.into()) }
+}
+
+/// LLVMGetInlineAsm: create an inline-asm callee value of function type `fn_ty`.
+#[allow(clippy::too_many_arguments)]
+pub fn llvm_get_inline_asm(
+    fn_ty: LLVMType,
+    asm: &str,
+    constraints: &str,
+    has_side_effects: bool,
+    is_align_stack: bool,
+    dialect: llvm_sys::LLVMInlineAsmDialect,
+    can_throw: bool,
+) -> LLVMValue {
+    unsafe {
+        llvm_sys::core::LLVMGetInlineAsm(
+            fn_ty.into(),
+            asm.as_ptr() as *const core::ffi::c_char,
+            asm.len(),
+            constraints.as_ptr() as *const core::ffi::c_char,
+            constraints.len(),
+            has_side_effects as llvm_sys::prelude::LLVMBool,
+            is_align_stack as llvm_sys::prelude::LLVMBool,
+            dialect,
+            can_throw as llvm_sys::prelude::LLVMBool,
+        )
+        .into()
+    }
+}
+
+/// LLVMGetInlineAsmAsmString
+pub fn llvm_get_inline_asm_asm_string(v: LLVMValue) -> String {
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = llvm_sys::core::LLVMGetInlineAsmAsmString(v.into(), &mut len);
+        String::from_utf8_lossy(std::slice::from_raw_parts(ptr as *const u8, len)).into_owned()
+    }
+}
+
+/// LLVMGetInlineAsmConstraintString
+pub fn llvm_get_inline_asm_constraint_string(v: LLVMValue) -> String {
+    unsafe {
+        let mut len: usize = 0;
+        let ptr = llvm_sys::core::LLVMGetInlineAsmConstraintString(v.into(), &mut len);
+        String::from_utf8_lossy(std::slice::from_raw_parts(ptr as *const u8, len)).into_owned()
+    }
+}
+
+/// LLVMGetInlineAsmHasSideEffects
+pub fn llvm_get_inline_asm_has_side_effects(v: LLVMValue) -> bool {
+    unsafe { llvm_sys::core::LLVMGetInlineAsmHasSideEffects(v.into()) != 0 }
+}
+
+/// LLVMGetInlineAsmFunctionType
+pub fn llvm_get_inline_asm_function_type(v: LLVMValue) -> LLVMType {
+    unsafe { llvm_sys::core::LLVMGetInlineAsmFunctionType(v.into()).into() }
+}

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -52,15 +52,16 @@ use llvm_sys::{
         LLVMGetPreviousInstruction, LLVMGetPreviousParam, LLVMGetReturnType,
         LLVMGetStructElementTypes, LLVMGetStructName, LLVMGetSwitchCaseValue, LLVMGetTypeKind,
         LLVMGetUndef, LLVMGetUndefMaskElem, LLVMGetValueKind, LLVMGetValueName2, LLVMGetVectorSize,
-        LLVMGlobalGetValueType, LLVMIntTypeInContext, LLVMIntrinsicIsOverloaded, LLVMIsAFunction,
-        LLVMIsATerminatorInst, LLVMIsAUser, LLVMIsDeclaration, LLVMIsFunctionVarArg,
-        LLVMIsOpaqueStruct, LLVMLookupIntrinsicID, LLVMModuleCreateWithNameInContext,
-        LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore,
-        LLVMPrintModuleToFile, LLVMPrintModuleToString, LLVMPrintTypeToString,
-        LLVMPrintValueToString, LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags,
-        LLVMSetInitializer, LLVMSetLinkage, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
-        LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf, LLVMValueAsBasicBlock,
-        LLVMValueIsBasicBlock, LLVMVectorType, LLVMVoidTypeInContext,
+        LLVMGlobalGetValueType, LLVMHalfTypeInContext, LLVMIntTypeInContext,
+        LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst, LLVMIsAUser,
+        LLVMIsDeclaration, LLVMIsFunctionVarArg, LLVMIsOpaqueStruct, LLVMLookupIntrinsicID,
+        LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd,
+        LLVMPositionBuilderBefore, LLVMPrintModuleToFile, LLVMPrintModuleToString,
+        LLVMPrintTypeToString, LLVMPrintValueToString, LLVMScalableVectorType, LLVMSetAlignment,
+        LLVMSetFastMathFlags, LLVMSetInitializer, LLVMSetLinkage, LLVMSetNNeg,
+        LLVMStructCreateNamed, LLVMStructSetBody, LLVMStructTypeInContext, LLVMTypeIsSized,
+        LLVMTypeOf, LLVMValueAsBasicBlock, LLVMValueIsBasicBlock, LLVMVectorType,
+        LLVMVoidTypeInContext,
     },
     error::{LLVMDisposeErrorMessage, LLVMErrorRef, LLVMGetErrorMessage},
     prelude::{
@@ -1254,6 +1255,11 @@ pub fn llvm_float_type_in_context(context: &LLVMContext) -> LLVMType {
 /// LLVMDoubleTypeInContext
 pub fn llvm_double_type_in_context(context: &LLVMContext) -> LLVMType {
     unsafe { LLVMDoubleTypeInContext(context.inner_ref()).into() }
+}
+
+/// LLVMHalfTypeInContext
+pub fn llvm_half_type_in_context(context: &LLVMContext) -> LLVMType {
+    unsafe { LLVMHalfTypeInContext(context.inner_ref()).into() }
 }
 
 /// ArrayType::isValidElementType

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -4207,3 +4207,186 @@ impl IsDeclaration for FuncOp {
         self.get_region(ctx).is_none()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AddrSpaceCastOp, AtomicCmpxchgOp, AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, FenceOp,
+        FuncOp, ReturnOp,
+    };
+    use crate::attributes::{AtomicOrderingAttr, AtomicRmwKindAttr};
+    use crate::op_interfaces::CastOpInterface;
+    use crate::types::{FuncType, PointerType, VoidType};
+    use pliron::{
+        basic_block::BasicBlock,
+        builtin::{
+            op_interfaces::SingleBlockRegionInterface,
+            ops::ModuleOp,
+            types::{IntegerType, Signedness},
+        },
+        combine::Parser,
+        context::{Context, Ptr},
+        irfmt::parsers::spaced,
+        location,
+        op::Op,
+        operation::Operation,
+        parsable::{self, state_stream_from_iterator},
+        printable::Printable,
+        r#type::TypeObj,
+        value::Value,
+    };
+
+    /// Build a module with a function whose entry block has the given argument
+    /// types, let `build` add ops to that block, then assert the whole module
+    /// round-trips through the parser unchanged.
+    fn assert_op_roundtrips(
+        make_arg_types: impl FnOnce(&mut Context) -> Vec<Ptr<TypeObj>>,
+        build: impl FnOnce(&mut Context, Ptr<BasicBlock>, &[Value]),
+        expected: &[&str],
+    ) {
+        let ctx = &mut Context::new();
+        let arg_types = make_arg_types(ctx);
+
+        let module = ModuleOp::new(ctx, "test".try_into().unwrap());
+        let module_block = module.get_body(ctx, 0);
+
+        let void = VoidType::get(ctx).into();
+        let fty = FuncType::get(ctx, void, arg_types, false);
+        let func = FuncOp::new(ctx, "f".try_into().unwrap(), fty);
+        let entry = func.get_or_create_entry_block(ctx);
+        let args: Vec<Value> = entry.deref(ctx).arguments().collect();
+
+        build(ctx, entry, &args);
+        ReturnOp::new(ctx, None)
+            .get_operation()
+            .insert_at_back(entry, ctx);
+        func.get_operation().insert_at_back(module_block, ctx);
+
+        let printed = module.get_operation().disp(ctx).to_string();
+        for tok in expected {
+            assert!(
+                printed.contains(tok),
+                "expected `{tok}` in printed IR:\n{printed}"
+            );
+        }
+
+        // The printed IR must re-parse: this exercises the op's (and its
+        // attributes') parser against exactly what its printer produced.
+        let ctx2 = &mut Context::new();
+        let state_stream = state_stream_from_iterator(
+            printed.chars(),
+            parsable::State::new(ctx2, location::Source::InMemory),
+        );
+        spaced(Operation::top_level_parser())
+            .parse(state_stream)
+            .expect("printed IR should re-parse");
+    }
+
+    fn i32_ty(ctx: &mut Context) -> Ptr<TypeObj> {
+        IntegerType::get(ctx, 32, Signedness::Signless).into()
+    }
+
+    #[test]
+    fn test_addrspacecast_roundtrips() {
+        assert_op_roundtrips(
+            |ctx| vec![PointerType::get(ctx, 0).into()],
+            |ctx, entry, args| {
+                let dst = PointerType::get(ctx, 1).into();
+                AddrSpaceCastOp::new(ctx, args[0], dst)
+                    .get_operation()
+                    .insert_at_back(entry, ctx);
+            },
+            &["llvm.addrspacecast", "llvm.ptr addrspace(1)"],
+        );
+    }
+
+    #[test]
+    fn test_atomicrmw_roundtrips() {
+        assert_op_roundtrips(
+            |ctx| vec![PointerType::get(ctx, 1).into(), i32_ty(ctx)],
+            |ctx, entry, args| {
+                AtomicRmwOp::new(
+                    ctx,
+                    args[0],
+                    args[1],
+                    AtomicRmwKindAttr::Add,
+                    AtomicOrderingAttr::SeqCst,
+                    Some("device".to_string()),
+                )
+                .get_operation()
+                .insert_at_back(entry, ctx);
+            },
+            &["llvm.atomicrmw", "Add", "SeqCst", "device"],
+        );
+    }
+
+    #[test]
+    fn test_cmpxchg_roundtrips() {
+        assert_op_roundtrips(
+            |ctx| {
+                let i = i32_ty(ctx);
+                vec![PointerType::get(ctx, 0).into(), i, i]
+            },
+            |ctx, entry, args| {
+                AtomicCmpxchgOp::new(
+                    ctx,
+                    args[0],
+                    args[1],
+                    args[2],
+                    AtomicOrderingAttr::AcqRel,
+                    AtomicOrderingAttr::Monotonic,
+                    None,
+                )
+                .get_operation()
+                .insert_at_back(entry, ctx);
+            },
+            &["llvm.cmpxchg", "AcqRel", "Monotonic"],
+        );
+    }
+
+    #[test]
+    fn test_fence_roundtrips() {
+        assert_op_roundtrips(
+            |_ctx| vec![],
+            |ctx, entry, _args| {
+                FenceOp::new(ctx, AtomicOrderingAttr::SeqCst, Some("block".to_string()))
+                    .get_operation()
+                    .insert_at_back(entry, ctx);
+            },
+            &["llvm.fence", "SeqCst", "block"],
+        );
+    }
+
+    #[test]
+    fn test_atomic_load_roundtrips() {
+        assert_op_roundtrips(
+            |ctx| vec![PointerType::get(ctx, 3).into()],
+            |ctx, entry, args| {
+                let res = i32_ty(ctx);
+                AtomicLoadOp::new(ctx, args[0], res, AtomicOrderingAttr::Acquire, None)
+                    .get_operation()
+                    .insert_at_back(entry, ctx);
+            },
+            &["llvm.atomic_load", "Acquire"],
+        );
+    }
+
+    #[test]
+    fn test_atomic_store_roundtrips() {
+        assert_op_roundtrips(
+            |ctx| vec![i32_ty(ctx), PointerType::get(ctx, 3).into()],
+            |ctx, entry, args| {
+                AtomicStoreOp::new(
+                    ctx,
+                    args[0],
+                    args[1],
+                    AtomicOrderingAttr::Release,
+                    Some("device".to_string()),
+                )
+                .get_operation()
+                .insert_at_back(entry, ctx);
+            },
+            &["llvm.atomic_store", "Release", "device"],
+        );
+    }
+}

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -52,8 +52,9 @@ use pliron::{
 
 use crate::{
     attributes::{
-        AddressSpaceAttr, AlignmentAttr, CaseValuesAttr, FCmpPredicateAttr, FastmathFlagsAttr,
-        InsertExtractValueIndicesAttr, LinkageAttr, ShuffleVectorMaskAttr,
+        AddressSpaceAttr, AlignmentAttr, AtomicOrderingAttr, AtomicRmwKindAttr, CaseValuesAttr,
+        FCmpPredicateAttr, FastmathFlagsAttr, InsertExtractValueIndicesAttr, LinkageAttr,
+        ShuffleVectorMaskAttr,
     },
     op_interfaces::{
         AlignableOpInterface, BinArithOp, CastOpInterface, CastOpWithNNegInterface, FastMathFlags,
@@ -1564,6 +1565,257 @@ impl PromotableOpInterface for StoreOp {
         }
         rewriter.erase_operation(ctx, self.get_operation());
         Ok(())
+    }
+}
+
+/// Equivalent to LLVM's `atomicrmw`: atomically applies `kind` to the value at
+/// a pointer and returns the old value.
+///
+/// ### Operands
+/// | operand | description |
+/// |-----|-------|
+/// | `ptr` | [PointerType] |
+/// | `val` | value to combine with the one in memory |
+///
+/// ### Result(s):
+/// | result | description |
+/// |-----|-------|
+/// | `res` | the old value (same type as `val`) |
+#[pliron_op(
+    name = "llvm.atomicrmw",
+    format = "attr($llvm_rmw_kind, $AtomicRmwKindAttr) ` ` $0 `, ` $1 ` ` opt_attr($llvm_rmw_syncscope, $StringAttr, label($syncscope)) attr($llvm_rmw_ordering, $AtomicOrderingAttr) ` : ` type($0)",
+    interfaces = [
+        OneResultInterface,
+        NResultsInterface<1>,
+        NOpdsInterface<2>,
+        OperandNOfType<0, PointerType>
+    ],
+    attributes = (
+        llvm_rmw_kind: AtomicRmwKindAttr,
+        llvm_rmw_ordering: AtomicOrderingAttr,
+        llvm_rmw_syncscope: StringAttr
+    ),
+    verifier = "succ"
+)]
+pub struct AtomicRmwOp;
+
+impl AtomicRmwOp {
+    /// Create a new [AtomicRmwOp]. `syncscope` is `None` for the system scope.
+    pub fn new(
+        ctx: &mut Context,
+        ptr: Value,
+        val: Value,
+        kind: AtomicRmwKindAttr,
+        ordering: AtomicOrderingAttr,
+        syncscope: Option<String>,
+    ) -> Self {
+        use pliron::r#type::Typed;
+        let res_ty = val.get_type(ctx);
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![res_ty],
+            vec![ptr, val],
+            vec![],
+            0,
+        );
+        let op = AtomicRmwOp { op };
+        op.set_attr_llvm_rmw_kind(ctx, kind);
+        op.set_attr_llvm_rmw_ordering(ctx, ordering);
+        if let Some(scope) = syncscope {
+            op.set_attr_llvm_rmw_syncscope(ctx, StringAttr::new(scope));
+        }
+        op
+    }
+}
+
+/// Equivalent to LLVM's `cmpxchg`: atomically compares the value at a pointer
+/// with `cmp` and, if equal, stores `new`. Returns a `{ value, i1 }` pair of the
+/// loaded value and whether the swap succeeded.
+///
+/// ### Operands
+/// | operand | description |
+/// |-----|-------|
+/// | `ptr` | [PointerType] |
+/// | `cmp` | expected value |
+/// | `new` | value to store on success |
+///
+/// ### Result(s):
+/// | result | description |
+/// |-----|-------|
+/// | `res` | `{ value, i1 }` (loaded value, success flag) |
+#[pliron_op(
+    name = "llvm.cmpxchg",
+    format = "$0 `, ` $1 `, ` $2 ` ` opt_attr($llvm_cas_syncscope, $StringAttr, label($syncscope)) attr($llvm_cas_success_ordering, $AtomicOrderingAttr) ` ` attr($llvm_cas_failure_ordering, $AtomicOrderingAttr) ` : ` type($0)",
+    interfaces = [
+        OneResultInterface,
+        NResultsInterface<1>,
+        NOpdsInterface<3>,
+        OperandNOfType<0, PointerType>
+    ],
+    attributes = (
+        llvm_cas_success_ordering: AtomicOrderingAttr,
+        llvm_cas_failure_ordering: AtomicOrderingAttr,
+        llvm_cas_syncscope: StringAttr
+    ),
+    verifier = "succ"
+)]
+pub struct AtomicCmpxchgOp;
+
+impl AtomicCmpxchgOp {
+    /// Create a new [AtomicCmpxchgOp]. `syncscope` is `None` for the system scope.
+    pub fn new(
+        ctx: &mut Context,
+        ptr: Value,
+        cmp: Value,
+        new_val: Value,
+        success_ordering: AtomicOrderingAttr,
+        failure_ordering: AtomicOrderingAttr,
+        syncscope: Option<String>,
+    ) -> Self {
+        use pliron::r#type::Typed;
+        let val_ty = cmp.get_type(ctx);
+        let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
+        let res_ty = StructType::get_unnamed(ctx, vec![val_ty, bool_ty.into()]).into();
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![res_ty],
+            vec![ptr, cmp, new_val],
+            vec![],
+            0,
+        );
+        let op = AtomicCmpxchgOp { op };
+        op.set_attr_llvm_cas_success_ordering(ctx, success_ordering);
+        op.set_attr_llvm_cas_failure_ordering(ctx, failure_ordering);
+        if let Some(scope) = syncscope {
+            op.set_attr_llvm_cas_syncscope(ctx, StringAttr::new(scope));
+        }
+        op
+    }
+}
+
+/// Equivalent to LLVM's `fence`: orders memory accesses. Has no operands or
+/// results.
+#[pliron_op(
+    name = "llvm.fence",
+    format = "opt_attr($llvm_fence_syncscope, $StringAttr, label($syncscope)) attr($llvm_fence_ordering, $AtomicOrderingAttr)",
+    interfaces = [NResultsInterface<0>, NOpdsInterface<0>],
+    attributes = (llvm_fence_ordering: AtomicOrderingAttr, llvm_fence_syncscope: StringAttr),
+    verifier = "succ"
+)]
+pub struct FenceOp;
+
+impl FenceOp {
+    /// Create a new [FenceOp]. `syncscope` is `None` for the system scope.
+    pub fn new(ctx: &mut Context, ordering: AtomicOrderingAttr, syncscope: Option<String>) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 0);
+        let op = FenceOp { op };
+        op.set_attr_llvm_fence_ordering(ctx, ordering);
+        if let Some(scope) = syncscope {
+            op.set_attr_llvm_fence_syncscope(ctx, StringAttr::new(scope));
+        }
+        op
+    }
+}
+
+/// Equivalent to LLVM's atomic `load`.
+///
+/// ### Operands
+/// | operand | description |
+/// |-----|-------|
+/// | `ptr` | [PointerType] |
+///
+/// ### Result(s):
+/// | result | description |
+/// |-----|-------|
+/// | `res` | the loaded value |
+#[pliron_op(
+    name = "llvm.atomic_load",
+    format = "$0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`)) ` ` opt_attr($llvm_ld_syncscope, $StringAttr, label($syncscope)) attr($llvm_ld_ordering, $AtomicOrderingAttr) ` : ` type($0)",
+    interfaces = [
+        OneResultInterface,
+        OneOpdInterface,
+        NResultsInterface<1>,
+        NOpdsInterface<1>,
+        AlignableOpInterface,
+        OperandNOfType<0, PointerType>
+    ],
+    attributes = (llvm_ld_ordering: AtomicOrderingAttr, llvm_ld_syncscope: StringAttr),
+    verifier = "succ"
+)]
+pub struct AtomicLoadOp;
+
+impl AtomicLoadOp {
+    /// Create a new [AtomicLoadOp]. `syncscope` is `None` for the system scope.
+    pub fn new(
+        ctx: &mut Context,
+        ptr: Value,
+        res_ty: Ptr<TypeObj>,
+        ordering: AtomicOrderingAttr,
+        syncscope: Option<String>,
+    ) -> Self {
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![res_ty],
+            vec![ptr],
+            vec![],
+            0,
+        );
+        let op = AtomicLoadOp { op };
+        op.set_attr_llvm_ld_ordering(ctx, ordering);
+        if let Some(scope) = syncscope {
+            op.set_attr_llvm_ld_syncscope(ctx, StringAttr::new(scope));
+        }
+        op
+    }
+}
+
+/// Equivalent to LLVM's atomic `store`.
+///
+/// ### Operands
+/// | operand | description |
+/// |-----|-------|
+/// | `val` | value to store |
+/// | `ptr` | [PointerType] |
+#[pliron_op(
+    name = "llvm.atomic_store",
+    format = "`*` $1 ` <- ` $0 ` ` opt_attr($llvm_alignment, $AlignmentAttr, label($align), delimiters(`[`, `]`)) ` ` opt_attr($llvm_st_syncscope, $StringAttr, label($syncscope)) attr($llvm_st_ordering, $AtomicOrderingAttr)",
+    interfaces = [
+        NResultsInterface<0>,
+        AlignableOpInterface,
+        OperandNOfType<1, PointerType>,
+        NOpdsInterface<2>
+    ],
+    attributes = (llvm_st_ordering: AtomicOrderingAttr, llvm_st_syncscope: StringAttr),
+    verifier = "succ"
+)]
+pub struct AtomicStoreOp;
+
+impl AtomicStoreOp {
+    /// Create a new [AtomicStoreOp]. `syncscope` is `None` for the system scope.
+    pub fn new(
+        ctx: &mut Context,
+        value: Value,
+        ptr: Value,
+        ordering: AtomicOrderingAttr,
+        syncscope: Option<String>,
+    ) -> Self {
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![],
+            vec![value, ptr],
+            vec![],
+            0,
+        );
+        let op = AtomicStoreOp { op };
+        op.set_attr_llvm_st_ordering(ctx, ordering);
+        if let Some(scope) = syncscope {
+            op.set_attr_llvm_st_syncscope(ctx, StringAttr::new(scope));
+        }
+        op
     }
 }
 

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -52,7 +52,7 @@ use pliron::{
 
 use crate::{
     attributes::{
-        AlignmentAttr, CaseValuesAttr, FCmpPredicateAttr, FastmathFlagsAttr,
+        AddressSpaceAttr, AlignmentAttr, CaseValuesAttr, FCmpPredicateAttr, FastmathFlagsAttr,
         InsertExtractValueIndicesAttr, LinkageAttr, ShuffleVectorMaskAttr,
     },
     op_interfaces::{
@@ -449,7 +449,8 @@ impl PointerTypeResult for AllocaOp {
 impl AllocaOp {
     /// Create a new [AllocaOp]
     pub fn new(ctx: &mut Context, elem_type: Ptr<TypeObj>, size: Value) -> Self {
-        let ptr_ty = PointerType::get(ctx).into();
+        // `alloca` yields a pointer in the default (stack) address space.
+        let ptr_ty = PointerType::get(ctx, 0).into();
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),
@@ -600,6 +601,33 @@ pub enum PtrToIntOpErr {
     verifier = "succ"
 )]
 pub struct PtrToIntOp;
+
+/// Equivalent to LLVM's AddrSpaceCast opcode: casts a pointer to a pointer in a
+/// different address space.
+/// ### Operands
+/// | operand | description |
+/// |-----|-------|
+/// | `arg` | [PointerType] |
+///
+/// ### Result(s):
+/// | result | description |
+/// |-----|-------|
+/// | `res` | [PointerType] |
+#[pliron_op(
+    name = "llvm.addrspacecast",
+    format = "$0 ` to ` type($0)",
+    interfaces = [
+        OneResultInterface,
+        OneOpdInterface,
+        NResultsInterface<1>,
+        NOpdsInterface<1>,
+        CastOpInterface,
+        OperandNOfType<0, PointerType>,
+        ResultNOfType<0, PointerType>,
+    ],
+    verifier = "succ"
+)]
+pub struct AddrSpaceCastOp;
 
 /// Equivalent to LLVM's Unconditional Branch.
 /// ### Operands
@@ -1279,7 +1307,17 @@ impl GetElementPtrOp {
         indices: Vec<GepIndex>,
         src_elem_type: Ptr<TypeObj>,
     ) -> Self {
-        let result_type = PointerType::get(ctx).into();
+        use pliron::r#type::Typed;
+
+        // A GEP result inherits the address space of its base pointer.
+        let addr_space = {
+            let base_ty = base.get_type(ctx);
+            base_ty
+                .deref(ctx)
+                .downcast_ref::<PointerType>()
+                .map_or(0, PointerType::address_space)
+        };
+        let result_type = PointerType::get(ctx, addr_space).into();
         let mut attr: Vec<GepIndexAttr> = Vec::new();
         let mut opds: Vec<Value> = vec![base];
         for idx in indices {
@@ -1963,7 +2001,12 @@ pub enum GlobalOpVerifyErr {
         LlvmSymbolName,
         AlignableOpInterface
     ],
-    attributes = (llvm_global_type: TypeAttr, global_initializer, llvm_global_linkage: LinkageAttr)
+    attributes = (
+        llvm_global_type: TypeAttr,
+        global_initializer,
+        llvm_global_linkage: LinkageAttr,
+        llvm_global_addrspace: AddressSpaceAttr
+    )
 )]
 pub struct GlobalOp;
 
@@ -1975,6 +2018,17 @@ impl GlobalOp {
         op.set_symbol_name(ctx, name);
         op.set_attr_llvm_global_type(ctx, TypeAttr::new(ty));
         op
+    }
+
+    /// Get the address space of this global (0 if unset).
+    pub fn address_space(&self, ctx: &Context) -> u32 {
+        self.get_attr_llvm_global_addrspace(ctx)
+            .map_or(0, |attr| attr.0)
+    }
+
+    /// Set the address space of this global.
+    pub fn set_address_space(&self, ctx: &mut Context, addr_space: u32) {
+        self.set_attr_llvm_global_addrspace(ctx, AddressSpaceAttr(addr_space));
     }
 }
 
@@ -2175,7 +2229,8 @@ pub struct AddressOfOp;
 impl AddressOfOp {
     /// Create a new [AddressOfOp].
     pub fn new(ctx: &mut Context, global_name: Identifier) -> Self {
-        let result_type = PointerType::get(ctx).into();
+        // TODO: once globals carry an address space, use the global's space here.
+        let result_type = PointerType::get(ctx, 0).into();
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -96,7 +96,6 @@ use super::{
     name = "llvm.return",
     format = "operands(CharSpace(`,`))",
     interfaces = [IsTerminatorInterface, NResultsInterface<0>, AtMostNOpdsInterface<1>, OptionalOpdInterface],
-    verifier = "succ"
 )]
 pub struct ReturnOp;
 impl ReturnOp {
@@ -116,6 +115,45 @@ impl ReturnOp {
     /// Get the returned value, if it exists.
     pub fn retval(&self, ctx: &Context) -> Option<Value> {
         self.get_operand(ctx)
+    }
+}
+
+#[derive(Error, Debug)]
+enum ReturnOpVerifyErr {
+    #[error("ReturnOp must have no operands in a void function")]
+    VoidWithOperand,
+    #[error("ReturnOp must have exactly one operand in a non-void function")]
+    NonVoidArity,
+    #[error("ReturnOp operand type does not match the function's result type")]
+    ResultTypeMismatch,
+}
+
+impl Verify for ReturnOp {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        use pliron::r#type::Typed;
+        // Signature coupling is only enforced when the return is inside a FuncOp.
+        let Some(parent_op) = self.get_operation().deref(ctx).get_parent_op(ctx) else {
+            return Ok(());
+        };
+        let Some(func_op) = Operation::get_op::<FuncOp>(parent_op, ctx) else {
+            return Ok(());
+        };
+        let func_ty = func_op.get_type(ctx);
+        let res_ty = func_ty.deref(ctx).result_type();
+        let num_operands = self.get_operation().deref(ctx).get_num_operands();
+        if res_ty.deref(ctx).is::<crate::types::VoidType>() {
+            if num_operands != 0 {
+                verify_err!(self.loc(ctx), ReturnOpVerifyErr::VoidWithOperand)?
+            }
+        } else if num_operands != 1 {
+            verify_err!(self.loc(ctx), ReturnOpVerifyErr::NonVoidArity)?
+        } else {
+            let ret_ty = self.get_operation().deref(ctx).get_operand(0).get_type(ctx);
+            if ret_ty != res_ty {
+                verify_err!(self.loc(ctx), ReturnOpVerifyErr::ResultTypeMismatch)?
+            }
+        }
+        Ok(())
     }
 }
 
@@ -645,9 +683,25 @@ pub struct AddrSpaceCastOp;
     name = "llvm.br",
     format = "succ($0) `(` operands(CharSpace(`,`)) `)`",
     interfaces = [IsTerminatorInterface, NResultsInterface<0>],
-    verifier = "succ"
 )]
 pub struct BrOp;
+
+#[derive(Error, Debug)]
+enum BrOpVerifyErr {
+    #[error("BrOp must have exactly one successor")]
+    ExpectedOneSuccessor,
+}
+
+impl Verify for BrOp {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        // Operand/argument count and types are checked by BranchOpInterface;
+        // here we only enforce the single-successor invariant.
+        if self.get_operation().deref(ctx).get_num_successors() != 1 {
+            verify_err!(self.loc(ctx), BrOpVerifyErr::ExpectedOneSuccessor)?
+        }
+        Ok(())
+    }
+}
 
 #[op_interface_impl]
 impl BranchOpInterface for BrOp {
@@ -2168,7 +2222,7 @@ impl Verify for CallOp {
 #[pliron_op(
     name = "llvm.undef",
     format = "`: ` type($0)",
-    interfaces = [OneResultInterface, NResultsInterface<1>],
+    interfaces = [OneResultInterface, NResultsInterface<1>, NOpdsInterface<0>],
     verifier = "succ"
 )]
 pub struct UndefOp;
@@ -2525,11 +2579,25 @@ impl Parsable for GlobalOp {
 #[pliron_op(
     name = "llvm.addressof",
     format = "`@` attr($global_name, $IdentifierAttr) ` : ` type($0)",
-    interfaces = [OneResultInterface, NResultsInterface<1>, ResultNOfType<0, PointerType>],
+    interfaces = [OneResultInterface, NResultsInterface<1>, NOpdsInterface<0>, ResultNOfType<0, PointerType>],
     attributes = (global_name: IdentifierAttr),
-    verifier = "succ"
 )]
 pub struct AddressOfOp;
+
+#[derive(Error, Debug)]
+enum AddressOfOpVerifyErr {
+    #[error("AddressOfOp is missing its `global_name` attribute")]
+    MissingGlobalName,
+}
+
+impl Verify for AddressOfOp {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        if self.get_attr_global_name(ctx).is_none() {
+            verify_err!(self.loc(ctx), AddressOfOpVerifyErr::MissingGlobalName)?
+        }
+        Ok(())
+    }
+}
 
 impl AddressOfOp {
     /// Create a new [AddressOfOp].

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -11,9 +11,10 @@ use pliron::{
             self, ATTR_KEY_SYM_NAME, AtLeastNOpdsInterface, AtLeastNResultsInterface,
             AtMostNOpdsInterface, AtMostNRegionsInterface, AtMostOneRegionInterface,
             BranchOpInterface, CallOpCallable, CallOpInterface, IsTerminatorInterface,
-            IsolatedFromAboveInterface, NOpdsInterface, NResultsInterface, OneOpdInterface,
-            OneResultInterface, OperandNOfType, OperandSegmentInterface, OptionalOpdInterface,
-            ResultNOfType, SameOperandsAndResultType, SameOperandsType, SameResultsType,
+            IsolatedFromAboveInterface, NOpdsInterface, NResultsInterface, NSuccsInterface,
+            OneOpdInterface, OneResultInterface, OneSuccInterface, OperandNOfType,
+            OperandSegmentInterface, OptionalOpdInterface, ResultNOfType,
+            SameOperandsAndResultType, SameOperandsType, SameResultsType,
             SingleBlockRegionInterface, SymbolOpInterface, SymbolUserOpInterface,
         },
         type_interfaces::{FloatTypeInterface, FunctionTypeInterface},
@@ -682,26 +683,15 @@ pub struct AddrSpaceCastOp;
 #[pliron_op(
     name = "llvm.br",
     format = "succ($0) `(` operands(CharSpace(`,`)) `)`",
-    interfaces = [IsTerminatorInterface, NResultsInterface<0>],
+    interfaces = [
+        IsTerminatorInterface,
+        NResultsInterface<0>,
+        NSuccsInterface<1>,
+        OneSuccInterface
+    ],
+    verifier = "succ"
 )]
 pub struct BrOp;
-
-#[derive(Error, Debug)]
-enum BrOpVerifyErr {
-    #[error("BrOp must have exactly one successor")]
-    ExpectedOneSuccessor,
-}
-
-impl Verify for BrOp {
-    fn verify(&self, ctx: &Context) -> Result<()> {
-        // Operand/argument count and types are checked by BranchOpInterface;
-        // here we only enforce the single-successor invariant.
-        if self.get_operation().deref(ctx).get_num_successors() != 1 {
-            verify_err!(self.loc(ctx), BrOpVerifyErr::ExpectedOneSuccessor)?
-        }
-        Ok(())
-    }
-}
 
 #[op_interface_impl]
 impl BranchOpInterface for BrOp {
@@ -758,7 +748,7 @@ impl BrOp {
 /// | `false_dest` | Any successor |
 #[pliron_op(
     name = "llvm.cond_br",
-    interfaces = [IsTerminatorInterface, NResultsInterface<0>],
+    interfaces = [IsTerminatorInterface, NResultsInterface<0>, NSuccsInterface<2>],
 )]
 pub struct CondBrOp;
 impl CondBrOp {
@@ -4325,202 +4315,5 @@ impl Verify for FuncOp {
 impl IsDeclaration for FuncOp {
     fn is_declaration(&self, ctx: &Context) -> bool {
         self.get_region(ctx).is_none()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{
-        AddrSpaceCastOp, AtomicCmpxchgOp, AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, FenceOp,
-        FuncOp, InlineAsmOp, ReturnOp,
-    };
-    use crate::attributes::{AtomicOrderingAttr, AtomicRmwKindAttr};
-    use crate::op_interfaces::CastOpInterface;
-    use crate::types::{FuncType, PointerType, VoidType};
-    use pliron::{
-        basic_block::BasicBlock,
-        builtin::{
-            op_interfaces::SingleBlockRegionInterface,
-            ops::ModuleOp,
-            types::{IntegerType, Signedness},
-        },
-        combine::Parser,
-        context::{Context, Ptr},
-        irfmt::parsers::spaced,
-        location,
-        op::Op,
-        operation::Operation,
-        parsable::{self, state_stream_from_iterator},
-        printable::Printable,
-        r#type::TypeObj,
-        value::Value,
-    };
-
-    /// Build a module with a function whose entry block has the given argument
-    /// types, let `build` add ops to that block, then assert the whole module
-    /// round-trips through the parser unchanged.
-    fn assert_op_roundtrips(
-        make_arg_types: impl FnOnce(&mut Context) -> Vec<Ptr<TypeObj>>,
-        build: impl FnOnce(&mut Context, Ptr<BasicBlock>, &[Value]),
-        expected: &[&str],
-    ) {
-        let ctx = &mut Context::new();
-        let arg_types = make_arg_types(ctx);
-
-        let module = ModuleOp::new(ctx, "test".try_into().unwrap());
-        let module_block = module.get_body(ctx, 0);
-
-        let void = VoidType::get(ctx).into();
-        let fty = FuncType::get(ctx, void, arg_types, false);
-        let func = FuncOp::new(ctx, "f".try_into().unwrap(), fty);
-        let entry = func.get_or_create_entry_block(ctx);
-        let args: Vec<Value> = entry.deref(ctx).arguments().collect();
-
-        build(ctx, entry, &args);
-        ReturnOp::new(ctx, None)
-            .get_operation()
-            .insert_at_back(entry, ctx);
-        func.get_operation().insert_at_back(module_block, ctx);
-
-        let printed = module.get_operation().disp(ctx).to_string();
-        for tok in expected {
-            assert!(
-                printed.contains(tok),
-                "expected `{tok}` in printed IR:\n{printed}"
-            );
-        }
-
-        // The printed IR must re-parse: this exercises the op's (and its
-        // attributes') parser against exactly what its printer produced.
-        let ctx2 = &mut Context::new();
-        let state_stream = state_stream_from_iterator(
-            printed.chars(),
-            parsable::State::new(ctx2, location::Source::InMemory),
-        );
-        spaced(Operation::top_level_parser())
-            .parse(state_stream)
-            .expect("printed IR should re-parse");
-    }
-
-    fn i32_ty(ctx: &mut Context) -> Ptr<TypeObj> {
-        IntegerType::get(ctx, 32, Signedness::Signless).into()
-    }
-
-    #[test]
-    fn test_addrspacecast_roundtrips() {
-        assert_op_roundtrips(
-            |ctx| vec![PointerType::get(ctx, 0).into()],
-            |ctx, entry, args| {
-                let dst = PointerType::get(ctx, 1).into();
-                AddrSpaceCastOp::new(ctx, args[0], dst)
-                    .get_operation()
-                    .insert_at_back(entry, ctx);
-            },
-            &["llvm.addrspacecast", "llvm.ptr addrspace(1)"],
-        );
-    }
-
-    #[test]
-    fn test_atomicrmw_roundtrips() {
-        assert_op_roundtrips(
-            |ctx| vec![PointerType::get(ctx, 1).into(), i32_ty(ctx)],
-            |ctx, entry, args| {
-                AtomicRmwOp::new(
-                    ctx,
-                    args[0],
-                    args[1],
-                    AtomicRmwKindAttr::Add,
-                    AtomicOrderingAttr::SeqCst,
-                    Some("device".to_string()),
-                )
-                .get_operation()
-                .insert_at_back(entry, ctx);
-            },
-            &["llvm.atomicrmw", "Add", "SeqCst", "device"],
-        );
-    }
-
-    #[test]
-    fn test_cmpxchg_roundtrips() {
-        assert_op_roundtrips(
-            |ctx| {
-                let i = i32_ty(ctx);
-                vec![PointerType::get(ctx, 0).into(), i, i]
-            },
-            |ctx, entry, args| {
-                AtomicCmpxchgOp::new(
-                    ctx,
-                    args[0],
-                    args[1],
-                    args[2],
-                    AtomicOrderingAttr::AcqRel,
-                    AtomicOrderingAttr::Monotonic,
-                    None,
-                )
-                .get_operation()
-                .insert_at_back(entry, ctx);
-            },
-            &["llvm.cmpxchg", "AcqRel", "Monotonic"],
-        );
-    }
-
-    #[test]
-    fn test_fence_roundtrips() {
-        assert_op_roundtrips(
-            |_ctx| vec![],
-            |ctx, entry, _args| {
-                FenceOp::new(ctx, AtomicOrderingAttr::SeqCst, Some("block".to_string()))
-                    .get_operation()
-                    .insert_at_back(entry, ctx);
-            },
-            &["llvm.fence", "SeqCst", "block"],
-        );
-    }
-
-    #[test]
-    fn test_atomic_load_roundtrips() {
-        assert_op_roundtrips(
-            |ctx| vec![PointerType::get(ctx, 3).into()],
-            |ctx, entry, args| {
-                let res = i32_ty(ctx);
-                AtomicLoadOp::new(ctx, args[0], res, AtomicOrderingAttr::Acquire, None)
-                    .get_operation()
-                    .insert_at_back(entry, ctx);
-            },
-            &["llvm.atomic_load", "Acquire"],
-        );
-    }
-
-    #[test]
-    fn test_atomic_store_roundtrips() {
-        assert_op_roundtrips(
-            |ctx| vec![i32_ty(ctx), PointerType::get(ctx, 3).into()],
-            |ctx, entry, args| {
-                AtomicStoreOp::new(
-                    ctx,
-                    args[0],
-                    args[1],
-                    AtomicOrderingAttr::Release,
-                    Some("device".to_string()),
-                )
-                .get_operation()
-                .insert_at_back(entry, ctx);
-            },
-            &["llvm.atomic_store", "Release", "device"],
-        );
-    }
-
-    #[test]
-    fn test_inline_asm_roundtrips() {
-        assert_op_roundtrips(
-            |ctx| vec![i32_ty(ctx)],
-            |ctx, entry, args| {
-                let res = i32_ty(ctx);
-                InlineAsmOp::new(ctx, res, vec![args[0]], "mov $0, $1", "=r,r", true)
-                    .get_operation()
-                    .insert_at_back(entry, ctx);
-            },
-            &["llvm.inline_asm", "mov", "=r,r", "convergent"],
-        );
     }
 }

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -2533,9 +2533,8 @@ pub struct AddressOfOp;
 
 impl AddressOfOp {
     /// Create a new [AddressOfOp].
-    pub fn new(ctx: &mut Context, global_name: Identifier) -> Self {
-        // TODO: once globals carry an address space, use the global's space here.
-        let result_type = PointerType::get(ctx, 0).into();
+    pub fn new(ctx: &mut Context, global_name: Identifier, address_space: u32) -> Self {
+        let result_type = PointerType::get(ctx, address_space).into();
         let op = Operation::new(
             ctx,
             Self::get_concrete_op_info(),

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -6,7 +6,7 @@ use pliron::{
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::TypedAttrInterface,
-        attributes::{IdentifierAttr, IntegerAttr, StringAttr, TypeAttr},
+        attributes::{BoolAttr, IdentifierAttr, IntegerAttr, StringAttr, TypeAttr},
         op_interfaces::{
             self, ATTR_KEY_SYM_NAME, AtLeastNOpdsInterface, AtLeastNResultsInterface,
             AtMostNOpdsInterface, AtMostNRegionsInterface, AtMostOneRegionInterface,
@@ -1815,6 +1815,59 @@ impl AtomicStoreOp {
         if let Some(scope) = syncscope {
             op.set_attr_llvm_st_syncscope(ctx, StringAttr::new(scope));
         }
+        op
+    }
+}
+
+/// Equivalent to LLVM's inline assembly call. The template and constraint
+/// strings follow LLVM's inline-asm syntax; `convergent` marks asm that must
+/// not be reordered across divergent control flow (e.g. warp-synchronous PTX).
+///
+/// ### Operands
+/// | operand | description |
+/// |-----|-------|
+/// | `inputs` | input operands to the inline asm |
+///
+/// ### Result(s):
+/// | result | description |
+/// |-----|-------|
+/// | `res` | the asm result (a void type when there is none) |
+#[pliron_op(
+    name = "llvm.inline_asm",
+    format = "attr($inline_asm_template, $StringAttr) `, ` attr($inline_asm_constraints, $StringAttr) ` convergent = ` attr($inline_asm_convergent, $BoolAttr) ` (` operands(CharSpace(`,`)) `) : ` type($0)",
+    interfaces = [OneResultInterface, NResultsInterface<1>],
+    attributes = (
+        inline_asm_template: StringAttr,
+        inline_asm_constraints: StringAttr,
+        inline_asm_convergent: BoolAttr
+    ),
+    verifier = "succ"
+)]
+pub struct InlineAsmOp;
+
+impl InlineAsmOp {
+    /// Create a new [InlineAsmOp]. Use a void result type for asm with no
+    /// result value.
+    pub fn new(
+        ctx: &mut Context,
+        result_ty: Ptr<TypeObj>,
+        inputs: Vec<Value>,
+        asm_template: &str,
+        constraints: &str,
+        convergent: bool,
+    ) -> Self {
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![result_ty],
+            inputs,
+            vec![],
+            0,
+        );
+        let op = InlineAsmOp { op };
+        op.set_attr_inline_asm_template(ctx, StringAttr::new(asm_template.to_string()));
+        op.set_attr_inline_asm_constraints(ctx, StringAttr::new(constraints.to_string()));
+        op.set_attr_inline_asm_convergent(ctx, BoolAttr::new(convergent));
         op
     }
 }
@@ -4212,7 +4265,7 @@ impl IsDeclaration for FuncOp {
 mod tests {
     use super::{
         AddrSpaceCastOp, AtomicCmpxchgOp, AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, FenceOp,
-        FuncOp, ReturnOp,
+        FuncOp, InlineAsmOp, ReturnOp,
     };
     use crate::attributes::{AtomicOrderingAttr, AtomicRmwKindAttr};
     use crate::op_interfaces::CastOpInterface;
@@ -4387,6 +4440,20 @@ mod tests {
                 .insert_at_back(entry, ctx);
             },
             &["llvm.atomic_store", "Release", "device"],
+        );
+    }
+
+    #[test]
+    fn test_inline_asm_roundtrips() {
+        assert_op_roundtrips(
+            |ctx| vec![i32_ty(ctx)],
+            |ctx, entry, args| {
+                let res = i32_ty(ctx);
+                InlineAsmOp::new(ctx, res, vec![args[0]], "mov $0, $1", "=r,r", true)
+                    .get_operation()
+                    .insert_at_back(entry, ctx);
+            },
+            &["llvm.inline_asm", "mov", "=r,r", "convergent"],
         );
     }
 }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -42,14 +42,14 @@ use crate::{
     attributes::{FCmpPredicateAttr, ICmpPredicateAttr, LinkageAttr},
     llvm_sys::core::{
         LLVMBasicBlock, LLVMBuilder, LLVMContext, LLVMModule, LLVMType, LLVMValue,
-        instruction_iter, llvm_add_case, llvm_add_function, llvm_add_global, llvm_add_incoming,
-        llvm_append_basic_block_in_context, llvm_array_type2, llvm_build_add, llvm_build_and,
-        llvm_build_array_alloca, llvm_build_ashr, llvm_build_bitcast, llvm_build_br,
-        llvm_build_call2, llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value,
-        llvm_build_fadd, llvm_build_fcmp, llvm_build_fdiv, llvm_build_fmul, llvm_build_fpext,
-        llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc, llvm_build_freeze,
-        llvm_build_frem, llvm_build_fsub, llvm_build_gep2, llvm_build_icmp,
-        llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
+        instruction_iter, llvm_add_case, llvm_add_function, llvm_add_global_in_address_space,
+        llvm_add_incoming, llvm_append_basic_block_in_context, llvm_array_type2, llvm_build_add,
+        llvm_build_addrspacecast, llvm_build_and, llvm_build_array_alloca, llvm_build_ashr,
+        llvm_build_bitcast, llvm_build_br, llvm_build_call2, llvm_build_cond_br,
+        llvm_build_extract_element, llvm_build_extract_value, llvm_build_fadd, llvm_build_fcmp,
+        llvm_build_fdiv, llvm_build_fmul, llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui,
+        llvm_build_fptrunc, llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2,
+        llvm_build_icmp, llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
         llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or, llvm_build_phi,
         llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void, llvm_build_sdiv,
         llvm_build_select, llvm_build_sext, llvm_build_shl, llvm_build_shuffle_vector,
@@ -71,13 +71,13 @@ use crate::{
         PointerTypeResult,
     },
     ops::{
-        AShrOp, AddOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp, CallIntrinsicOp, CallOp,
-        CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp, FPExtOp,
-        FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FreezeOp, FuncOp, GetElementPtrOp, GlobalOp,
-        ICmpOp, InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp,
-        PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp,
-        StoreOp, SubOp, SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, UnreachableOp,
-        VAArgOp, XorOp, ZExtOp, ZeroOp,
+        AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp,
+        CallIntrinsicOp, CallOp, CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp,
+        FDivOp, FMulOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FreezeOp, FuncOp,
+        GetElementPtrOp, GlobalOp, ICmpOp, InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp,
+        LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp,
+        SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchOp, TruncOp, UDivOp, UIToFPOp,
+        URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
     },
     types::{ArrayType, FuncType, PointerType, StructType, VectorType, VoidType},
 };
@@ -339,7 +339,7 @@ impl ToLLVMType for PointerType {
         llvm_ctx: &LLVMContext,
         _cctx: &mut ConversionContext,
     ) -> Result<LLVMType> {
-        Ok(llvm_pointer_type_in_context(llvm_ctx, 0))
+        Ok(llvm_pointer_type_in_context(llvm_ctx, self.address_space()))
     }
 }
 
@@ -546,6 +546,26 @@ impl ToLLVMValue for BitcastOp {
             &self.get_result(ctx).unique_name(ctx),
         );
         Ok(bitcast_op)
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for AddrSpaceCastOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let arg = convert_value_operand(cctx, ctx, &self.get_operand(ctx))?;
+        let ty = convert_type(ctx, llvm_ctx, cctx, self.result_type(ctx))?;
+        let addrspacecast_op = llvm_build_addrspacecast(
+            &cctx.builder,
+            arg,
+            ty,
+            &self.get_result(ctx).unique_name(ctx),
+        );
+        Ok(addrspacecast_op)
     }
 }
 
@@ -1998,7 +2018,13 @@ pub fn convert_module(
             let llvm_global_name = global_op
                 .llvm_symbol_name(ctx)
                 .unwrap_or(global_name.clone().into());
-            let global_llvm = llvm_add_global(&llvm_module, global_ty_llvm, &llvm_global_name);
+            let global_addr_space = global_op.address_space(ctx);
+            let global_llvm = llvm_add_global_in_address_space(
+                &llvm_module,
+                global_ty_llvm,
+                &llvm_global_name,
+                global_addr_space,
+            );
             cctx.globals_map.insert(global_name, global_llvm);
         }
     }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -2,7 +2,10 @@
 
 use std::collections::hash_map;
 
-use llvm_sys::{LLVMIntPredicate, LLVMLinkage, LLVMRealPredicate};
+use llvm_sys::{
+    LLVMAtomicOrdering, LLVMAtomicRMWBinOp, LLVMInlineAsmDialect, LLVMIntPredicate, LLVMLinkage,
+    LLVMRealPredicate,
+};
 use pliron::{
     attribute::{Attribute, attr_cast},
     basic_block::BasicBlock,
@@ -39,17 +42,20 @@ use rustc_hash::FxHashMap;
 use thiserror::Error;
 
 use crate::{
-    attributes::{FCmpPredicateAttr, ICmpPredicateAttr, LinkageAttr},
+    attributes::{
+        AtomicOrderingAttr, AtomicRmwKindAttr, FCmpPredicateAttr, ICmpPredicateAttr, LinkageAttr,
+    },
     llvm_sys::core::{
         LLVMBasicBlock, LLVMBuilder, LLVMContext, LLVMModule, LLVMType, LLVMValue,
         instruction_iter, llvm_add_case, llvm_add_function, llvm_add_global_in_address_space,
         llvm_add_incoming, llvm_append_basic_block_in_context, llvm_array_type2, llvm_build_add,
         llvm_build_addrspacecast, llvm_build_and, llvm_build_array_alloca, llvm_build_ashr,
-        llvm_build_bitcast, llvm_build_br, llvm_build_call2, llvm_build_cond_br,
-        llvm_build_extract_element, llvm_build_extract_value, llvm_build_fadd, llvm_build_fcmp,
-        llvm_build_fdiv, llvm_build_fmul, llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui,
-        llvm_build_fptrunc, llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2,
-        llvm_build_icmp, llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
+        llvm_build_atomic_cmpxchg, llvm_build_atomic_rmw, llvm_build_bitcast, llvm_build_br,
+        llvm_build_call2, llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value,
+        llvm_build_fadd, llvm_build_fcmp, llvm_build_fdiv, llvm_build_fence, llvm_build_fmul,
+        llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc,
+        llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2, llvm_build_icmp,
+        llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
         llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or, llvm_build_phi,
         llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void, llvm_build_sdiv,
         llvm_build_select, llvm_build_sext, llvm_build_shl, llvm_build_shuffle_vector,
@@ -58,26 +64,28 @@ use crate::{
         llvm_build_urem, llvm_build_va_arg, llvm_build_xor, llvm_build_zext,
         llvm_can_value_use_fast_math_flags, llvm_clear_insertion_position, llvm_const_int,
         llvm_const_null, llvm_const_real, llvm_const_vector, llvm_double_type_in_context,
-        llvm_float_type_in_context, llvm_function_type, llvm_get_named_function, llvm_get_param,
-        llvm_get_poison, llvm_get_undef, llvm_half_type_in_context, llvm_int_type_in_context,
-        llvm_is_a, llvm_lookup_intrinsic_id, llvm_pointer_type_in_context,
-        llvm_position_builder_at_end, llvm_scalable_vector_type, llvm_set_alignment,
+        llvm_float_type_in_context, llvm_function_type, llvm_get_inline_asm,
+        llvm_get_named_function, llvm_get_param, llvm_get_poison, llvm_get_sync_scope_id,
+        llvm_get_undef, llvm_half_type_in_context, llvm_int_type_in_context, llvm_is_a,
+        llvm_lookup_intrinsic_id, llvm_pointer_type_in_context, llvm_position_builder_at_end,
+        llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
         llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
-        llvm_struct_create_named, llvm_struct_set_body, llvm_struct_type_in_context,
-        llvm_vector_type, llvm_void_type_in_context,
+        llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
+        llvm_struct_type_in_context, llvm_type_of, llvm_vector_type, llvm_void_type_in_context,
     },
     op_interfaces::{
         AlignableOpInterface, FastMathFlags, IsDeclaration, LlvmSymbolName, NNegFlag,
         PointerTypeResult,
     },
     ops::{
-        AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp,
-        CallIntrinsicOp, CallOp, CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp,
-        FDivOp, FMulOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FreezeOp, FuncOp,
-        GetElementPtrOp, GlobalOp, ICmpOp, InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp,
-        LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp,
-        SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchOp, TruncOp, UDivOp, UIToFPOp,
-        URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
+        AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,
+        AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BrOp, CallIntrinsicOp, CallOp,
+        CondBrOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp, FPExtOp,
+        FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FenceOp, FreezeOp, FuncOp, GetElementPtrOp,
+        GlobalOp, ICmpOp, InlineAsmOp, InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp, LoadOp,
+        MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp,
+        ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp,
+        UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
     },
     types::{ArrayType, FuncType, PointerType, StructType, VectorType, VoidType},
 };
@@ -760,6 +768,271 @@ impl ToLLVMValue for StoreOp {
             llvm_set_alignment(store_op, alignment);
         }
         Ok(store_op)
+    }
+}
+
+/// Map a pliron [AtomicOrderingAttr] to its LLVM-C counterpart.
+fn convert_atomic_ordering(o: &AtomicOrderingAttr) -> LLVMAtomicOrdering {
+    match o {
+        AtomicOrderingAttr::Monotonic => LLVMAtomicOrdering::LLVMAtomicOrderingMonotonic,
+        AtomicOrderingAttr::Acquire => LLVMAtomicOrdering::LLVMAtomicOrderingAcquire,
+        AtomicOrderingAttr::Release => LLVMAtomicOrdering::LLVMAtomicOrderingRelease,
+        AtomicOrderingAttr::AcqRel => LLVMAtomicOrdering::LLVMAtomicOrderingAcquireRelease,
+        AtomicOrderingAttr::SeqCst => LLVMAtomicOrdering::LLVMAtomicOrderingSequentiallyConsistent,
+    }
+}
+
+/// Map a pliron [AtomicRmwKindAttr] to its LLVM-C counterpart.
+fn convert_rmw_kind(k: &AtomicRmwKindAttr) -> LLVMAtomicRMWBinOp {
+    match k {
+        AtomicRmwKindAttr::Xchg => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXchg,
+        AtomicRmwKindAttr::Add => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpAdd,
+        AtomicRmwKindAttr::Sub => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpSub,
+        AtomicRmwKindAttr::And => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpAnd,
+        AtomicRmwKindAttr::Nand => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpNand,
+        AtomicRmwKindAttr::Or => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpOr,
+        AtomicRmwKindAttr::Xor => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpXor,
+        AtomicRmwKindAttr::Max => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMax,
+        AtomicRmwKindAttr::Min => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpMin,
+        AtomicRmwKindAttr::UMax => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMax,
+        AtomicRmwKindAttr::UMin => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpUMin,
+        AtomicRmwKindAttr::FAdd => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFAdd,
+        AtomicRmwKindAttr::FSub => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFSub,
+        AtomicRmwKindAttr::FMax => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMax,
+        AtomicRmwKindAttr::FMin => LLVMAtomicRMWBinOp::LLVMAtomicRMWBinOpFMin,
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for AtomicRmwOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let (ptr_opd, val_opd) = {
+            let op = self.get_operation().deref(ctx);
+            (op.get_operand(0), op.get_operand(1))
+        };
+        let ptr = convert_value_operand(cctx, ctx, &ptr_opd)?;
+        let val = convert_value_operand(cctx, ctx, &val_opd)?;
+        let kind = convert_rmw_kind(
+            &self
+                .get_attr_llvm_rmw_kind(ctx)
+                .expect("atomicrmw missing rmw kind"),
+        );
+        let ordering = convert_atomic_ordering(
+            &self
+                .get_attr_llvm_rmw_ordering(ctx)
+                .expect("atomicrmw missing ordering"),
+        );
+        let scope = self
+            .get_attr_llvm_rmw_syncscope(ctx)
+            .map(|s| String::from((*s).clone()))
+            .unwrap_or_default();
+        let ssid = llvm_get_sync_scope_id(llvm_ctx, &scope);
+        Ok(llvm_build_atomic_rmw(
+            &cctx.builder,
+            kind,
+            ptr,
+            val,
+            ordering,
+            ssid,
+        ))
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for AtomicCmpxchgOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let (ptr_opd, cmp_opd, new_opd) = {
+            let op = self.get_operation().deref(ctx);
+            (op.get_operand(0), op.get_operand(1), op.get_operand(2))
+        };
+        let ptr = convert_value_operand(cctx, ctx, &ptr_opd)?;
+        let cmp = convert_value_operand(cctx, ctx, &cmp_opd)?;
+        let new = convert_value_operand(cctx, ctx, &new_opd)?;
+        let success = convert_atomic_ordering(
+            &self
+                .get_attr_llvm_cas_success_ordering(ctx)
+                .expect("cmpxchg missing success ordering"),
+        );
+        let failure = convert_atomic_ordering(
+            &self
+                .get_attr_llvm_cas_failure_ordering(ctx)
+                .expect("cmpxchg missing failure ordering"),
+        );
+        let scope = self
+            .get_attr_llvm_cas_syncscope(ctx)
+            .map(|s| String::from((*s).clone()))
+            .unwrap_or_default();
+        let ssid = llvm_get_sync_scope_id(llvm_ctx, &scope);
+        Ok(llvm_build_atomic_cmpxchg(
+            &cctx.builder,
+            ptr,
+            cmp,
+            new,
+            success,
+            failure,
+            ssid,
+        ))
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for FenceOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let ordering = convert_atomic_ordering(
+            &self
+                .get_attr_llvm_fence_ordering(ctx)
+                .expect("fence missing ordering"),
+        );
+        let scope = self
+            .get_attr_llvm_fence_syncscope(ctx)
+            .map(|s| String::from((*s).clone()))
+            .unwrap_or_default();
+        let ssid = llvm_get_sync_scope_id(llvm_ctx, &scope);
+        Ok(llvm_build_fence(&cctx.builder, ordering, ssid, ""))
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for AtomicLoadOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let (ptr_opd, result_val) = {
+            let op = self.get_operation().deref(ctx);
+            (op.get_operand(0), op.get_result(0))
+        };
+        let pointee_ty = convert_type(ctx, llvm_ctx, cctx, result_val.get_type(ctx))?;
+        let ptr = convert_value_operand(cctx, ctx, &ptr_opd)?;
+        let load = llvm_build_load2(&cctx.builder, pointee_ty, ptr, &result_val.unique_name(ctx));
+        let ordering = convert_atomic_ordering(
+            &self
+                .get_attr_llvm_ld_ordering(ctx)
+                .expect("atomic load missing ordering"),
+        );
+        llvm_set_ordering(load, ordering);
+        let scope = self
+            .get_attr_llvm_ld_syncscope(ctx)
+            .map(|s| String::from((*s).clone()))
+            .unwrap_or_default();
+        llvm_set_atomic_sync_scope_id(load, llvm_get_sync_scope_id(llvm_ctx, &scope));
+        if let Some(alignment) = self.alignment(ctx) {
+            llvm_set_alignment(load, alignment);
+        }
+        Ok(load)
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for AtomicStoreOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let (val_opd, ptr_opd) = {
+            let op = self.get_operation().deref(ctx);
+            (op.get_operand(0), op.get_operand(1))
+        };
+        let value = convert_value_operand(cctx, ctx, &val_opd)?;
+        let ptr = convert_value_operand(cctx, ctx, &ptr_opd)?;
+        let store = llvm_build_store(&cctx.builder, value, ptr);
+        let ordering = convert_atomic_ordering(
+            &self
+                .get_attr_llvm_st_ordering(ctx)
+                .expect("atomic store missing ordering"),
+        );
+        llvm_set_ordering(store, ordering);
+        let scope = self
+            .get_attr_llvm_st_syncscope(ctx)
+            .map(|s| String::from((*s).clone()))
+            .unwrap_or_default();
+        llvm_set_atomic_sync_scope_id(store, llvm_get_sync_scope_id(llvm_ctx, &scope));
+        if let Some(alignment) = self.alignment(ctx) {
+            llvm_set_alignment(store, alignment);
+        }
+        Ok(store)
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for InlineAsmOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let (arg_opds, result_val) = {
+            let op = self.get_operation().deref(ctx);
+            let n = op.get_num_operands();
+            let args: Vec<Value> = (0..n).map(|i| op.get_operand(i)).collect();
+            (args, op.get_result(0))
+        };
+        let args: Vec<LLVMValue> = arg_opds
+            .iter()
+            .map(|v| convert_value_operand(cctx, ctx, v))
+            .collect::<Result<_>>()?;
+        let result_ty = result_val.get_type(ctx);
+        let result_llvm_ty = convert_type(ctx, llvm_ctx, cctx, result_ty)?;
+        let arg_types: Vec<LLVMType> = args.iter().map(|a| llvm_type_of(*a)).collect();
+        let fn_ty = llvm_function_type(result_llvm_ty, &arg_types, false);
+        let asm = String::from(
+            (*self
+                .get_attr_inline_asm_template(ctx)
+                .expect("inline asm missing template"))
+            .clone(),
+        );
+        let constraints = String::from(
+            (*self
+                .get_attr_inline_asm_constraints(ctx)
+                .expect("inline asm missing constraints"))
+            .clone(),
+        );
+        // `has_side_effects` is set unconditionally: this op does not model a
+        // side-effects flag, and side-effecting asm is the safe default.
+        // NOTE: the op's `inline_asm_convergent` attribute is not applied here.
+        // `convergent` is an LLVM call-site attribute (not part of the inline-asm
+        // value), so converting to LLVM IR drops the convergent flag.
+        let asm_val = llvm_get_inline_asm(
+            fn_ty,
+            &asm,
+            &constraints,
+            true,
+            false,
+            LLVMInlineAsmDialect::LLVMInlineAsmDialectATT,
+            false,
+        );
+        let name = if result_ty.deref(ctx).is::<VoidType>() {
+            String::new()
+        } else {
+            result_val.unique_name(ctx).to_string()
+        };
+        Ok(llvm_build_call2(
+            &cctx.builder,
+            fn_ty,
+            asm_val,
+            &args,
+            &name,
+        ))
     }
 }
 

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -15,7 +15,7 @@ use pliron::{
         },
         ops::{ConstantOp, ModuleOp},
         type_interfaces::FunctionTypeInterface,
-        types::{FP32Type, FP64Type, IntegerType},
+        types::{FP16Type, FP32Type, FP64Type, IntegerType},
     },
     common_traits::Named,
     context::{Context, Ptr},
@@ -59,12 +59,12 @@ use crate::{
         llvm_can_value_use_fast_math_flags, llvm_clear_insertion_position, llvm_const_int,
         llvm_const_null, llvm_const_real, llvm_const_vector, llvm_double_type_in_context,
         llvm_float_type_in_context, llvm_function_type, llvm_get_named_function, llvm_get_param,
-        llvm_get_poison, llvm_get_undef, llvm_int_type_in_context, llvm_is_a,
-        llvm_lookup_intrinsic_id, llvm_pointer_type_in_context, llvm_position_builder_at_end,
-        llvm_scalable_vector_type, llvm_set_alignment, llvm_set_fast_math_flags,
-        llvm_set_initializer, llvm_set_linkage, llvm_set_nneg, llvm_struct_create_named,
-        llvm_struct_set_body, llvm_struct_type_in_context, llvm_vector_type,
-        llvm_void_type_in_context,
+        llvm_get_poison, llvm_get_undef, llvm_half_type_in_context, llvm_int_type_in_context,
+        llvm_is_a, llvm_lookup_intrinsic_id, llvm_pointer_type_in_context,
+        llvm_position_builder_at_end, llvm_scalable_vector_type, llvm_set_alignment,
+        llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
+        llvm_struct_create_named, llvm_struct_set_body, llvm_struct_type_in_context,
+        llvm_vector_type, llvm_void_type_in_context,
     },
     op_interfaces::{
         AlignableOpInterface, FastMathFlags, IsDeclaration, LlvmSymbolName, NNegFlag,
@@ -415,6 +415,18 @@ impl ToLLVMType for FP64Type {
         _cctx: &mut ConversionContext,
     ) -> Result<LLVMType> {
         Ok(llvm_double_type_in_context(llvm_ctx))
+    }
+}
+
+#[type_interface_impl]
+impl ToLLVMType for FP16Type {
+    fn convert(
+        &self,
+        _ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        _cctx: &mut ConversionContext,
+    ) -> Result<LLVMType> {
+        Ok(llvm_half_type_in_context(llvm_ctx))
     }
 }
 

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -1,6 +1,6 @@
 //! [Type]s defined in the LLVM dialect.
 
-use pliron::combine::{Parser, between, optional, token};
+use pliron::combine::{self, Parser, between, optional, token};
 
 use pliron::builtin::type_interfaces::FunctionTypeInterface;
 use pliron::derive::{format, pliron_type, type_interface_impl};
@@ -10,7 +10,7 @@ use pliron::{
     identifier::Identifier,
     input_err_noloc,
     irfmt::{
-        parsers::{delimited_list_parser, location, spaced},
+        parsers::{delimited_list_parser, int_parser, location, spaced},
         printers::{enclosed, list_with_sep},
     },
     location::Located,
@@ -295,10 +295,62 @@ impl Parsable for StructType {
 
 impl Eq for StructType {}
 
-/// An opaque pointer, corresponding to LLVM's pointer type.
-#[pliron_type(name = "llvm.ptr", generate_get = true, format, verifier = "succ")]
+/// A pointer, corresponding to LLVM's pointer type. It is opaque (carries no
+/// pointee type) but carries an address space, mirroring LLVM's `ptr` /
+/// `ptr addrspace(N)`. Address space 0 prints as a bare `llvm.ptr`.
+#[pliron_type(name = "llvm.ptr", generate_get = true, verifier = "succ")]
 #[derive(Hash, PartialEq, Eq, Debug)]
-pub struct PointerType;
+pub struct PointerType {
+    address_space: u32,
+}
+
+impl PointerType {
+    /// The address space of this pointer.
+    pub fn address_space(&self) -> u32 {
+        self.address_space
+    }
+}
+
+impl Printable for PointerType {
+    fn fmt(
+        &self,
+        _ctx: &Context,
+        _state: &printable::State,
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> core::fmt::Result {
+        // Address space 0 prints as a bare `llvm.ptr`; non-zero adds `addrspace(N)`.
+        if self.address_space != 0 {
+            write!(f, "addrspace({})", self.address_space)?;
+        }
+        Ok(())
+    }
+}
+
+impl Parsable for PointerType {
+    type Arg = ();
+    type Parsed = TypePtr<Self>;
+    fn parse<'a>(
+        state_stream: &mut StateStream<'a>,
+        _arg: Self::Arg,
+    ) -> ParseResult<'a, Self::Parsed>
+    where
+        Self: Sized,
+    {
+        // Optionally parse `addrspace(N)`; its absence means address space 0.
+        let mut parser = spaced(optional(
+            combine::parser::char::string("addrspace").with(between(
+                token('('),
+                token(')'),
+                int_parser::<u32>(),
+            )),
+        ))
+        .map(|addr_space| addr_space.unwrap_or(0));
+        parser
+            .parse_stream(state_stream)
+            .map(|address_space| PointerType::get(state_stream.state.ctx, address_space))
+            .into()
+    }
+}
 
 /// Array type, corresponding to LLVM's array type.
 #[pliron_type(
@@ -421,7 +473,7 @@ mod tests {
     use pliron::combine::{self, Parser, eof, token};
     use pliron::derive::{pliron_type, verify_succ};
 
-    use crate::types::{FuncType, StructType, VoidType};
+    use crate::types::{FuncType, PointerType, StructType, VoidType};
     use pliron::{
         builtin::types::{IntegerType, Signedness},
         context::{Context, Ptr},
@@ -575,6 +627,43 @@ mod tests {
         assert_eq!(
             &res.disp(&ctx).to_string(),
             "llvm.typed_ptr <builtin.integer si64>"
+        );
+    }
+
+    #[test]
+    fn test_opaque_pointer_addrspace() {
+        let mut ctx = Context::new();
+
+        // Address space 0 prints (and round-trips) as a bare `llvm.ptr`.
+        let state_stream = state_stream_from_iterator(
+            "llvm.ptr".chars(),
+            parsable::State::new(&mut ctx, location::Source::InMemory),
+        );
+        let res = type_parser().parse(state_stream).unwrap().0;
+        // The framework appends a space after every type name; addrspace 0 adds
+        // no body, so the canonical form is a bare `llvm.ptr`.
+        assert_eq!(res.disp(&ctx).to_string().trim(), "llvm.ptr");
+        assert_eq!(
+            res.deref(&ctx)
+                .downcast_ref::<PointerType>()
+                .unwrap()
+                .address_space(),
+            0
+        );
+
+        // A non-zero address space round-trips as `llvm.ptr addrspace(N)`.
+        let state_stream = state_stream_from_iterator(
+            "llvm.ptr addrspace(3)".chars(),
+            parsable::State::new(&mut ctx, location::Source::InMemory),
+        );
+        let res = type_parser().parse(state_stream).unwrap().0;
+        assert_eq!(res.disp(&ctx).to_string().trim(), "llvm.ptr addrspace(3)");
+        assert_eq!(
+            res.deref(&ctx)
+                .downcast_ref::<PointerType>()
+                .unwrap()
+                .address_space(),
+            3
         );
     }
 

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -1,6 +1,6 @@
 //! [Type]s defined in the LLVM dialect.
 
-use pliron::combine::{self, Parser, between, optional, token};
+use pliron::combine::{Parser, between, optional, token};
 
 use pliron::builtin::type_interfaces::FunctionTypeInterface;
 use pliron::derive::{format, pliron_type, type_interface_impl};
@@ -10,7 +10,7 @@ use pliron::{
     identifier::Identifier,
     input_err_noloc,
     irfmt::{
-        parsers::{delimited_list_parser, int_parser, location, spaced},
+        parsers::{delimited_list_parser, location, spaced},
         printers::{enclosed, list_with_sep},
     },
     location::Located,
@@ -296,9 +296,14 @@ impl Parsable for StructType {
 impl Eq for StructType {}
 
 /// A pointer, corresponding to LLVM's pointer type. It is opaque (carries no
-/// pointee type) but carries an address space, mirroring LLVM's `ptr` /
-/// `ptr addrspace(N)`. Address space 0 prints as a bare `llvm.ptr`.
-#[pliron_type(name = "llvm.ptr", generate_get = true, verifier = "succ")]
+/// pointee type) but carries an address space. The address space is always
+/// printed, e.g. `llvm.ptr (0)` or `llvm.ptr (1)`.
+#[pliron_type(
+    name = "llvm.ptr",
+    generate_get = true,
+    format = "`(` $address_space `)`",
+    verifier = "succ"
+)]
 #[derive(Hash, PartialEq, Eq, Debug)]
 pub struct PointerType {
     address_space: u32,
@@ -308,47 +313,6 @@ impl PointerType {
     /// The address space of this pointer.
     pub fn address_space(&self) -> u32 {
         self.address_space
-    }
-}
-
-impl Printable for PointerType {
-    fn fmt(
-        &self,
-        _ctx: &Context,
-        _state: &printable::State,
-        f: &mut core::fmt::Formatter<'_>,
-    ) -> core::fmt::Result {
-        // Address space 0 prints as a bare `llvm.ptr`; non-zero adds `addrspace(N)`.
-        if self.address_space != 0 {
-            write!(f, "addrspace({})", self.address_space)?;
-        }
-        Ok(())
-    }
-}
-
-impl Parsable for PointerType {
-    type Arg = ();
-    type Parsed = TypePtr<Self>;
-    fn parse<'a>(
-        state_stream: &mut StateStream<'a>,
-        _arg: Self::Arg,
-    ) -> ParseResult<'a, Self::Parsed>
-    where
-        Self: Sized,
-    {
-        // Optionally parse `addrspace(N)`; its absence means address space 0.
-        let mut parser = spaced(optional(
-            combine::parser::char::string("addrspace").with(between(
-                token('('),
-                token(')'),
-                int_parser::<u32>(),
-            )),
-        ))
-        .map(|addr_space| addr_space.unwrap_or(0));
-        parser
-            .parse_stream(state_stream)
-            .map(|address_space| PointerType::get(state_stream.state.ctx, address_space))
-            .into()
     }
 }
 
@@ -634,15 +598,14 @@ mod tests {
     fn test_opaque_pointer_addrspace() {
         let mut ctx = Context::new();
 
-        // Address space 0 prints (and round-trips) as a bare `llvm.ptr`.
+        // The address space is always printed, so addrspace 0 round-trips as
+        // `llvm.ptr (0)`.
         let state_stream = state_stream_from_iterator(
-            "llvm.ptr".chars(),
+            "llvm.ptr (0)".chars(),
             parsable::State::new(&mut ctx, location::Source::InMemory),
         );
         let res = type_parser().parse(state_stream).unwrap().0;
-        // The framework appends a space after every type name; addrspace 0 adds
-        // no body, so the canonical form is a bare `llvm.ptr`.
-        assert_eq!(res.disp(&ctx).to_string().trim(), "llvm.ptr");
+        assert_eq!(res.disp(&ctx).to_string().trim(), "llvm.ptr (0)");
         assert_eq!(
             res.deref(&ctx)
                 .downcast_ref::<PointerType>()
@@ -651,13 +614,13 @@ mod tests {
             0
         );
 
-        // A non-zero address space round-trips as `llvm.ptr addrspace(N)`.
+        // A non-zero address space round-trips as `llvm.ptr (N)`.
         let state_stream = state_stream_from_iterator(
-            "llvm.ptr addrspace(3)".chars(),
+            "llvm.ptr (3)".chars(),
             parsable::State::new(&mut ctx, location::Source::InMemory),
         );
         let res = type_parser().parse(state_stream).unwrap().0;
-        assert_eq!(res.disp(&ctx).to_string().trim(), "llvm.ptr addrspace(3)");
+        assert_eq!(res.disp(&ctx).to_string().trim(), "llvm.ptr (3)");
         assert_eq!(
             res.deref(&ctx)
                 .downcast_ref::<PointerType>()

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -668,6 +668,22 @@ mod tests {
     }
 
     #[test]
+    fn test_fp16_type_roundtrip() {
+        let mut ctx = Context::new();
+        let state_stream = state_stream_from_iterator(
+            "builtin.fp16".chars(),
+            parsable::State::new(&mut ctx, location::Source::InMemory),
+        );
+        let res = type_parser().parse(state_stream).unwrap().0;
+        assert_eq!(res.disp(&ctx).to_string().trim(), "builtin.fp16");
+        assert!(
+            res.deref(&ctx)
+                .downcast_ref::<pliron::builtin::types::FP16Type>()
+                .is_some()
+        );
+    }
+
+    #[test]
     fn test_struct_type_parsing() {
         let mut ctx = Context::new();
 

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -386,3 +386,76 @@ fn test_vector_ops() {
         0,
     );
 }
+
+/// Round-trip the atomic and inline-asm constructs through the LLVM bridge
+/// (LLVM-IR -> pliron -> LLVM-IR) and verify both representations. The IR is
+/// provided inline rather than as a resource file, and is not executed (the
+/// test only round-trips and verifies); `out_module.verify()` proves the
+/// emitted IR is well-formed.
+#[test]
+fn test_atomics_and_inline_asm_roundtrip() {
+    init_env_logger_for_tests!();
+
+    let input_ir = r#"
+define i32 @atomics_asm(ptr %p, i32 %v) {
+entry:
+  %old = atomicrmw add ptr %p, i32 %v monotonic
+  %cx = cmpxchg ptr %p, i32 %old, i32 %v acquire monotonic
+  fence seq_cst
+  %la = load atomic i32, ptr %p monotonic, align 4
+  store atomic i32 %la, ptr %p release, align 4
+  %asm = call i32 asm sideeffect "mov $0, $1", "=r,r"(i32 %v)
+  ret i32 %asm
+}
+"#;
+
+    let llvm_context = LLVMContext::default();
+    let tmp_dir = tempdir().unwrap();
+    let in_path = tmp_dir.path().join("atomics_asm.ll");
+    std::fs::write(&in_path, input_ir).unwrap();
+
+    let module = LLVMModule::from_ir_in_file(&llvm_context, in_path.to_str().unwrap())
+        .expect("input LLVM IR should parse");
+
+    let ctx = &mut Context::new();
+    let pliron_module =
+        from_llvm_ir::convert_module(ctx, &module).expect("from_llvm_ir should succeed");
+    verify_op(&pliron_module, ctx).expect("reconstructed pliron module should verify");
+
+    let plir = pliron_module.get_operation().disp(ctx).to_string();
+    for needle in [
+        "llvm.atomicrmw",
+        "llvm.cmpxchg",
+        "llvm.fence",
+        "llvm.atomic_load",
+        "llvm.atomic_store",
+        "llvm.inline_asm",
+    ] {
+        assert!(
+            plir.contains(needle),
+            "pliron IR missing `{needle}`:\n{plir}"
+        );
+    }
+
+    // Round-trip back to LLVM IR and verify it.
+    let out_module = to_llvm_ir::convert_module(ctx, &llvm_context, pliron_module)
+        .expect("to_llvm_ir should succeed");
+    out_module
+        .verify()
+        .expect("round-tripped LLVM module should verify");
+
+    let out_ir = llvm_print_module_to_string(&out_module).expect("print module");
+    for needle in [
+        "atomicrmw add",
+        "cmpxchg",
+        "fence seq_cst",
+        "load atomic",
+        "store atomic",
+        "asm sideeffect",
+    ] {
+        assert!(
+            out_ir.contains(needle),
+            "emitted IR missing `{needle}`:\n{out_ir}"
+        );
+    }
+}

--- a/pliron-llvm/tests/op_unit_tests.rs
+++ b/pliron-llvm/tests/op_unit_tests.rs
@@ -91,7 +91,7 @@ fn test_addrspacecast_roundtrips() {
                 .get_operation()
                 .insert_at_back(entry, ctx);
         },
-        &["llvm.addrspacecast", "llvm.ptr addrspace(1)"],
+        &["llvm.addrspacecast", "llvm.ptr (1)"],
     );
 }
 

--- a/pliron-llvm/tests/op_unit_tests.rs
+++ b/pliron-llvm/tests/op_unit_tests.rs
@@ -1,0 +1,200 @@
+//! Unit tests for the LLVM dialect ops. Each test builds a small module, prints
+//! it, checks for expected tokens, and asserts the printed IR re-parses. They
+//! exercise only the printer and parser (no `llvm-sys`), so they run without
+//! that feature.
+
+use pliron::{
+    basic_block::BasicBlock,
+    builtin::{
+        op_interfaces::SingleBlockRegionInterface,
+        ops::ModuleOp,
+        types::{IntegerType, Signedness},
+    },
+    combine::Parser,
+    context::{Context, Ptr},
+    irfmt::parsers::spaced,
+    location,
+    op::Op,
+    operation::Operation,
+    parsable::{self, state_stream_from_iterator},
+    printable::Printable,
+    r#type::TypeObj,
+    value::Value,
+};
+use pliron_llvm::attributes::{AtomicOrderingAttr, AtomicRmwKindAttr};
+// `AddrSpaceCastOp::new` is provided by this interface (cast ops share a
+// generated constructor), so the trait must be in scope.
+use pliron_llvm::op_interfaces::CastOpInterface;
+use pliron_llvm::ops::{
+    AddrSpaceCastOp, AtomicCmpxchgOp, AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, FenceOp, FuncOp,
+    InlineAsmOp, ReturnOp,
+};
+use pliron_llvm::types::{FuncType, PointerType, VoidType};
+
+/// Build a module with a function whose entry block has the given argument
+/// types, let `build` add ops to that block, then assert the whole module
+/// round-trips through the parser unchanged.
+fn assert_op_roundtrips(
+    make_arg_types: impl FnOnce(&mut Context) -> Vec<Ptr<TypeObj>>,
+    build: impl FnOnce(&mut Context, Ptr<BasicBlock>, &[Value]),
+    expected: &[&str],
+) {
+    let ctx = &mut Context::new();
+    let arg_types = make_arg_types(ctx);
+
+    let module = ModuleOp::new(ctx, "test".try_into().unwrap());
+    let module_block = module.get_body(ctx, 0);
+
+    let void = VoidType::get(ctx).into();
+    let fty = FuncType::get(ctx, void, arg_types, false);
+    let func = FuncOp::new(ctx, "f".try_into().unwrap(), fty);
+    let entry = func.get_or_create_entry_block(ctx);
+    let args: Vec<Value> = entry.deref(ctx).arguments().collect();
+
+    build(ctx, entry, &args);
+    ReturnOp::new(ctx, None)
+        .get_operation()
+        .insert_at_back(entry, ctx);
+    func.get_operation().insert_at_back(module_block, ctx);
+
+    let printed = module.get_operation().disp(ctx).to_string();
+    for tok in expected {
+        assert!(
+            printed.contains(tok),
+            "expected `{tok}` in printed IR:\n{printed}"
+        );
+    }
+
+    // The printed IR must re-parse: this exercises the op's (and its
+    // attributes') parser against exactly what its printer produced.
+    let ctx2 = &mut Context::new();
+    let state_stream = state_stream_from_iterator(
+        printed.chars(),
+        parsable::State::new(ctx2, location::Source::InMemory),
+    );
+    spaced(Operation::top_level_parser())
+        .parse(state_stream)
+        .expect("printed IR should re-parse");
+}
+
+fn i32_ty(ctx: &mut Context) -> Ptr<TypeObj> {
+    IntegerType::get(ctx, 32, Signedness::Signless).into()
+}
+
+#[test]
+fn test_addrspacecast_roundtrips() {
+    assert_op_roundtrips(
+        |ctx| vec![PointerType::get(ctx, 0).into()],
+        |ctx, entry, args| {
+            let dst = PointerType::get(ctx, 1).into();
+            AddrSpaceCastOp::new(ctx, args[0], dst)
+                .get_operation()
+                .insert_at_back(entry, ctx);
+        },
+        &["llvm.addrspacecast", "llvm.ptr addrspace(1)"],
+    );
+}
+
+#[test]
+fn test_atomicrmw_roundtrips() {
+    assert_op_roundtrips(
+        |ctx| vec![PointerType::get(ctx, 1).into(), i32_ty(ctx)],
+        |ctx, entry, args| {
+            AtomicRmwOp::new(
+                ctx,
+                args[0],
+                args[1],
+                AtomicRmwKindAttr::Add,
+                AtomicOrderingAttr::SeqCst,
+                Some("device".to_string()),
+            )
+            .get_operation()
+            .insert_at_back(entry, ctx);
+        },
+        &["llvm.atomicrmw", "Add", "SeqCst", "device"],
+    );
+}
+
+#[test]
+fn test_cmpxchg_roundtrips() {
+    assert_op_roundtrips(
+        |ctx| {
+            let i = i32_ty(ctx);
+            vec![PointerType::get(ctx, 0).into(), i, i]
+        },
+        |ctx, entry, args| {
+            AtomicCmpxchgOp::new(
+                ctx,
+                args[0],
+                args[1],
+                args[2],
+                AtomicOrderingAttr::AcqRel,
+                AtomicOrderingAttr::Monotonic,
+                None,
+            )
+            .get_operation()
+            .insert_at_back(entry, ctx);
+        },
+        &["llvm.cmpxchg", "AcqRel", "Monotonic"],
+    );
+}
+
+#[test]
+fn test_fence_roundtrips() {
+    assert_op_roundtrips(
+        |_ctx| vec![],
+        |ctx, entry, _args| {
+            FenceOp::new(ctx, AtomicOrderingAttr::SeqCst, Some("block".to_string()))
+                .get_operation()
+                .insert_at_back(entry, ctx);
+        },
+        &["llvm.fence", "SeqCst", "block"],
+    );
+}
+
+#[test]
+fn test_atomic_load_roundtrips() {
+    assert_op_roundtrips(
+        |ctx| vec![PointerType::get(ctx, 3).into()],
+        |ctx, entry, args| {
+            let res = i32_ty(ctx);
+            AtomicLoadOp::new(ctx, args[0], res, AtomicOrderingAttr::Acquire, None)
+                .get_operation()
+                .insert_at_back(entry, ctx);
+        },
+        &["llvm.atomic_load", "Acquire"],
+    );
+}
+
+#[test]
+fn test_atomic_store_roundtrips() {
+    assert_op_roundtrips(
+        |ctx| vec![i32_ty(ctx), PointerType::get(ctx, 3).into()],
+        |ctx, entry, args| {
+            AtomicStoreOp::new(
+                ctx,
+                args[0],
+                args[1],
+                AtomicOrderingAttr::Release,
+                Some("device".to_string()),
+            )
+            .get_operation()
+            .insert_at_back(entry, ctx);
+        },
+        &["llvm.atomic_store", "Release", "device"],
+    );
+}
+
+#[test]
+fn test_inline_asm_roundtrips() {
+    assert_op_roundtrips(
+        |ctx| vec![i32_ty(ctx)],
+        |ctx, entry, args| {
+            let res = i32_ty(ctx);
+            InlineAsmOp::new(ctx, res, vec![args[0]], "mov $0, $1", "=r,r", true)
+                .get_operation()
+                .insert_at_back(entry, ctx);
+        },
+        &["llvm.inline_asm", "mov", "=r,r", "convergent"],
+    );
+}

--- a/src/builtin/attributes.rs
+++ b/src/builtin/attributes.rs
@@ -13,7 +13,7 @@ use crate::{
     attribute::{AttrObj, AttributeDict},
     builtin::{
         attr_interfaces::FloatAttr,
-        types::{FP32Type, FP64Type},
+        types::{FP16Type, FP32Type, FP64Type},
     },
     common_traits::Verify,
     context::{Context, Ptr},
@@ -246,6 +246,49 @@ impl MaterializableAttr for IntegerAttr {
     fn materialize(&self, ctx: &mut Context) -> Ptr<Operation> {
         let const_op = ConstantOp::new(ctx, Box::new(self.clone()));
         const_op.get_operation()
+    }
+}
+
+#[pliron_attr(name = "builtin.half", format = "$0", verifier = "succ")]
+#[derive(PartialEq, Clone, Debug)]
+/// An attribute that is a half-precision (16-bit) floating-point number.
+pub struct FPHalfAttr(pub apfloat::Half);
+
+impl Hash for FPHalfAttr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.to_bits().hash(state);
+    }
+}
+
+#[attr_interface_impl]
+impl TypedAttrInterface for FPHalfAttr {
+    fn get_type(&self, ctx: &Context) -> Ptr<TypeObj> {
+        FP16Type::get(ctx).into()
+    }
+}
+
+#[attr_interface_impl]
+impl FloatAttr for FPHalfAttr {
+    fn get_inner(&self) -> &dyn apfloat::DynFloat {
+        &self.0
+    }
+
+    fn build_from(&self, df: Box<dyn apfloat::DynFloat>) -> Box<dyn FloatAttr> {
+        let df = df
+            .downcast::<apfloat::Half>()
+            .expect("Expected a Half precision float");
+        Box::new(FPHalfAttr(*df))
+    }
+
+    fn get_semantics(&self) -> apfloat::Semantics {
+        Self::get_semantics_static()
+    }
+
+    fn get_semantics_static() -> apfloat::Semantics
+    where
+        Self: Sized,
+    {
+        <apfloat::Half as apfloat::GetSemantics>::get_semantics()
     }
 }
 

--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -111,6 +111,44 @@ pub trait BranchOpInterface: IsTerminatorInterface {
     }
 }
 
+#[derive(Error, Debug)]
+#[error("Expected {0} successors, but found {1}")]
+pub struct NSuccsVerifyErr(pub usize, pub usize);
+
+/// An [Op] having exactly `N` successors. Successors are branch targets, so this
+/// requires [BranchOpInterface] (which separately checks the forwarded operands
+/// against each target block's arguments).
+#[op_interface]
+pub trait NSuccsInterface<const N: usize>: BranchOpInterface {
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let opr = op.get_operation();
+        let op = &*opr.deref(ctx);
+        if op.get_num_successors() != N {
+            return verify_err!(op.loc(), NSuccsVerifyErr(N, op.get_num_successors()));
+        }
+        Ok(())
+    }
+}
+
+/// An [Op] having exactly one successor.
+#[op_interface]
+pub trait OneSuccInterface: NSuccsInterface<1> {
+    /// Get the single successor block of this [Op].
+    fn get_successor(&self, ctx: &Context) -> Ptr<BasicBlock> {
+        self.get_operation().deref(ctx).get_successor(0)
+    }
+
+    fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        Ok(())
+    }
+}
+
 dict_key!(
     /// Key for the `operand_segment_sizes` attribute.
     ATTR_KEY_OPERAND_SEGMENT_SIZES, "operand_segment_sizes"

--- a/src/builtin/types.rs
+++ b/src/builtin/types.rs
@@ -172,6 +172,16 @@ impl FloatTypeInterface for FP64Type {
     }
 }
 
+#[pliron_type(name = "builtin.fp16", format, generate_get = true, verifier = "succ")]
+#[derive(Hash, PartialEq, Eq, Debug)]
+pub struct FP16Type;
+#[type_interface_impl]
+impl FloatTypeInterface for FP16Type {
+    fn get_semantics(&self) -> Semantics {
+        apfloat::Half::get_semantics()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use combine::{Parser, eof};

--- a/tests/opts/mem2reg.rs
+++ b/tests/opts/mem2reg.rs
@@ -100,7 +100,7 @@ fn mem2reg_basic_store_and_load() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       stored_val = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64;
       llvm.store *alloc <- stored_val;
       loaded_val = llvm.load alloc : builtin.integer i64;
@@ -127,7 +127,7 @@ fn mem2reg_multiple_stores_one_load() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       val1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
       llvm.store *alloc <- val1;
       val2 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64;
@@ -155,7 +155,7 @@ fn mem2reg_no_store_uses_default() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       loaded = llvm.load alloc : builtin.integer i64;
       llvm.return loaded
     }
@@ -180,7 +180,7 @@ fn mem2reg_no_load_dead_allocation() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       val = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64;
       llvm.store *alloc <- val;
       dead_val = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
@@ -204,7 +204,7 @@ fn mem2reg_phi_with_conditional_branch() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1) variadic = false> [] {
       ^entry(cond: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       llvm.cond_br if cond ^then() else ^else()
 
       ^then():
@@ -244,8 +244,8 @@ fn mem2reg_multiple_allocations() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc1 = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
-      alloc2 = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc1 = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
+      alloc2 = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       val1 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64;
       val2 = builtin.constant <builtin.integer <20: i64>> : builtin.integer i64;
       llvm.store *alloc1 <- val1;
@@ -278,7 +278,7 @@ fn mem2reg_linear_chain_of_stores_and_loads() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       val1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
       llvm.store *alloc <- val1;
       load1 = llvm.load alloc : builtin.integer i64;
@@ -301,7 +301,7 @@ fn mem2reg_diamond_pattern() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1) variadic = false> [] {
       ^entry(cond: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       init_val = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
       llvm.store *alloc <- init_val;
       llvm.cond_br if cond ^then() else ^else()
@@ -337,7 +337,7 @@ fn mem2reg_nested_branches() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1, builtin.integer i1) variadic = false> [] {
       ^entry(cond1: builtin.integer i1, cond2: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       val0 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
       llvm.store *alloc <- val0;
       llvm.cond_br if cond1 ^if1_then() else ^if1_else()
@@ -384,7 +384,7 @@ fn mem2reg_unused_block_arguments() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1) variadic = false> [] {
       ^entry(cond: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       val_then = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
       val_else = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64;
       llvm.cond_br if cond ^then() else ^else()
@@ -417,7 +417,7 @@ fn mem2reg_multiple_paths_convergence() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1, builtin.integer i1) variadic = false> [] {
       ^entry(cond1: builtin.integer i1, cond2: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       v0 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
       llvm.store *alloc <- v0;
       llvm.cond_br if cond1 ^path1() else ^path2()
@@ -462,7 +462,7 @@ fn mem2reg_load_before_any_store() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       first_load = llvm.load alloc : builtin.integer i64;
       store_val = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64;
       llvm.store *alloc <- store_val;
@@ -489,7 +489,7 @@ fn mem2reg_complex_liveness() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1) variadic = false> [] {
       ^entry(cond: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       init = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
       llvm.store *alloc <- init;
       loaded1 = llvm.load alloc : builtin.integer i64;
@@ -527,7 +527,7 @@ fn mem2reg_no_promotion_when_alloca_address_escapes() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       val = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64;
       llvm.store *alloc <- val;
       loaded = llvm.load alloc : builtin.integer i64;
@@ -552,7 +552,7 @@ fn mem2reg_repeated_forward_edges() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1, builtin.integer i1) variadic = false> [] {
       ^entry(cond1: builtin.integer i1, cond2: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       v0 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
       llvm.store *alloc <- v0;
       llvm.cond_br if cond1 ^block_a() else ^block_b()
@@ -586,7 +586,7 @@ fn mem2reg_not_promoted_when_load_is_in_nested_region() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       v = builtin.constant <builtin.integer <9: i64>> : builtin.integer i64;
       llvm.store *alloc <- v;
       test.region_carrier {
@@ -612,7 +612,7 @@ fn mem2reg_not_promoted_when_store_is_in_nested_region() -> Result<()> {
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       v = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64;
       test.region_carrier {
         ^nested():
@@ -639,7 +639,7 @@ fn mem2reg_not_promoted_for_interface_declared_non_promotable_use() -> Result<()
     llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
       ^entry():
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       v = builtin.constant <builtin.integer <13: i64>> : builtin.integer i64;
       llvm.store *alloc <- v;
       test.non_promotable_use alloc;
@@ -664,7 +664,7 @@ fn mem2reg_not_promoted_when_phi_pred_has_non_branch_successor_terminator() -> R
     llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i1) variadic = false> [] {
       ^entry(cond: builtin.integer i1):
       size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
-      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr;
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
       llvm.cond_br if cond ^left() else ^right()
 
       ^left():


### PR DESCRIPTION
This branch includes additions that cuda-oxide depends on which I believe will also be useful to other users of pliron.

It is stacked on top of #94 (llvm_sys_optional), so the base of this PR is that branch rather than master.

Commit by commit:

- Add address space support - PointerType carries an address space, plus an addrspacecast op and address spaces on globals.
- Add atomic operations - atomicrmw, cmpxchg, fence, and atomic load/store, with memory ordering and sync scope modeled as attributes.
- Add round-trip tests for the address-space and atomic constructs.
- Add half (FP16) float type and constant attribute to the builtin dialect.
- Add an inline assembly op.
- Thread address space through AddressOfOp.
- Strengthen verification for undef / addressof / br / return.
- Bridge atomics + inline asm through the llvm-sys FFI layer (to_llvm_ir / from_llvm_ir).

Two choices worth calling out:

I put f16 (the half type and its constant attribute) in builtin, not in the LLVM dialect. f16 is a general floating-point type rather than an LLVM-specific concept, so it sits alongside the other builtin floats where any dialect can reach it.

I tightened verification on a few pliron-llvm ops that were on the permissive "succ" verifier. undef/addressof now pin their operand count, br checks it has exactly one successor, and return checks its operands match the enclosing function's signature. These were constructible in malformed states before and slipped through verify; cuda-oxide relies on the stricter checks, and they should help any consumer catch bad IR earlier.

All changes come with tests, and the FFI layer also includes round-trip tests (LLVM IR -> pliron -> LLVM IR, verified at both ends) for the atomic and inline-asm constructs.

One known limitation in the bridge: only the system and singlethread sync scopes round-trip inbound (LLVM-C exposes the scope id but not its name), and the convergent inline-asm flag is not carried across. Both emit correctly outbound.

Tested on stable + LLVM 22: fmt, clippy --all-targets -D warnings, build, test (debug + release), doc, and the pliron-llvm --no-default-features build all pass.
