### PR TITLE
const folding: `sdiv` and `srem` fix. added `and`, `or`, `xor`, `lshr`, and `rshr`

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -258,6 +258,17 @@ fn check_fold_int_bin_op_with_overflow(
     vec![Some(res)]
 }
 
+/// Returns `true` if signed-dividing/remaindering `lhs` by `rhs` is undefined
+/// behavior in LLVM, and so must not be constant folded. The two cases are
+/// division by zero, and the signed overflow `INT_MIN / -1` (true quotient
+/// `INT_MAX + 1`, not representable), whose result LLVM leaves as poison and
+/// whose hardware behavior diverges (x86 traps, AArch64 wraps).
+fn is_signed_div_ub(lhs: &APInt, rhs: &APInt) -> bool {
+    let bw = NonZero::new(rhs.bw()).expect("operand has zero bitwidth");
+    // `-1` is the all-ones bit pattern, i.e. the unsigned max.
+    rhs.is_zero() || (*lhs == APInt::imin(bw) && *rhs == APInt::umax(bw))
+}
+
 /// Constant fold this binary integer operation into a singleton vector
 /// containing its result type if folding is successful, or None otherwise.
 fn check_fold_int_bin_op(
@@ -384,7 +395,7 @@ impl ConstFoldInterface for UDivOp {
 impl ConstFoldInterface for SDivOp {
     fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
         match get_int_bin_operands(ops) {
-            Some((_, rhs)) if rhs.value().is_zero() => vec![None],
+            Some((lhs, rhs)) if is_signed_div_ub(&lhs.value(), &rhs.value()) => vec![None],
             _ => check_fold_int_bin_op(ops, APInt::sdiv),
         }
     }
@@ -420,8 +431,135 @@ impl ConstFoldInterface for URemOp {
 impl ConstFoldInterface for SRemOp {
     fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
         match get_int_bin_operands(ops) {
-            Some((_, rhs)) if rhs.value().is_zero() => vec![None],
+            Some((lhs, rhs)) if is_signed_div_ub(&lhs.value(), &rhs.value()) => vec![None],
             _ => check_fold_int_bin_op(ops, APInt::srem),
+        }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for AndOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        assert!(ops.len() == 2);
+        for op in ops.iter().flatten() {
+            let int = op
+                .downcast_ref::<IntegerAttr>()
+                .expect("invalid operand type: typecheck before optimizing");
+            if int.value().is_zero() {
+                let zero = APInt::zero(NonZero::new(int.value().bw()).expect("zero bitwidth"));
+                let res = Box::new(IntegerAttr::new(int.get_type(), zero)) as AttrObj;
+                return vec![Some(res)];
+            }
+        }
+        check_fold_int_bin_op(ops, APInt::and)
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for OrOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        assert!(ops.len() == 2);
+        for op in ops.iter().flatten() {
+            let int = op
+                .downcast_ref::<IntegerAttr>()
+                .expect("invalid operand type: typecheck before optimizing");
+            let bw = NonZero::new(int.value().bw()).expect("zero bitwidth");
+            if int.value() == APInt::umax(bw) {
+                let all_ones = APInt::umax(bw);
+                let res = Box::new(IntegerAttr::new(int.get_type(), all_ones)) as AttrObj;
+                return vec![Some(res)];
+            }
+        }
+        check_fold_int_bin_op(ops, APInt::or)
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for XorOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_int_bin_op(ops, APInt::xor)
+    }
+
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for LShrOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        // A shift amount >= the bitwidth is undefined behavior in LLVM, so it
+        // must not be folded.
+        match get_int_bin_operands(ops) {
+            Some((lhs, rhs)) => {
+                let lhs_bw = lhs.value().bw();
+                let lhs_bw = APInt::from_usize(lhs_bw, NonZero::new(lhs_bw).unwrap());
+                if rhs.value().ult(&lhs_bw) {
+                    check_fold_int_bin_op(ops, APInt::lshr)
+                } else {
+                    vec![None]
+                }
+            }
+            None => vec![None],
+        }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for AShrOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        // A shift amount >= the bitwidth is undefined behavior in LLVM, so it
+        // must not be folded.
+        match get_int_bin_operands(ops) {
+            Some((lhs, rhs)) => {
+                let lhs_bw = lhs.value().bw();
+                let lhs_bw = APInt::from_usize(lhs_bw, NonZero::new(lhs_bw).unwrap());
+                if rhs.value().ult(&lhs_bw) {
+                    check_fold_int_bin_op(ops, APInt::ashr)
+                } else {
+                    vec![None]
+                }
+            }
+            None => vec![None],
         }
     }
     fn fold_in_place(

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -511,3 +511,442 @@ fn shl_nsw_nuw_still_folds_without_overflow() -> Result<()> {
     assert!(after.contains("<8: i8>"));
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// llvm.sdiv
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sdiv_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <2: i8>> : builtin.integer i8;
+        q = llvm.sdiv a, b : builtin.integer i8;
+        llvm.return q
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<3: i8>"));
+    Ok(())
+}
+
+#[test]
+fn sdiv_does_not_fold_on_division_by_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        q = llvm.sdiv a, b : builtin.integer i8;
+        llvm.return q
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+/// `INT_MIN / -1` overflows (true quotient `INT_MAX + 1`); LLVM leaves it
+/// poison, so we must not fold it.
+#[test]
+fn sdiv_does_not_fold_on_signed_overflow() -> Result<()> {
+    // i8: INT_MIN is 128 unsigned, -1 is 255 unsigned.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        q = llvm.sdiv a, b : builtin.integer i8;
+        llvm.return q
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.srem
+// ---------------------------------------------------------------------------
+
+#[test]
+fn srem_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <7: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8;
+        r = llvm.srem a, b : builtin.integer i8;
+        llvm.return r
+      }
+    "#;
+
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<1: i8>"));
+    Ok(())
+}
+
+#[test]
+fn srem_does_not_fold_on_division_by_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <7: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        r = llvm.srem a, b : builtin.integer i8;
+        llvm.return r
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn srem_does_not_fold_on_signed_overflow() -> Result<()> {
+    // i8: INT_MIN is 128 unsigned, -1 is 255 unsigned.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        r = llvm.srem a, b : builtin.integer i8;
+        llvm.return r
+      }
+    "#;
+
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.udiv (unsigned: no signed-overflow case, only div-by-zero)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn udiv_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <13: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8;
+        q = llvm.udiv a, b : builtin.integer i8;
+        llvm.return q
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<3: i8>"));
+    Ok(())
+}
+
+#[test]
+fn udiv_does_not_fold_on_division_by_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <13: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        q = llvm.udiv a, b : builtin.integer i8;
+        llvm.return q
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.urem (unsigned: no signed-overflow case, only div-by-zero)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn urem_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <13: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8;
+        r = llvm.urem a, b : builtin.integer i8;
+        llvm.return r
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<1: i8>"));
+    Ok(())
+}
+
+#[test]
+fn urem_does_not_fold_on_division_by_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <13: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        r = llvm.urem a, b : builtin.integer i8;
+        llvm.return r
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.and
+// ---------------------------------------------------------------------------
+
+#[test]
+fn and_folds_two_constants() -> Result<()> {
+    // 0b1100 & 0b1010 == 0b1000 == 8.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <12: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8;
+        c = llvm.and a, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<8: i8>"));
+    Ok(())
+}
+
+#[test]
+fn and_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        b = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8;
+        c = llvm.and x, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn and_folds_to_zero_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 (builtin.integer i1) variadic = false> [] {
+        ^entry(x: builtin.integer i1):
+        z = builtin.constant <builtin.integer <0: i1>> : builtin.integer i1;
+        c = llvm.and x, z : builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<0: i1>").count(), 2);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.or
+// ---------------------------------------------------------------------------
+
+#[test]
+fn or_folds_two_constants() -> Result<()> {
+    // 0b1100 | 0b1010 == 0b1110 == 14.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <12: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8;
+        c = llvm.or a, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<14: i8>"));
+    Ok(())
+}
+
+#[test]
+fn or_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        b = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8;
+        c = llvm.or x, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn or_folds_to_one_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 (builtin.integer i1) variadic = false> [] {
+        ^entry(x: builtin.integer i1):
+        one = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1;
+        c = llvm.or x, one : builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<1: i1>").count(), 2);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.xor
+// ---------------------------------------------------------------------------
+
+#[test]
+fn xor_folds_two_constants() -> Result<()> {
+    // 0b1100 ^ 0b1010 == 0b0110 == 6.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <12: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8;
+        c = llvm.xor a, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<6: i8>"));
+    Ok(())
+}
+
+#[test]
+fn xor_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        b = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8;
+        c = llvm.xor x, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.lshr
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lshr_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        c = llvm.lshr a, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<64: i8>"));
+    Ok(())
+}
+
+#[test]
+fn lshr_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        c = llvm.lshr x, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn lshr_does_not_fold_when_shift_amount_exceeds_bitwidth() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <8: i8>> : builtin.integer i8;
+        c = llvm.lshr a, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.ashr
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ashr_folds_two_constants() -> Result<()> {
+    // Arithmetic shift copies the sign bit: 128 is -128 signed, -128 >> 1 ==
+    // -64, which is 192 unsigned.
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        c = llvm.ashr a, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<192: i8>"));
+    Ok(())
+}
+
+#[test]
+fn ashr_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        b = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8;
+        c = llvm.ashr x, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn ashr_does_not_fold_when_shift_amount_exceeds_bitwidth() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i8 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <8: i8>> : builtin.integer i8;
+        c = llvm.ashr a, b : builtin.integer i8;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}

