### PR TITLE
Implement ConstFoldInterface for mul, shl, xdiv, xrem

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -181,14 +181,13 @@ impl ConstFoldInterface for MulOp {
 impl ConstFoldInterface for ShlOp {
     fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
         match get_int_bin_operands(ops) {
-            Some((_, rhs)) => {
+            Some((lhs, rhs)) => {
                 let shamt = rhs.value();
-                let bw = APInt::from_usize(shamt.bw(), NonZero::new(shamt.bw()).unwrap());
-                if shamt.ult(&bw) {
+                let lhs_bw : usize = lhs.value().bw();
+                let lhs_bw : APInt = APInt::from_usize(lhs_bw, NonZero::new(lhs_bw).unwrap());
+                if shamt.ult(&lhs_bw) {
                     check_fold_int_bin_op(ops, APInt::shl)
                 } else {
-                    // A shift amount >= the bitwidth is poison in LLVM, so only fold
-                    // when the shift amount is in range.
                     vec![None]
                 }
             }

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -1,9 +1,11 @@
 //! Implementation of various op interfaces for LLVM IR instructions.
 
+use std::num::NonZero;
+
 use pliron::{
     attribute::AttrObj,
     basic_block::BasicBlock,
-    builtin::{attributes::IntegerAttr, op_interfaces::BranchOpInterface, ops::ConstantOp},
+    builtin::{attributes::IntegerAttr, op_interfaces::BranchOpInterface},
     context::{Context, Ptr},
     derive::op_interface_impl,
     irbuild::{IRStatus, rewriter::Rewriter},
@@ -98,13 +100,10 @@ impl BlockArgRemoval for FuncOp {
     }
 }
 
-/// If all elements of `operand_attrs` are `Some(x)`, combine the operands
-/// and return the result. Otherwise, return None. Assumes that the
-/// concrete type of the attributes are `IntegerAttr`.
-fn fold_int_bin_operands(
-    operand_attrs: &[Option<AttrObj>],
-    combine: impl Fn(&APInt, &APInt) -> APInt,
-) -> Option<AttrObj> {
+/// Assumes `operand_attrs` has length 2. If both elements are `Some(x)` where `x` can
+/// be casted to an [IntegerAttr], return the casted results. Otherwise, return `None`.
+fn get_int_bin_operands(operand_attrs: &[Option<AttrObj>]) -> Option<(IntegerAttr, IntegerAttr)> {
+    assert!(operand_attrs.len() == 2);
     let [Some(lhs), Some(rhs)] = operand_attrs else {
         return None;
     };
@@ -114,38 +113,23 @@ fn fold_int_bin_operands(
     let rhs_int = rhs
         .downcast_ref::<IntegerAttr>()
         .expect("invalid operand type: typecheck before optimizing");
-    Some(Box::new(IntegerAttr::new(
-        lhs_int.get_type(),
-        combine(&lhs_int.value(), &rhs_int.value()),
-    )) as AttrObj)
+    Some((lhs_int.clone(), rhs_int.clone()))
 }
 
-/// Constant fold this binary operation into a singleton vector containing
-/// its result type if folding is successful, or None otherwise.
+/// Constant fold this binary integer operation into a singleton vector
+/// containing its result type if folding is successful, or None otherwise.
 fn check_fold_int_bin_op(
     operand_attrs: &[Option<AttrObj>],
     combine: impl Fn(&APInt, &APInt) -> APInt,
 ) -> Vec<Option<AttrObj>> {
-    vec![fold_int_bin_operands(operand_attrs, combine)]
-}
-
-/// Attempt to perform constant folding the given operation
-fn fold_in_place_int_bin_op(
-    op: &impl Op,
-    ctx: &mut Context,
-    operand_attrs: &[Option<AttrObj>],
-    rewriter: &mut dyn Rewriter,
-    combine: impl Fn(&APInt, &APInt) -> APInt,
-) -> IRStatus {
-    let Some(folded) = fold_int_bin_operands(operand_attrs, combine) else {
-        return IRStatus::Unchanged;
+    let Some((lhs, rhs)) = get_int_bin_operands(operand_attrs) else {
+        return vec![None];
     };
-    let new_const = ConstantOp::new(ctx, folded);
-    let old_op = op.get_operation();
-    let new_op = new_const.get_operation();
-    rewriter.insert_operation(ctx, new_op);
-    rewriter.replace_operation(ctx, old_op, new_op);
-    IRStatus::Changed
+    let res = Box::new(IntegerAttr::new(
+        lhs.get_type(),
+        combine(&lhs.value(), &rhs.value()),
+    )) as AttrObj;
+    vec![Some(res)]
 }
 
 #[op_interface_impl]
@@ -159,7 +143,7 @@ impl ConstFoldInterface for AddOp {
         ops: &[Option<AttrObj>],
         rw: &mut dyn Rewriter,
     ) -> IRStatus {
-        fold_in_place_int_bin_op(self, ctx, ops, rw, APInt::add)
+        self.fold_with_materialization(ctx, ops, rw)
     }
 }
 
@@ -174,7 +158,122 @@ impl ConstFoldInterface for SubOp {
         ops: &[Option<AttrObj>],
         rw: &mut dyn Rewriter,
     ) -> IRStatus {
-        fold_in_place_int_bin_op(self, ctx, ops, rw, APInt::sub)
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for MulOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_int_bin_op(ops, APInt::mul)
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for ShlOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        match get_int_bin_operands(ops) {
+            Some((_, rhs)) => {
+                let shamt = rhs.value();
+                let bw = APInt::from_usize(shamt.bw(), NonZero::new(shamt.bw()).unwrap());
+                if shamt.ult(&bw) {
+                    check_fold_int_bin_op(ops, APInt::shl)
+                } else {
+                    // A shift amount >= the bitwidth is poison in LLVM, so only fold
+                    // when the shift amount is in range.
+                    vec![None]
+                }
+            }
+            None => vec![None],
+        }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for UDivOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        match get_int_bin_operands(ops) {
+            Some((_, rhs)) if rhs.value().is_zero() => vec![None],
+            _ => check_fold_int_bin_op(ops, APInt::udiv),
+        }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for SDivOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        match get_int_bin_operands(ops) {
+            Some((_, rhs)) if rhs.value().is_zero() => vec![None],
+            _ => check_fold_int_bin_op(ops, APInt::sdiv),
+        }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for URemOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        match get_int_bin_operands(ops) {
+            Some((_, rhs)) if rhs.value().is_zero() => vec![None],
+            _ => check_fold_int_bin_op(ops, APInt::urem),
+        }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for SRemOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        match get_int_bin_operands(ops) {
+            Some((_, rhs)) if rhs.value().is_zero() => vec![None],
+            _ => check_fold_int_bin_op(ops, APInt::srem),
+        }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
     }
 }
 

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -183,8 +183,8 @@ impl ConstFoldInterface for ShlOp {
         match get_int_bin_operands(ops) {
             Some((lhs, rhs)) => {
                 let shamt = rhs.value();
-                let lhs_bw : usize = lhs.value().bw();
-                let lhs_bw : APInt = APInt::from_usize(lhs_bw, NonZero::new(lhs_bw).unwrap());
+                let lhs_bw: usize = lhs.value().bw();
+                let lhs_bw: APInt = APInt::from_usize(lhs_bw, NonZero::new(lhs_bw).unwrap());
                 if shamt.ult(&lhs_bw) {
                     check_fold_int_bin_op(ops, APInt::shl)
                 } else {

--- a/src/opts/constants/mod.rs
+++ b/src/opts/constants/mod.rs
@@ -58,7 +58,8 @@ pub trait ConstFoldInterface {
             };
             let Some(materializable) = attr_cast::<dyn MaterializableAttr>(&**attr) else {
                 log::info!(
-                    "Constant propagation tried to materialize {}, but its type does not implement MaterializableAttr.",
+                    "Constant propagation tried to materialize {}, but its type does not \
+                     implement MaterializableAttr. This potentially prevents optimizations.",
                     attr.disp(ctx)
                 );
                 continue;

--- a/src/opts/constants/mod.rs
+++ b/src/opts/constants/mod.rs
@@ -7,9 +7,7 @@ use crate::{
     builtin::{attr_interfaces::MaterializableAttr, op_interfaces::BranchOpInterface},
     context::{Context, Ptr},
     irbuild::{IRStatus, rewriter::Rewriter},
-    op::{Op, op_cast},
-    operation::Operation,
-    opts::dce::SideEffects,
+    op::Op,
     result::Result,
 };
 
@@ -52,7 +50,6 @@ pub trait ConstFoldInterface {
     ) -> IRStatus {
         let folded = self.check_fold(ctx, operand_attrs);
         let op = self.get_operation();
-        let num_results = op.deref(ctx).get_num_results();
 
         let mut num_materialized = 0;
         for (result_idx, attr) in folded.iter().enumerate() {
@@ -70,19 +67,10 @@ pub trait ConstFoldInterface {
             num_materialized += 1;
         }
         if num_materialized == 0 {
-            return IRStatus::Unchanged;
+            IRStatus::Unchanged
+        } else {
+            IRStatus::Changed
         }
-        if num_materialized == num_results {
-            let op_dyn = Operation::get_op_dyn(op, ctx);
-            let has_side_effects = match op_cast::<dyn SideEffects>(&*op_dyn) {
-                Some(side_effects_op) => side_effects_op.has_side_effects(ctx),
-                None => true,
-            };
-            if !has_side_effects {
-                rewriter.erase_operation(ctx, op);
-            }
-        }
-        IRStatus::Changed
     }
 
     fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>

--- a/src/opts/constants/mod.rs
+++ b/src/opts/constants/mod.rs
@@ -2,12 +2,14 @@ use alloc::vec::Vec;
 use pliron_derive::op_interface;
 
 use crate::{
-    attribute::AttrObj,
+    attribute::{AttrObj, attr_cast},
     basic_block::BasicBlock,
-    builtin::op_interfaces::BranchOpInterface,
+    builtin::{attr_interfaces::MaterializableAttr, op_interfaces::BranchOpInterface},
     context::{Context, Ptr},
     irbuild::{IRStatus, rewriter::Rewriter},
-    op::Op,
+    op::{Op, op_cast},
+    operation::Operation,
+    opts::dce::SideEffects,
     result::Result,
 };
 
@@ -26,12 +28,62 @@ pub trait ConstFoldInterface {
     /// compile time constant value for that operand (if any), attempts to fold the op in
     /// place using the provided `rewriter`. Assumes that `rewriter` is positioned just
     /// before the op to be folded.
+    ///
+    /// Implementors that fold by materializing constant values for their results can
+    /// usually delegate to [fold_with_materialization](Self::fold_with_materialization)
+    /// rather than reimplementing the materialization logic.
     fn fold_in_place(
         &self,
         ctx: &mut Context,
         operand_attrs: &[Option<AttrObj>],
         rewriter: &mut dyn Rewriter,
     ) -> IRStatus;
+
+    /// A helper for implementing [fold_in_place](Self::fold_in_place) by materializing
+    /// the constants inferred by [check_fold](Self::check_fold).
+    ///
+    /// Only constants whose attribute types implement [MaterializableAttr] get
+    /// materialized.
+    fn fold_with_materialization(
+        &self,
+        ctx: &mut Context,
+        operand_attrs: &[Option<AttrObj>],
+        rewriter: &mut dyn Rewriter,
+    ) -> IRStatus {
+        let folded = self.check_fold(ctx, operand_attrs);
+        let op = self.get_operation();
+        let num_results = op.deref(ctx).get_num_results();
+
+        let mut num_materialized = 0;
+        for (result_idx, attr) in folded.iter().enumerate() {
+            let Some(attr) = attr else {
+                continue;
+            };
+            let Some(materializable) = attr_cast::<dyn MaterializableAttr>(&**attr) else {
+                continue;
+            };
+            let const_op = materializable.materialize(ctx);
+            rewriter.insert_operation(ctx, const_op);
+            let new_value = const_op.deref(ctx).get_result(0);
+            let old_value = op.deref(ctx).get_result(result_idx);
+            rewriter.replace_value_uses_with(ctx, old_value, new_value);
+            num_materialized += 1;
+        }
+        if num_materialized == 0 {
+            return IRStatus::Unchanged;
+        }
+        if num_materialized == num_results {
+            let op_dyn = Operation::get_op_dyn(op, ctx);
+            let has_side_effects = match op_cast::<dyn SideEffects>(&*op_dyn) {
+                Some(side_effects_op) => side_effects_op.has_side_effects(ctx),
+                None => true,
+            };
+            if !has_side_effects {
+                rewriter.erase_operation(ctx, op);
+            }
+        }
+        IRStatus::Changed
+    }
 
     fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>
     where

--- a/src/opts/constants/mod.rs
+++ b/src/opts/constants/mod.rs
@@ -51,7 +51,7 @@ pub trait ConstFoldInterface {
         let folded = self.check_fold(ctx, operand_attrs);
         let op = self.get_operation();
 
-        let mut num_materialized = 0;
+        let mut status = IRStatus::Unchanged;
         for (result_idx, attr) in folded.iter().enumerate() {
             let Some(attr) = attr else {
                 continue;
@@ -60,17 +60,13 @@ pub trait ConstFoldInterface {
                 continue;
             };
             let const_op = materializable.materialize(ctx);
-            rewriter.insert_operation(ctx, const_op);
+            rewriter.append_operation(ctx, const_op);
             let new_value = const_op.deref(ctx).get_result(0);
             let old_value = op.deref(ctx).get_result(result_idx);
             rewriter.replace_value_uses_with(ctx, old_value, new_value);
-            num_materialized += 1;
+            status = IRStatus::Changed;
         }
-        if num_materialized == 0 {
-            IRStatus::Unchanged
-        } else {
-            IRStatus::Changed
-        }
+        status
     }
 
     fn verify(_op: &dyn Op, _ctx: &Context) -> Result<()>

--- a/src/opts/constants/mod.rs
+++ b/src/opts/constants/mod.rs
@@ -57,6 +57,10 @@ pub trait ConstFoldInterface {
                 continue;
             };
             let Some(materializable) = attr_cast::<dyn MaterializableAttr>(&**attr) else {
+                log::info!(
+                    "Constant propagation tried to materialize {}, but its type does not implement MaterializableAttr.",
+                    attr.disp(ctx)
+                );
                 continue;
             };
             let const_op = materializable.materialize(ctx);

--- a/src/utils/apint.rs
+++ b/src/utils/apint.rs
@@ -3,7 +3,7 @@
 
 use crate::{arg_error_noloc, result::Result};
 use alloc::string::String;
-use awint::{Awi, SerdeError};
+use awint::{Awi, Bits, SerdeError};
 use core::num::NonZero;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -67,6 +67,130 @@ impl APInt {
             .sub_(&rhs.value)
             .expect("APInt::sub: bitwidth mismatch");
         APInt { value }
+    }
+
+    /// Multiply `self` and `rhs`. They must have the same bitwidth.
+    pub fn mul(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::mul: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        let mut value = Awi::zero(NonZero::new(self.bw()).expect("self has zero bitwidth"));
+        value
+            .mul_add_(&self.value, &rhs.value)
+            .expect("APInt::mul: bitwidth mismatch");
+        APInt { value }
+    }
+
+    /// Left-shift `self` by `rhs` bits. They must have the same bitwidth.
+    /// If the shift amount is greater than or equal to the bitwidth, the
+    /// result is zero.
+    pub fn shl(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::shl: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        let shamt = rhs.to_usize();
+        let mut value = self.value.clone();
+        if value.shl_(shamt).is_none() {
+            // Shift amount >= bitwidth: every bit is shifted out.
+            value.zero_();
+        }
+        APInt { value }
+    }
+
+    /// Unsigned-divide `self` by `rhs`. They must have the same bitwidth.
+    pub fn udiv(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::udiv: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        assert!(!rhs.is_zero(), "APInt::udiv: division by zero");
+        let width = NonZero::new(self.bw()).expect("self has zero bitwidth");
+        let mut quo = Awi::zero(width);
+        let mut rem = Awi::zero(width);
+        Bits::udivide(&mut quo, &mut rem, &self.value, &rhs.value).unwrap();
+        APInt { value: quo }
+    }
+
+    /// Signed-divide `self` by `rhs`. They must have the same bitwidth.
+    pub fn sdiv(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::sdiv: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        assert!(!rhs.is_zero(), "APInt::sdiv: division by zero");
+        let width = NonZero::new(self.bw()).expect("self has zero bitwidth");
+        let mut quo = Awi::zero(width);
+        let mut rem = Awi::zero(width);
+        let mut duo = self.value.clone();
+        let mut div = rhs.value.clone();
+        Bits::idivide(&mut quo, &mut rem, &mut duo, &mut div).unwrap();
+        APInt { value: quo }
+    }
+
+    /// Unsigned remainder of `self` divided by `rhs`. They must have the same
+    /// bitwidth.
+    pub fn urem(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::urem: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        assert!(!rhs.is_zero(), "APInt::urem: division by zero");
+        let width = NonZero::new(self.bw()).expect("self has zero bitwidth");
+        let mut quo = Awi::zero(width);
+        let mut rem = Awi::zero(width);
+        Bits::udivide(&mut quo, &mut rem, &self.value, &rhs.value).unwrap();
+        APInt { value: rem }
+    }
+
+    /// Signed remainder of `self` divided by `rhs`. They must have the same
+    /// bitwidth. The sign of the result follows the dividend.
+    pub fn srem(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::srem: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        assert!(!rhs.is_zero(), "APInt::srem: division by zero");
+        let width = NonZero::new(self.bw()).expect("self has zero bitwidth");
+        let mut quo = Awi::zero(width);
+        let mut rem = Awi::zero(width);
+        let mut duo = self.value.clone();
+        let mut div = rhs.value.clone();
+        Bits::idivide(&mut quo, &mut rem, &mut duo, &mut div).unwrap();
+        APInt { value: rem }
+    }
+
+    /// Unsigned less-than comparison. They must have the same bitwidth.
+    pub fn ult(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::ult: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .ult(&rhs.value)
+            .expect("APInt::ult: bitwidth mismatch")
     }
 
     /// Get unsigned max value
@@ -496,5 +620,279 @@ mod tests {
             let apint = APInt::from_i128(i, width);
             assert_eq!(apint.to_i128(), i);
         }
+    }
+
+    #[test]
+    fn test_add() {
+        let width = bw(4);
+
+        // Basic addition.
+        let sum = APInt::from_u8(3, width).add(&APInt::from_u8(4, width));
+        assert_eq!(sum.to_u8(), 7);
+
+        // Wraps (truncates) on overflow: 15 + 1 == 0 (mod 16).
+        let sum = APInt::from_u8(15, width).add(&APInt::from_u8(1, width));
+        assert_eq!(sum.to_u8(), 0);
+
+        // Signed view of wrapping: (-1) + 1 == 0.
+        let sum = APInt::from_i8(-1, width).add(&APInt::from_i8(1, width));
+        assert_eq!(sum.to_i8(), 0);
+
+        // Adding zero is the identity.
+        let sum = APInt::from_u8(9, width).add(&APInt::zero(width));
+        assert_eq!(sum.to_u8(), 9);
+    }
+
+    #[test]
+    fn test_sub() {
+        let width = bw(4);
+
+        // Basic subtraction.
+        let diff = APInt::from_u8(7, width).sub(&APInt::from_u8(4, width));
+        assert_eq!(diff.to_u8(), 3);
+
+        // Wraps (truncates) on borrow: 0 - 1 == 15 (mod 16), i.e. -1.
+        let diff = APInt::from_u8(0, width).sub(&APInt::from_u8(1, width));
+        assert_eq!(diff.to_u8(), 15);
+        assert_eq!(diff.to_i8(), -1);
+
+        // Subtracting from itself yields zero.
+        let diff = APInt::from_u8(5, width).sub(&APInt::from_u8(5, width));
+        assert!(diff.is_zero());
+    }
+
+    #[test]
+    fn test_mul() {
+        let width = bw(4);
+
+        // Basic multiplication.
+        let prod = APInt::from_u8(3, width).mul(&APInt::from_u8(4, width));
+        assert_eq!(prod.to_u8(), 12);
+
+        // Wraps (truncates) on overflow: 3 * 6 == 18 == 2 (mod 16).
+        let prod = APInt::from_u8(3, width).mul(&APInt::from_u8(6, width));
+        assert_eq!(prod.to_u8(), 2);
+
+        // (-2) * 3 == -6, whose 4-bit representation is 10 unsigned.
+        let prod = APInt::from_i8(-2, width).mul(&APInt::from_i8(3, width));
+        assert_eq!(prod.to_i8(), -6);
+        assert_eq!(prod.to_u8(), 10);
+
+        // Multiplying by zero yields zero.
+        let prod = APInt::from_u8(7, width).mul(&APInt::zero(width));
+        assert!(prod.is_zero());
+    }
+
+    #[test]
+    fn test_shl() {
+        let width = bw(4);
+
+        // Basic shift: 1 << 2 == 4.
+        let res = APInt::from_u8(1, width).shl(&APInt::from_u8(2, width));
+        assert_eq!(res.to_u8(), 4);
+
+        // Shifting by zero is the identity.
+        let res = APInt::from_u8(5, width).shl(&APInt::zero(width));
+        assert_eq!(res.to_u8(), 5);
+
+        // Bits shifted past the top are truncated: 3 << 3 == 24 == 8 (mod 16).
+        let res = APInt::from_u8(3, width).shl(&APInt::from_u8(3, width));
+        assert_eq!(res.to_u8(), 8);
+
+        // Shift amount equal to the bitwidth shifts every bit out, yielding 0.
+        let res = APInt::from_u8(0xf, width).shl(&APInt::from_u8(4, width));
+        assert!(res.is_zero());
+
+        // Shift amount greater than the bitwidth also yields 0.
+        let res = APInt::from_u8(0xf, width).shl(&APInt::from_u8(7, width));
+        assert!(res.is_zero());
+    }
+
+    #[test]
+    fn test_udiv() {
+        let width = bw(4);
+
+        // Exact division.
+        let res = APInt::from_u8(12, width).udiv(&APInt::from_u8(4, width));
+        assert_eq!(res.to_u8(), 3);
+
+        // Truncating (floor) division.
+        let res = APInt::from_u8(13, width).udiv(&APInt::from_u8(4, width));
+        assert_eq!(res.to_u8(), 3);
+
+        // Unsigned: the top bit is magnitude, not sign. 0xf == 15, not -1.
+        let res = APInt::from_u8(0xf, width).udiv(&APInt::from_u8(2, width));
+        assert_eq!(res.to_u8(), 7);
+
+        // Dividing by one is the identity.
+        let res = APInt::from_u8(9, width).udiv(&APInt::uone(width));
+        assert_eq!(res.to_u8(), 9);
+
+        // Divisor larger than dividend yields zero.
+        let res = APInt::from_u8(3, width).udiv(&APInt::from_u8(5, width));
+        assert!(res.is_zero());
+    }
+
+    #[test]
+    #[should_panic(expected = "division by zero")]
+    fn test_udiv_by_zero_panics() {
+        let width = bw(4);
+        let _ = APInt::from_u8(7, width).udiv(&APInt::zero(width));
+    }
+
+    #[test]
+    fn test_ult() {
+        let width = bw(4);
+
+        // Strictly less / greater.
+        assert!(APInt::from_u8(3, width).ult(&APInt::from_u8(5, width)));
+        assert!(!APInt::from_u8(5, width).ult(&APInt::from_u8(3, width)));
+
+        // Equal values are not less-than.
+        assert!(!APInt::from_u8(4, width).ult(&APInt::from_u8(4, width)));
+
+        // Unsigned interpretation: 0xf == 15 is the largest, not -1.
+        assert!(APInt::from_u8(1, width).ult(&APInt::from_u8(0xf, width)));
+        assert!(!APInt::from_u8(0xf, width).ult(&APInt::from_u8(1, width)));
+    }
+
+    #[test]
+    fn test_sdiv() {
+        let width = bw(4);
+
+        // Positive / positive.
+        assert_eq!(
+            APInt::from_i8(6, width)
+                .sdiv(&APInt::from_i8(2, width))
+                .to_i8(),
+            3
+        );
+
+        // Negative dividend: truncates toward zero, so -7 / 2 == -3.
+        assert_eq!(
+            APInt::from_i8(-7, width)
+                .sdiv(&APInt::from_i8(2, width))
+                .to_i8(),
+            -3
+        );
+
+        // Negative divisor.
+        assert_eq!(
+            APInt::from_i8(7, width)
+                .sdiv(&APInt::from_i8(-2, width))
+                .to_i8(),
+            -3
+        );
+
+        // Negative / negative is positive.
+        assert_eq!(
+            APInt::from_i8(-6, width)
+                .sdiv(&APInt::from_i8(-3, width))
+                .to_i8(),
+            2
+        );
+
+        // Dividing by one is the identity.
+        assert_eq!(
+            APInt::from_i8(-5, width).sdiv(&APInt::uone(width)).to_i8(),
+            -5
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "division by zero")]
+    fn test_sdiv_by_zero_panics() {
+        let width = bw(4);
+        let _ = APInt::from_i8(7, width).sdiv(&APInt::zero(width));
+    }
+
+    #[test]
+    fn test_urem() {
+        let width = bw(4);
+
+        // Basic remainder.
+        assert_eq!(
+            APInt::from_u8(13, width)
+                .urem(&APInt::from_u8(4, width))
+                .to_u8(),
+            1
+        );
+
+        // Exact division leaves no remainder.
+        assert_eq!(
+            APInt::from_u8(12, width)
+                .urem(&APInt::from_u8(4, width))
+                .to_u8(),
+            0
+        );
+
+        // Dividend smaller than divisor.
+        assert_eq!(
+            APInt::from_u8(3, width)
+                .urem(&APInt::from_u8(5, width))
+                .to_u8(),
+            3
+        );
+
+        // Unsigned: 0xf == 15, so 15 % 4 == 3 (not -1 % 4).
+        assert_eq!(
+            APInt::from_u8(0xf, width)
+                .urem(&APInt::from_u8(4, width))
+                .to_u8(),
+            3
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "division by zero")]
+    fn test_urem_by_zero_panics() {
+        let width = bw(4);
+        let _ = APInt::from_u8(7, width).urem(&APInt::zero(width));
+    }
+
+    #[test]
+    fn test_srem() {
+        let width = bw(4);
+
+        // The result's sign follows the dividend.
+        assert_eq!(
+            APInt::from_i8(7, width)
+                .srem(&APInt::from_i8(3, width))
+                .to_i8(),
+            1
+        );
+        assert_eq!(
+            APInt::from_i8(-7, width)
+                .srem(&APInt::from_i8(3, width))
+                .to_i8(),
+            -1
+        );
+        assert_eq!(
+            APInt::from_i8(7, width)
+                .srem(&APInt::from_i8(-3, width))
+                .to_i8(),
+            1
+        );
+        assert_eq!(
+            APInt::from_i8(-7, width)
+                .srem(&APInt::from_i8(-3, width))
+                .to_i8(),
+            -1
+        );
+
+        // Exact division leaves no remainder.
+        assert_eq!(
+            APInt::from_i8(-6, width)
+                .srem(&APInt::from_i8(3, width))
+                .to_i8(),
+            0
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "division by zero")]
+    fn test_srem_by_zero_panics() {
+        let width = bw(4);
+        let _ = APInt::from_i8(7, width).srem(&APInt::zero(width));
     }
 }

--- a/tests/opts/sccp.rs
+++ b/tests/opts/sccp.rs
@@ -75,7 +75,6 @@ fn sccp_folds_add_of_two_constants() -> Result<()> {
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     assert!(after.contains("<7: i64>"));
-    assert!(!after.contains("llvm.add"));
     Ok(())
 }
 
@@ -236,7 +235,6 @@ fn sccp_folds_inside_nested_region_using_outer_constant() -> Result<()> {
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     assert!(after.contains("<7: i64>"));
-    assert!(!after.contains("llvm.add"));
     Ok(())
 }
 
@@ -268,7 +266,6 @@ fn sccp_folds_inside_two_nested_regions() -> Result<()> {
     // Both inner adds should fold.
     assert!(after.contains("<7: i64>"));
     assert!(after.contains("<30: i64>"));
-    assert!(!after.contains("llvm.add"));
     Ok(())
 }
 
@@ -293,7 +290,6 @@ fn sccp_folds_inside_nested_region() -> Result<()> {
     assert_eq!(status, IRStatus::Changed);
     // The inner add should fold to 7.
     assert!(after.contains("<7: i64>"));
-    assert!(!after.contains("llvm.add"));
     Ok(())
 }
 


### PR DESCRIPTION
This PR does *not* complete https://github.com/pliron-org/pliron/issues/118, but makes progress toward that goal, by implementing `ConstFoldInterface` for the llvm ops `mul`, `shl`, `sdiv`, `udiv`, `srem`, and `urem`.

Enough subtle decisions have surfaced that implementing *all* of the remaining ops would be rushing things.

### Fold_with_materialization

A method `fold_with_materialization` was added to the `ConstFoldInterface` trait, which provides a default implementation for `fold_in_place`. Since this implementation doesn't work for constant-producing operations such as `builtin.constant`,  we don't implement this as the default implementation of `fold_in_place`, forcing the dialect implementor to opt in to using it.

For each result `r` of the fold target operation, if `r` is inferred constant and the constant type implements `MaterializableAttr` then the `r` is materialized: a constant-producing op is inserted directly above `r`'s defining op (the fold target operation), and the materialized value is substituted for all occurrences of the target op's result.

Even if all of the fold target op's results are materialized, the fold target op is not removed. That should be done later by the `dce` optimizer. Previously, custom `fold_in_place` implementations for `AddOp` and `SubOp` *did* remove the operations; because of this, this PR modified some integration tests for `sccp`. 

## llvm.shl

Shifting an integer left by a value at least as great as its bit width produces different results on different machines. For this reason, our `check_fold` implementation refrains from folding when the right operand is at least as great as the bit-width of the shifted integer. 

## sdiv, udiv, srem, urem

All of the division operations require that the second operand (the divisor) is non-zero. Their `check_fold` implementations intercept cases where the divisor has been inferred to be the constant zero and refrain from folding.