### PR TITLE
added overflow-aware constant folding for `llvm` dialect's `add`, `sub`, `mul`, `shl`. 

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -27,6 +27,8 @@ use pliron::{
     value::Value,
 };
 
+use crate::attributes::IntegerOverflowFlagsAttr;
+use crate::op_interfaces::IntBinArithOpWithOverflowFlag;
 use crate::{
     op_interfaces::PointerTypeResult,
     ops::{
@@ -227,6 +229,35 @@ fn get_int_bin_operands(operand_attrs: &[Option<AttrObj>]) -> Option<(IntegerAtt
     Some((lhs_int.clone(), rhs_int.clone()))
 }
 
+/// Constant fold this binary integer operation, taking integer overflow flags
+/// into account.
+///
+/// `operand_attrs` contains `Some(attr)` for operands inferred constant
+/// and `None` for operands not inferred constant.
+///
+/// `flags` contains the llvm integer overflow flags associated with this operation
+///
+/// `combine` computes the wrapped result together with whether the operation
+/// unsigned- and signed-overflowed (the two booleans, in that order). The
+///
+/// Returns a singleton vector containing the folded result, or `None` if folding
+/// is not possible.
+fn check_fold_int_bin_op_with_overflow(
+    operand_attrs: &[Option<AttrObj>],
+    flags: IntegerOverflowFlagsAttr,
+    combine: impl Fn(&APInt, &APInt) -> (APInt, bool, bool),
+) -> Vec<Option<AttrObj>> {
+    let Some((lhs, rhs)) = get_int_bin_operands(operand_attrs) else {
+        return vec![None];
+    };
+    let (res, unsigned_overflow, signed_overflow) = combine(&lhs.value(), &rhs.value());
+    if (flags.nsw && signed_overflow) || (flags.nuw && unsigned_overflow) {
+        return vec![None];
+    }
+    let res = Box::new(IntegerAttr::new(lhs.get_type(), res)) as AttrObj;
+    vec![Some(res)]
+}
+
 /// Constant fold this binary integer operation into a singleton vector
 /// containing its result type if folding is successful, or None otherwise.
 fn check_fold_int_bin_op(
@@ -245,8 +276,12 @@ fn check_fold_int_bin_op(
 
 #[op_interface_impl]
 impl ConstFoldInterface for AddOp {
-    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
-        check_fold_int_bin_op(ops, APInt::add)
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_int_bin_op_with_overflow(
+            ops,
+            self.integer_overflow_flag(ctx),
+            APInt::add_overflow,
+        )
     }
     fn fold_in_place(
         &self,
@@ -260,8 +295,12 @@ impl ConstFoldInterface for AddOp {
 
 #[op_interface_impl]
 impl ConstFoldInterface for SubOp {
-    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
-        check_fold_int_bin_op(ops, APInt::sub)
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_int_bin_op_with_overflow(
+            ops,
+            self.integer_overflow_flag(ctx),
+            APInt::sub_overflow,
+        )
     }
     fn fold_in_place(
         &self,
@@ -275,8 +314,12 @@ impl ConstFoldInterface for SubOp {
 
 #[op_interface_impl]
 impl ConstFoldInterface for MulOp {
-    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
-        check_fold_int_bin_op(ops, APInt::mul)
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_int_bin_op_with_overflow(
+            ops,
+            self.integer_overflow_flag(ctx),
+            APInt::mul_overflow,
+        )
     }
     fn fold_in_place(
         &self,
@@ -290,14 +333,18 @@ impl ConstFoldInterface for MulOp {
 
 #[op_interface_impl]
 impl ConstFoldInterface for ShlOp {
-    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
         match get_int_bin_operands(ops) {
             Some((lhs, rhs)) => {
                 let shamt = rhs.value();
                 let lhs_bw: usize = lhs.value().bw();
                 let lhs_bw: APInt = APInt::from_usize(lhs_bw, NonZero::new(lhs_bw).unwrap());
                 if shamt.ult(&lhs_bw) {
-                    check_fold_int_bin_op(ops, APInt::shl)
+                    check_fold_int_bin_op_with_overflow(
+                        ops,
+                        self.integer_overflow_flag(ctx),
+                        APInt::shl_overflow,
+                    )
                 } else {
                     vec![None]
                 }

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1,0 +1,513 @@
+//! Test that llvm operations implement the constant folding interfaces
+//! [ConstFoldInterface] and [BranchOpFoldInterface] correctly
+
+use pliron::{
+    combine::Parser,
+    context::Context,
+    init_env_logger_for_tests,
+    irbuild::IRStatus,
+    irfmt::parsers::spaced,
+    operation::{Operation, verify_operation},
+    opts::constants::sccp::sccp,
+    parsable::{self, state_stream_from_iterator},
+    printable::Printable,
+    result::Result,
+};
+
+// Linking the crate registers the LLVM dialect
+use pliron_llvm as _;
+
+fn run_sccp_on_text(input: &str) -> Result<(IRStatus, String, String)> {
+    init_env_logger_for_tests!();
+    let ctx = &mut Context::new();
+    let state_stream = state_stream_from_iterator(
+        input.chars(),
+        parsable::State::new(ctx, pliron::location::Source::InMemory),
+    );
+    let op = spaced(Operation::top_level_parser())
+        .parse(state_stream)
+        .expect("textual LLVM IR should parse")
+        .0;
+
+    let before = op.disp(ctx).to_string();
+    log::trace!("Before SCCP:\n{}", before);
+    verify_operation(op, ctx)?;
+
+    let status = sccp(op, ctx)?;
+
+    let after = op.disp(ctx).to_string();
+    log::trace!("After SCCP:\n{}", after);
+    verify_operation(op, ctx)?;
+    Ok((status, before, after))
+}
+
+// ---------------------------------------------------------------------------
+// llvm.add
+// ---------------------------------------------------------------------------
+
+#[test]
+fn add_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64;
+        b = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64;
+        sum = llvm.add a, b <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return sum
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<7: i64>"));
+    Ok(())
+}
+
+#[test]
+fn add_wraps_on_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <127: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        sum = llvm.add a, b <{nsw=false,nuw=false}> : builtin.integer i8;
+        llvm.return sum
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<128: i8>"));
+    Ok(())
+}
+
+#[test]
+fn add_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i64) variadic = false> [] {
+        ^entry(x: builtin.integer i64):
+        c = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64;
+        sum = llvm.add x, c <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return sum
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn add_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <127: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        sum = llvm.add a, b <{nsw=true,nuw=false}> : builtin.integer i8;
+        llvm.return sum
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn add_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        sum = llvm.add a, b <{nsw=false,nuw=true}> : builtin.integer i8;
+        llvm.return sum
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn add_nsw_still_folds_without_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8;
+        sum = llvm.add a, b <{nsw=true,nuw=true}> : builtin.integer i8;
+        llvm.return sum
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<7: i8>"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.sub
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64;
+        b = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64;
+        diff = llvm.sub a, b <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return diff
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<6: i64>"));
+    Ok(())
+}
+
+#[test]
+fn sub_wraps_on_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        diff = llvm.sub a, b <{nsw=false,nuw=false}> : builtin.integer i8;
+        llvm.return diff
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<255: i8>"));
+    Ok(())
+}
+
+#[test]
+fn sub_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i64) variadic = false> [] {
+        ^entry(x: builtin.integer i64):
+        c = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64;
+        diff = llvm.sub x, c <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return diff
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn sub_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
+    // The bit pattern for 128 (10000000) is -128 read as signed two's complement.
+    // Its true difference -128 - 1 == -129 does not fit in i8's signed range
+    // [-128, 127], so this signed-overflows and `nsw` is violated.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        diff = llvm.sub a, b <{nsw=true,nuw=false}> : builtin.integer i8;
+        llvm.return diff
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn sub_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        diff = llvm.sub a, b <{nsw=false,nuw=true}> : builtin.integer i8;
+        llvm.return diff
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn sub_nsw_still_folds_without_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8;
+        diff = llvm.sub a, b <{nsw=true,nuw=true}> : builtin.integer i8;
+        llvm.return diff
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<6: i8>"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.mul
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mul_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64;
+        b = builtin.constant <builtin.integer <6: i64>> : builtin.integer i64;
+        prod = llvm.mul a, b <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return prod
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<30: i64>"));
+    Ok(())
+}
+
+#[test]
+fn mul_wraps_on_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <100: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8;
+        prod = llvm.mul a, b <{nsw=false,nuw=false}> : builtin.integer i8;
+        llvm.return prod
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<44: i8>"));
+    Ok(())
+}
+
+#[test]
+fn mul_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i64) variadic = false> [] {
+        ^entry(x: builtin.integer i64):
+        c = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64;
+        prod = llvm.mul x, c <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return prod
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn mul_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
+    // 100 * 2 == 200 does not fit the signed range [-128, 127], so `nsw` is
+    // violated.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <100: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <2: i8>> : builtin.integer i8;
+        prod = llvm.mul a, b <{nsw=true,nuw=false}> : builtin.integer i8;
+        llvm.return prod
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn mul_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <200: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <2: i8>> : builtin.integer i8;
+        prod = llvm.mul a, b <{nsw=false,nuw=true}> : builtin.integer i8;
+        llvm.return prod
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn mul_nsw_still_folds_without_overflow() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8;
+        prod = llvm.mul a, b <{nsw=true,nuw=true}> : builtin.integer i8;
+        llvm.return prod
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<30: i8>"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.shl
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shl_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
+        b = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64;
+        shifted = llvm.shl a, b <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return shifted
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<8: i64>"));
+    Ok(())
+}
+
+/// Without flags, `llvm.shl` discards the bits shifted off the top, just like
+/// LLVM's `shl`.
+#[test]
+fn shl_wraps_on_overflow() -> Result<()> {
+    // 00000011 << 7 shifts bit 0 to bit 7 and drops bit 1 off the top,
+    // giving 10000000, or 128 in decimal
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <7: i8>> : builtin.integer i8;
+        shifted = llvm.shl a, b <{nsw=false,nuw=false}> : builtin.integer i8;
+        llvm.return shifted
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<128: i8>"));
+    Ok(())
+}
+
+/// A shift amount `>=` the bitwidth is undefined for `shl`; SCCP must not fold
+/// it regardless of flags.
+#[test]
+fn shl_does_not_fold_when_shift_amount_exceeds_bitwidth() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <8: i8>> : builtin.integer i8;
+        shifted = llvm.shl a, b <{nsw=false,nuw=false}> : builtin.integer i8;
+        llvm.return shifted
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn shl_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i64) variadic = false> [] {
+        ^entry(x: builtin.integer i64):
+        c = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64;
+        shifted = llvm.shl x, c <{nsw=false,nuw=false}> : builtin.integer i64;
+        llvm.return shifted
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+/// `llvm.shl nuw` must not fold when a set bit is shifted off the top.
+#[test]
+fn shl_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
+    // The bit pattern for 255 is 11111111. 11111111 << 1 shifts a set bit off the
+    // top, so `nuw` is violated.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        shifted = llvm.shl a, b <{nsw=false,nuw=true}> : builtin.integer i8;
+        llvm.return shifted
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+/// `llvm.shl nsw` must not fold when the shift changes the sign, even if no set
+/// bit is shifted off the top.
+#[test]
+fn shl_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
+    // The bit pattern for 64 is 01000000. 01000000 << 1 == 10000000, which flips the sign from + to -.
+    // Only a 0 bit is shifted off the top, so `nuw` is satisfied, but `nsw` is
+    // violated.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <64: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        shifted = llvm.shl a, b <{nsw=true,nuw=false}> : builtin.integer i8;
+        llvm.return shifted
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+/// A set overflow flag must not block folding when the shift does not actually
+/// overflow.
+#[test]
+fn shl_nsw_nuw_still_folds_without_overflow() -> Result<()> {
+    // i8: 1 << 3 == 8, with no bits shifted off the top and no sign change.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8;
+        shifted = llvm.shl a, b <{nsw=true,nuw=true}> : builtin.integer i8;
+        llvm.return shifted
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<8: i8>"));
+    Ok(())
+}

--- a/pliron-llvm/tests/opts/main.rs
+++ b/pliron-llvm/tests/opts/main.rs
@@ -1,0 +1,3 @@
+//! Integration tests for optimizations on the LLVM dialect.
+
+mod constants;

--- a/src/utils/apint.rs
+++ b/src/utils/apint.rs
@@ -53,6 +53,25 @@ impl APInt {
         APInt { value }
     }
 
+    /// Add `self` and `rhs`, reporting whether the (truncating) result overflowed.
+    /// They must have the same bitwidth.
+    ///
+    /// Returns `(result, unsigned_overflow_occured, signed_overflow_occured)`
+    pub fn add_overflow(&self, rhs: &APInt) -> (APInt, bool, bool) {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::add_overflow: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        let mut value = Awi::zero(NonZero::new(self.bw()).expect("self has zero bitwidth"));
+        let (unsigned_overflow, signed_overflow) = value
+            .cin_sum_(false, &self.value, &rhs.value)
+            .expect("APInt::add_overflow: bitwidth mismatch");
+        (APInt { value }, unsigned_overflow, signed_overflow)
+    }
+
     /// Subtract `rhs` from `self`. They must have the same bitwidth.
     pub fn sub(&self, rhs: &APInt) -> APInt {
         assert_eq!(
@@ -69,6 +88,36 @@ impl APInt {
         APInt { value }
     }
 
+    /// Subtract `rhs` from `self`, reporting whether the (truncating) result
+    /// overflowed. They must have the same bitwidth.
+    ///
+    /// Returns `(result, unsigned_overflow_occured, signed_overflow_occured)`.
+    pub fn sub_overflow(&self, rhs: &APInt) -> (APInt, bool, bool) {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::sub_overflow: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        // Below, I use `n` to denote the bitwidth.
+        // Two's complement: `self - rhs ≡ self + (~rhs) + 1  (mod 2^n)`.
+        let mut not_rhs = rhs.value.clone();
+        not_rhs.not_();
+        let mut value = Awi::zero(NonZero::new(self.bw()).expect("self has zero bitwidth"));
+        let (carry_out, signed_overflow) = value
+            .cin_sum_(true, &self.value, &not_rhs)
+            .expect("APInt::sub_overflow: bitwidth mismatch");
+        // Signed overflow occurs when the true mathematical value of `self - rhs``
+        // is not in `[−2^(n−1), 2^(n−1)−1]`. This matches addition's signed overflow.
+        //
+        // Unsigned overflow occurs when `self < rhs`.
+        // Computed as an integer, `self + (~rhs) + 1 = (self - rhs) + 2^n`, so
+        // `carry_out == true` iff `(self - rhs) + 2^n >= 2^n`` iff `self >= rhs`.
+        // Hence unsigned overflow is !carry_out.
+        (APInt { value }, !carry_out, signed_overflow)
+    }
+
     /// Multiply `self` and `rhs`. They must have the same bitwidth.
     pub fn mul(&self, rhs: &APInt) -> APInt {
         assert_eq!(
@@ -83,6 +132,42 @@ impl APInt {
             .mul_add_(&self.value, &rhs.value)
             .expect("APInt::mul: bitwidth mismatch");
         APInt { value }
+    }
+
+    /// Multiply `self` and `rhs`, reporting whether the (truncating) result
+    /// overflowed. They must have the same bitwidth.
+    ///
+    /// Returns `(result, unsigned_overflow_occured, signed_overflow_occured)`.
+    pub fn mul_overflow(&self, rhs: &APInt) -> (APInt, bool, bool) {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::mul_overflow: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        let bw = NonZero::new(self.bw()).expect("self has zero bitwidth");
+        let dbw = NonZero::new(self.bw() * 2).expect("self has zero bitwidth");
+
+        let mut ulhs = Awi::zero(dbw);
+        ulhs.zero_resize_(&self.value);
+        let mut urhs = Awi::zero(dbw);
+        urhs.zero_resize_(&rhs.value);
+        let mut uprod = Awi::zero(dbw);
+        uprod.arb_umul_add_(&ulhs, &urhs);
+        let mut utrunc = Awi::zero(bw);
+        let unsigned_overflow = utrunc.zero_resize_(&uprod);
+
+        let mut slhs = Awi::zero(dbw);
+        slhs.sign_resize_(&self.value);
+        let mut srhs = Awi::zero(dbw);
+        srhs.sign_resize_(&rhs.value);
+        let mut sprod = Awi::zero(dbw);
+        sprod.arb_imul_add_(&mut slhs, &mut srhs);
+        let mut strunc = Awi::zero(bw);
+        let signed_overflow = strunc.sign_resize_(&sprod);
+
+        (self.mul(rhs), unsigned_overflow, signed_overflow)
     }
 
     /// Left-shift `self` by `rhs` bits. They must have the same bitwidth.
@@ -103,6 +188,51 @@ impl APInt {
             value.zero_();
         }
         APInt { value }
+    }
+
+    /// Left-shift `self` by `rhs` bits, reporting whether the result
+    /// overflowed. They must have the same bitwidth, and the shift amount `rhs`
+    /// must be less than the bitwidth (a shift amount `>=` the bitwidth is
+    /// undefined for `shl` and must be ruled out by the caller).
+    ///
+    /// Returns `(result, unsigned_overflow_occured, signed_overflow_occured)`,
+    /// where the result is the shifted value, `unsigned_overflow_occured` is true
+    /// if any bit shifted off the top was set (so the shift is not invertible by a
+    /// logical right shift), and `signed_overflow_occured` is true if the bits
+    /// shifted off the top together with the result's new sign bit are not all
+    /// equal to the original sign bit (so the shift is not invertible by an
+    /// arithmetic right shift). These match LLVM's `nuw` and `nsw` poison
+    /// conditions for `shl`, respectively.
+    pub fn shl_overflow(&self, rhs: &APInt) -> (APInt, bool, bool) {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::shl_overflow: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        let shamt = rhs.to_usize();
+        assert!(
+            shamt < self.bw(),
+            "APInt::shl_overflow: shift amount {} >= bitwidth {}",
+            shamt,
+            self.bw()
+        );
+        let result = self.shl(rhs);
+
+        let mut ushifted_back = result.value.clone();
+        ushifted_back
+            .lshr_(shamt)
+            .expect("shift amount checked against bitwidth above");
+        let unsigned_overflow = ushifted_back != self.value;
+
+        let mut sshifted_back = result.value.clone();
+        sshifted_back
+            .ashr_(shamt)
+            .expect("shift amount checked against bitwidth above");
+        let signed_overflow = sshifted_back != self.value;
+
+        (result, unsigned_overflow, signed_overflow)
     }
 
     /// Unsigned-divide `self` by `rhs`. They must have the same bitwidth.


### PR DESCRIPTION
This PR contributes to https://github.com/pliron-org/pliron/issues/118 but does not close it.

An arithmetic integer operation has *unsigned overflow* if, when we interpret its operations and result as unsigned integers, its result destination does not have enough space (i.e. bit width) to store the true mathematical result of the operation. When the arithmetic operation produces some integer value despite the occurrence of an overflow, it is called *wrapping*.  The LLVM arithmetic operations provide a `nuw` (or "no unsigned wrap") flag. When this flag is true, the operation produces a special *poison* value upon overflow instead of wrapping. 

A *signed overflow* happens when the result destination is unable to represent the true mathematical value of the operation when the result and operands are interpreted as signed integers. LLVM ops similarly have a `nsw` (or "no signed wrap") flag, which causes the op to produce poison instead of wrapping when a signed overflow occurs.

In Pliron, our integer types have no poison value; therefore, we must avoid constant folding when the llvm op would produce poison. This PR updates the `add`, `sub`, `mul`, and `shl` to properly avoid folding in accordance with their `nuw` and `nsw` flags. To accomplish this, I implemented added `add_overflow`, `sub_overflow`, `mul_overflow`, and `shl_overflow` methods to `APInt`. These are like `add`, `sub`, etc., except that they return triples of type `(APInt, bool, bool)`, where the booleans indicate whether unsigned overflow and signed overflow occurred.

I also added a new integration test suite at `pliron-llvm/src/tests/opts/constants.rs`. The purpose of this file is to test that all of the LLVM operations implement the interfaces `ConstFoldInterface` and `BranchOpFoldInterface` correctly.