--- a/src/utils/apint.rs
+++ b/src/utils/apint.rs
@@ -190,6 +190,45 @@ impl APInt {
         APInt { value }
     }
 
+    /// Logically (unsigned) right-shift `self` by `rhs` bits. They must have the
+    /// same bitwidth. If the shift amount is greater than or equal to the
+    /// bitwidth, the result is zero.
+    pub fn lshr(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::lshr: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        let shamt = rhs.to_usize();
+        let mut value = self.value.clone();
+        if value.lshr_(shamt).is_none() {
+            // Shift amount >= bitwidth: every bit is shifted out.
+            value.zero_();
+        }
+        APInt { value }
+    }
+
+    /// Arithmetically (signed) right-shift `self` by `rhs` bits. They must have
+    /// the same bitwidth. If the shift amount is greater than or equal to the
+    /// bitwidth, the result is the sign bit replicated across all bits.
+    pub fn ashr(&self, rhs: &APInt) -> APInt {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::ashr: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        let shamt = rhs.to_usize().min(self.bw() - 1);
+        let mut value = self.value.clone();
+        value
+            .ashr_(shamt)
+            .expect("shift amount clamped below bitwidth above");
+        APInt { value }
+    }
+
     /// Left-shift `self` by `rhs` bits, reporting whether the result
     /// overflowed. They must have the same bitwidth, and the shift amount `rhs`
     /// must be less than the bitwidth (a shift amount `>=` the bitwidth is
@@ -307,6 +346,31 @@ impl APInt {
         let mut div = rhs.value.clone();
         Bits::idivide(&mut quo, &mut rem, &mut duo, &mut div).unwrap();
         APInt { value: rem }
+    }
+
+    /// Bitwise AND of `self` and `rhs`. They must have the same bitwidth.
+    pub fn and(&self, rhs: &APInt) -> APInt {
+        let mut value = self.value.clone();
+        value
+            .and_(&rhs.value)
+            .expect("APInt::and: bitwidth mismatch");
+        APInt { value }
+    }
+
+    /// Bitwise OR of `self` and `rhs`. They must have the same bitwidth.
+    pub fn or(&self, rhs: &APInt) -> APInt {
+        let mut value = self.value.clone();
+        value.or_(&rhs.value).expect("APInt::or: bitwidth mismatch");
+        APInt { value }
+    }
+
+    /// Bitwise XOR of `self` and `rhs`. They must have the same bitwidth.
+    pub fn xor(&self, rhs: &APInt) -> APInt {
+        let mut value = self.value.clone();
+        value
+            .xor_(&rhs.value)
+            .expect("APInt::xor: bitwidth mismatch");
+        APInt { value }
     }
 
     /// Unsigned less-than comparison. They must have the same bitwidth.
@@ -839,26 +903,64 @@ mod tests {
     }
 
     #[test]
+    fn test_lshr() {
+        let width = bw(4);
+
+        let res = APInt::from_u8(8, width).lshr(&APInt::from_u8(2, width));
+        assert_eq!(res.to_u8(), 2);
+
+        let res = APInt::from_u8(5, width).lshr(&APInt::zero(width));
+        assert_eq!(res.to_u8(), 5);
+
+        let res = APInt::from_u8(0b1000, width).lshr(&APInt::from_u8(1, width));
+        assert_eq!(res.to_u8(), 0b0100);
+
+        let res = APInt::from_u8(0xf, width).lshr(&APInt::from_u8(4, width));
+        assert!(res.is_zero());
+
+        let res = APInt::from_u8(0xf, width).lshr(&APInt::from_u8(7, width));
+        assert!(res.is_zero());
+    }
+
+    #[test]
+    fn test_ashr() {
+        let width = bw(4);
+
+        let res = APInt::from_i8(6, width).ashr(&APInt::from_u8(1, width));
+        assert_eq!(res.to_i8(), 3);
+
+        let res = APInt::from_i8(-3, width).ashr(&APInt::zero(width));
+        assert_eq!(res.to_i8(), -3);
+
+        let res = APInt::from_i8(-8, width).ashr(&APInt::from_u8(1, width));
+        assert_eq!(res.to_i8(), -4);
+
+        // Shift amount >= bitwidth replicates the sign bit across all bits:
+        // a negative value yields all-ones (-1), ...
+        let res = APInt::from_i8(-8, width).ashr(&APInt::from_u8(4, width));
+        assert_eq!(res.to_i8(), -1);
+
+        // ... and a non-negative value yields 0.
+        let res = APInt::from_i8(7, width).ashr(&APInt::from_u8(7, width));
+        assert!(res.is_zero());
+    }
+
+    #[test]
     fn test_udiv() {
         let width = bw(4);
 
-        // Exact division.
         let res = APInt::from_u8(12, width).udiv(&APInt::from_u8(4, width));
         assert_eq!(res.to_u8(), 3);
 
-        // Truncating (floor) division.
         let res = APInt::from_u8(13, width).udiv(&APInt::from_u8(4, width));
         assert_eq!(res.to_u8(), 3);
 
-        // Unsigned: the top bit is magnitude, not sign. 0xf == 15, not -1.
         let res = APInt::from_u8(0xf, width).udiv(&APInt::from_u8(2, width));
         assert_eq!(res.to_u8(), 7);
 
-        // Dividing by one is the identity.
         let res = APInt::from_u8(9, width).udiv(&APInt::uone(width));
         assert_eq!(res.to_u8(), 9);
 
-        // Divisor larger than dividend yields zero.
         let res = APInt::from_u8(3, width).udiv(&APInt::from_u8(5, width));
         assert!(res.is_zero());
     }
@@ -1024,5 +1126,68 @@ mod tests {
     fn test_srem_by_zero_panics() {
         let width = bw(4);
         let _ = APInt::from_i8(7, width).srem(&APInt::zero(width));
+    }
+
+    #[test]
+    fn test_and() {
+        let width = bw(4);
+        assert_eq!(
+            APInt::from_u8(0b1100, width)
+                .and(&APInt::from_u8(0b1010, width))
+                .to_u8(),
+            0b1000
+        );
+        assert_eq!(
+            APInt::from_u8(0b1011, width)
+                .and(&APInt::umax(width))
+                .to_u8(),
+            0b1011
+        );
+        assert!(
+            APInt::from_u8(0b1011, width)
+                .and(&APInt::zero(width))
+                .is_zero()
+        );
+    }
+
+    #[test]
+    fn test_or() {
+        let width = bw(4);
+        assert_eq!(
+            APInt::from_u8(0b1100, width)
+                .or(&APInt::from_u8(0b1010, width))
+                .to_u8(),
+            0b1110
+        );
+        assert_eq!(
+            APInt::from_u8(0b1011, width).or(&APInt::zero(width)).to_u8(),
+            0b1011
+        );
+        assert_eq!(
+            APInt::from_u8(0b1011, width).or(&APInt::umax(width)).to_u8(),
+            0b1111
+        );
+    }
+
+    #[test]
+    fn test_xor() {
+        let width = bw(4);
+        assert_eq!(
+            APInt::from_u8(0b1100, width)
+                .xor(&APInt::from_u8(0b1010, width))
+                .to_u8(),
+            0b0110
+        );
+        assert!(
+            APInt::from_u8(0b1011, width)
+                .xor(&APInt::from_u8(0b1011, width))
+                .is_zero()
+        );
+        assert_eq!(
+            APInt::from_u8(0b1011, width)
+                .xor(&APInt::umax(width))
+                .to_u8(),
+            0b0100
+        );
     }
 }

--- a/src/utils/apint.rs
+++ b/src/utils/apint.rs
@@ -1160,11 +1160,15 @@ mod tests {
             0b1110
         );
         assert_eq!(
-            APInt::from_u8(0b1011, width).or(&APInt::zero(width)).to_u8(),
+            APInt::from_u8(0b1011, width)
+                .or(&APInt::zero(width))
+                .to_u8(),
             0b1011
         );
         assert_eq!(
-            APInt::from_u8(0b1011, width).or(&APInt::umax(width)).to_u8(),
+            APInt::from_u8(0b1011, width)
+                .or(&APInt::umax(width))
+                .to_u8(),
             0b1111
         );
     }


### PR DESCRIPTION
This PR implements constant folding for several llvm dialect ops, contributing to https://github.com/pliron-org/pliron/issues/118 without closing it.

## Undefined behavior in sdiv and srem

The true value of the signed division `INT_MIN / -1` does not fit inside the signed integer representation. For this reason, it produces different results on different machines and is treated as poison by LLVM. This PR updates constant folding for `sdiv` and `srem` to refrain from constant folding this case.

Tests for constant folding these operations, along with `udiv` and `urem`, have been added to `pliron-llvm/tests/opts/constants.rs` .

## And, Or, Xor

Constant folding for `and`, `or`, and `xor` has been implemented. Interestingly, if either argument of `and` consists entirely of `0` bits then we can const fold the operation even if the other argument is not a constant. `or` exhibits a similar opportunity if one of its arguments consists of `1` bits.  

## Lshr, Ashr

Constant folding has also been implemented for the logical and arithmetic shift right operations. If the shift amount is greater than the number of bits, we refrain from folding due to undefined behavior.