### PR TITLE
Add IR cloning: IrMapping + clone_operation / clone_region_into / clone_blocks_into

### DIFF
--- a/src/irbuild/cloning.rs
+++ b/src/irbuild/cloning.rs
@@ -187,8 +187,12 @@ pub fn clone_region_into(
 /// values that flow across a back-edge ride block arguments, which are mapped in
 /// phase one and so resolve regardless of order.
 ///
-/// Op attributes (including op result names) are copied, but block attributes
-/// (block labels, block debug info) are not: the clone blocks are fresh.
+/// Op and block attributes (op result names, block debug info, block argument
+/// names) are copied, and so is the block label. The label is a block's
+/// `given_name`; pliron derives each block's `unique_name` by suffixing a fresh
+/// per-block id, so cloning one block several times (an unrolled loop body, say)
+/// still yields distinct blocks while keeping the original's label, which makes
+/// the cloned IR easier to read.
 pub fn clone_blocks_into(
     blocks: &[Ptr<BasicBlock>],
     dest_region: Ptr<Region>,
@@ -197,11 +201,22 @@ pub fn clone_blocks_into(
 ) {
     // Phase 1: create the clone blocks and their arguments, and record them.
     for &src_block in blocks {
-        let arg_types: Vec<_> = {
+        let (arg_types, label, attrs) = {
             let block_ref = src_block.deref(ctx);
-            block_ref.arguments().map(|arg| arg.get_type(ctx)).collect()
+            let arg_types: Vec<_> = block_ref.arguments().map(|arg| arg.get_type(ctx)).collect();
+            (
+                arg_types,
+                block_ref.label.clone(),
+                block_ref.attributes.clone(),
+            )
         };
-        let new_block = BasicBlock::new(ctx, None, arg_types);
+        // Copy the label and attributes, mirroring how op attributes (result
+        // names and so on) are cloned. The label is the block's `given_name`;
+        // pliron keeps each block's `unique_name` distinct by suffixing a fresh
+        // id, so cloning the same block several times (an unrolled loop body, say)
+        // yields distinct blocks that still show which block they came from.
+        let new_block = BasicBlock::new(ctx, label, arg_types);
+        new_block.deref_mut(ctx).attributes = attrs;
 
         let old_args: Vec<Value> = src_block.deref(ctx).arguments().collect();
         let new_args: Vec<Value> = new_block.deref(ctx).arguments().collect();

--- a/src/irbuild/cloning.rs
+++ b/src/irbuild/cloning.rs
@@ -1,0 +1,227 @@
+//! Cloning IR entities with a value / block / op remapping.
+//!
+//! This mirrors MLIR's [`IRMapping`] + `Operation::clone(mapper)` /
+//! `Region::cloneInto(mapper)`. An [IrMapping] records, for every original IR
+//! entity, the clone that should stand in for it. Cloning an [Operation]
+//! rewrites each operand and successor through the mapping; anything *not* in
+//! the mapping is left unchanged (the MLIR `lookupOrDefault` rule), so uses of
+//! values defined outside the cloned scope correctly keep pointing at the
+//! originals.
+//!
+//! Cloning a set of blocks is **two-phase**: every clone block and its block
+//! arguments are created and recorded first, and only then are the operations
+//! cloned. This way branch successors and block-argument references resolve
+//! even though they may point "forward" in the block list.
+//!
+//! [`IRMapping`]: https://mlir.llvm.org/doxygen/classmlir_1_1IRMapping.html
+
+use alloc::vec::Vec;
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    basic_block::BasicBlock,
+    context::{Context, Ptr},
+    linked_list::ContainsLinkedList,
+    location::Located,
+    operation::Operation,
+    region::Region,
+    r#type::Typed,
+    value::Value,
+};
+
+/// A mapping from original IR entities to their clones, used while cloning.
+///
+/// Holds three independent maps: [Value]s, [BasicBlock]s, and [Operation]s.
+/// While cloning, operand [Value]s are looked up in the value map and branch
+/// successor [BasicBlock]s in the block map; entries absent from a map resolve
+/// to themselves (see [IrMapping::lookup_value_or_default]).
+#[derive(Debug, Default)]
+pub struct IrMapping {
+    values: FxHashMap<Value, Value>,
+    blocks: FxHashMap<Ptr<BasicBlock>, Ptr<BasicBlock>>,
+    ops: FxHashMap<Ptr<Operation>, Ptr<Operation>>,
+}
+
+impl IrMapping {
+    /// Create an empty mapping.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that `from` maps to `to`. Overwrites any existing entry.
+    pub fn map_value(&mut self, from: Value, to: Value) {
+        self.values.insert(from, to);
+    }
+
+    /// Record that `from` maps to `to`. Overwrites any existing entry.
+    pub fn map_block(&mut self, from: Ptr<BasicBlock>, to: Ptr<BasicBlock>) {
+        self.blocks.insert(from, to);
+    }
+
+    /// Record that `from` maps to `to`. Overwrites any existing entry.
+    pub fn map_op(&mut self, from: Ptr<Operation>, to: Ptr<Operation>) {
+        self.ops.insert(from, to);
+    }
+
+    /// The clone recorded for `from`, if any.
+    pub fn lookup_value(&self, from: Value) -> Option<Value> {
+        self.values.get(&from).copied()
+    }
+
+    /// The clone recorded for `from`, if any.
+    pub fn lookup_block(&self, from: Ptr<BasicBlock>) -> Option<Ptr<BasicBlock>> {
+        self.blocks.get(&from).copied()
+    }
+
+    /// The clone recorded for `from`, if any.
+    pub fn lookup_op(&self, from: Ptr<Operation>) -> Option<Ptr<Operation>> {
+        self.ops.get(&from).copied()
+    }
+
+    /// The clone recorded for `from`, or `from` itself if none was recorded.
+    /// Mirrors MLIR's `IRMapping::lookupOrDefault`.
+    pub fn lookup_value_or_default(&self, from: Value) -> Value {
+        self.lookup_value(from).unwrap_or(from)
+    }
+
+    /// The clone recorded for `from`, or `from` itself if none was recorded.
+    /// Mirrors MLIR's `IRMapping::lookupOrDefault`.
+    pub fn lookup_block_or_default(&self, from: Ptr<BasicBlock>) -> Ptr<BasicBlock> {
+        self.lookup_block(from).unwrap_or(from)
+    }
+}
+
+/// Clone `op` (and the contents of its regions), remapping its operands and
+/// successors through `mapper`.
+///
+/// The returned [Operation] is **unlinked** (not in any block); the caller
+/// inserts it. Operands and successors absent from `mapper` are kept as-is, so
+/// values defined outside the cloned scope are shared with the original. The op
+/// and its results are recorded into `mapper` so later clones can refer to them.
+pub fn clone_operation(
+    op: Ptr<Operation>,
+    ctx: &mut Context,
+    mapper: &mut IrMapping,
+) -> Ptr<Operation> {
+    // Gather everything needed to rebuild the op, remapping operands and
+    // successors, then drop the borrow before `Operation::new` takes `&mut ctx`.
+    let (concrete_op, result_types, operands, successors, num_regions, attributes, loc) = {
+        let op_ref = op.deref(ctx);
+        let operands: Vec<Value> = op_ref
+            .operands()
+            .map(|v| mapper.lookup_value_or_default(v))
+            .collect();
+        let successors: Vec<Ptr<BasicBlock>> = op_ref
+            .successors()
+            .map(|b| mapper.lookup_block_or_default(b))
+            .collect();
+        (
+            op_ref.concrete_op_info(),
+            op_ref.result_types().collect::<Vec<_>>(),
+            operands,
+            successors,
+            op_ref.num_regions(),
+            op_ref.attributes.clone(),
+            op_ref.loc(),
+        )
+    };
+
+    let new_op = Operation::new(
+        ctx,
+        concrete_op,
+        result_types,
+        operands,
+        successors,
+        num_regions,
+    );
+    {
+        let mut new_ref = new_op.deref_mut(ctx);
+        new_ref.attributes = attributes;
+        new_ref.set_loc(loc);
+    }
+
+    // Record the op and its results before cloning nested regions.
+    mapper.map_op(op, new_op);
+    let old_results: Vec<Value> = op.deref(ctx).results().collect();
+    let new_results: Vec<Value> = new_op.deref(ctx).results().collect();
+    for (old, new) in old_results.into_iter().zip(new_results) {
+        mapper.map_value(old, new);
+    }
+
+    // Clone the blocks of each region into the corresponding (empty) region of
+    // the clone.
+    for region_idx in 0..num_regions {
+        let src_region = op.deref(ctx).get_region(region_idx);
+        let dest_region = new_op.deref(ctx).get_region(region_idx);
+        clone_region_into(src_region, dest_region, ctx, mapper);
+    }
+
+    new_op
+}
+
+/// Clone every block of `src_region` (in order) into `dest_region`, appended at
+/// its end, remapping through `mapper`. See [clone_blocks_into].
+pub fn clone_region_into(
+    src_region: Ptr<Region>,
+    dest_region: Ptr<Region>,
+    ctx: &mut Context,
+    mapper: &mut IrMapping,
+) {
+    let blocks: Vec<Ptr<BasicBlock>> = src_region.deref(ctx).iter(ctx).collect();
+    clone_blocks_into(&blocks, dest_region, ctx, mapper);
+}
+
+/// Clone `blocks` (and their operations) into `dest_region`, appended at its end
+/// in the given order, remapping through `mapper`.
+///
+/// Two-phase: all clone blocks and their block arguments are created and
+/// recorded first, then operations are cloned. This lets branch successors and
+/// block-argument references resolve even when they point forward in `blocks`.
+/// Values and blocks absent from `mapper` are left unchanged
+/// ([IrMapping::lookup_value_or_default]), so uses of values defined outside
+/// `blocks` correctly keep pointing at the originals.
+///
+/// `blocks` should be given in a dominance-respecting order (for example,
+/// reverse post-order) so that an operation result is cloned before its uses;
+/// values that flow across a back-edge ride block arguments, which are mapped in
+/// phase one and so resolve regardless of order.
+///
+/// Op attributes (including op result names) are copied, but block attributes
+/// (block labels, block debug info) are not: the clone blocks are fresh.
+pub fn clone_blocks_into(
+    blocks: &[Ptr<BasicBlock>],
+    dest_region: Ptr<Region>,
+    ctx: &mut Context,
+    mapper: &mut IrMapping,
+) {
+    // Phase 1: create the clone blocks and their arguments, and record them.
+    for &src_block in blocks {
+        let arg_types: Vec<_> = {
+            let block_ref = src_block.deref(ctx);
+            block_ref.arguments().map(|arg| arg.get_type(ctx)).collect()
+        };
+        let new_block = BasicBlock::new(ctx, None, arg_types);
+
+        let old_args: Vec<Value> = src_block.deref(ctx).arguments().collect();
+        let new_args: Vec<Value> = new_block.deref(ctx).arguments().collect();
+        for (old, new) in old_args.into_iter().zip(new_args) {
+            mapper.map_value(old, new);
+        }
+
+        new_block.insert_at_back(dest_region, ctx);
+        mapper.map_block(src_block, new_block);
+    }
+
+    // Phase 2: clone each block's operations into its mapped clone.
+    for &src_block in blocks {
+        let new_block = mapper
+            .lookup_block(src_block)
+            .expect("block was mapped in phase one");
+        let ops: Vec<Ptr<Operation>> = src_block.deref(ctx).iter(ctx).collect();
+        for src_op in ops {
+            let new_op = clone_operation(src_op, ctx, mapper);
+            new_op.insert_at_back(new_block, ctx);
+        }
+    }
+}

--- a/src/irbuild/cloning.rs
+++ b/src/irbuild/cloning.rs
@@ -8,10 +8,13 @@
 //! values defined outside the cloned scope correctly keep pointing at the
 //! originals.
 //!
-//! Cloning a set of blocks is **two-phase**: every clone block and its block
-//! arguments are created and recorded first, and only then are the operations
-//! cloned. This way branch successors and block-argument references resolve
-//! even though they may point "forward" in the block list.
+//! Cloning a set of blocks is **order-independent**: every clone block, block
+//! argument and op result is created and recorded before any operand or
+//! successor is wired. So a reference that points "forward" in the block list
+//! (a branch to a later block, a back-edge, or an operand whose def is cloned
+//! later) still resolves to its clone, whatever order the blocks are given in.
+//! New blocks and ops are inserted through a [Rewriter], so any listener it
+//! carries is notified.
 //!
 //! [`IRMapping`]: https://mlir.llvm.org/doxygen/classmlir_1_1IRMapping.html
 
@@ -22,6 +25,10 @@ use rustc_hash::FxHashMap;
 use crate::{
     basic_block::BasicBlock,
     context::{Context, Ptr},
+    irbuild::{
+        inserter::{BlockInsertionPoint, OpInsertionPoint},
+        rewriter::Rewriter,
+    },
     linked_list::ContainsLinkedList,
     location::Located,
     operation::Operation,
@@ -96,22 +103,39 @@ impl IrMapping {
 /// successors through `mapper`.
 ///
 /// The returned [Operation] is **unlinked** (not in any block); the caller
-/// inserts it. Operands and successors absent from `mapper` are kept as-is, so
-/// values defined outside the cloned scope are shared with the original. The op
-/// and its results are recorded into `mapper` so later clones can refer to them.
+/// inserts it. New blocks created while cloning nested regions are inserted
+/// through `rewriter`, so any listener it carries is notified. Operands and
+/// successors absent from `mapper` are kept as-is, so values defined outside
+/// the cloned scope are shared with the original. The op and its results are
+/// recorded into `mapper` so later clones can refer to them.
 pub fn clone_operation(
     op: Ptr<Operation>,
     ctx: &mut Context,
+    rewriter: &mut dyn Rewriter,
     mapper: &mut IrMapping,
 ) -> Ptr<Operation> {
-    // Gather everything needed to rebuild the op, remapping operands and
-    // successors, then drop the borrow before `Operation::new` takes `&mut ctx`.
-    let (concrete_op, result_types, operands, successors, num_regions, attributes, loc) = {
+    let new_op = clone_op_shell(op, ctx, mapper);
+    fill_operation(op, ctx, rewriter, mapper);
+    new_op
+}
+
+/// Phase one of cloning an op: build its clone with the right result types,
+/// successors and (empty) regions, but **no operands**, then record the op and
+/// its results in `mapper`.
+///
+/// Splitting the operands off into a later pass ([fill_operation]) is what makes
+/// cloning a block list order-independent: a use can be cloned before its def,
+/// because the def's result is already recorded by the time operands are wired.
+/// It also keeps the source IR untouched while shells are built (an empty
+/// operand list adds no uses to any of the source's values).
+///
+/// Successors are safe to remap now: when cloning a block list, every clone
+/// block is created and recorded before any op shell is built.
+///
+/// The returned op is **unlinked**.
+fn clone_op_shell(op: Ptr<Operation>, ctx: &mut Context, mapper: &mut IrMapping) -> Ptr<Operation> {
+    let (concrete_op, result_types, successors, num_regions, attributes, loc) = {
         let op_ref = op.deref(ctx);
-        let operands: Vec<Value> = op_ref
-            .operands()
-            .map(|v| mapper.lookup_value_or_default(v))
-            .collect();
         let successors: Vec<Ptr<BasicBlock>> = op_ref
             .successors()
             .map(|b| mapper.lookup_block_or_default(b))
@@ -119,7 +143,6 @@ pub fn clone_operation(
         (
             op_ref.concrete_op_info(),
             op_ref.result_types().collect::<Vec<_>>(),
-            operands,
             successors,
             op_ref.num_regions(),
             op_ref.attributes.clone(),
@@ -127,11 +150,12 @@ pub fn clone_operation(
         )
     };
 
+    // No operands yet: they are pushed, remapped, in `fill_operation`.
     let new_op = Operation::new(
         ctx,
         concrete_op,
         result_types,
-        operands,
+        Vec::new(),
         successors,
         num_regions,
     );
@@ -141,7 +165,8 @@ pub fn clone_operation(
         new_ref.set_loc(loc);
     }
 
-    // Record the op and its results before cloning nested regions.
+    // Record the op and its results so later shells (and the operand-wiring
+    // pass) can refer to them.
     mapper.map_op(op, new_op);
     let old_results: Vec<Value> = op.deref(ctx).results().collect();
     let new_results: Vec<Value> = new_op.deref(ctx).results().collect();
@@ -149,43 +174,82 @@ pub fn clone_operation(
         mapper.map_value(old, new);
     }
 
-    // Clone the blocks of each region into the corresponding (empty) region of
-    // the clone.
-    for region_idx in 0..num_regions {
-        let src_region = op.deref(ctx).get_region(region_idx);
-        let dest_region = new_op.deref(ctx).get_region(region_idx);
-        clone_region_into(src_region, dest_region, ctx, mapper);
-    }
-
     new_op
 }
 
-/// Clone every block of `src_region` (in order) into `dest_region`, appended at
-/// its end, remapping through `mapper`. See [clone_blocks_into].
+/// Phase two of cloning an op: wire the clone's operands and clone the contents
+/// of its nested regions.
+///
+/// By now [clone_op_shell] has recorded `op` and its results in `mapper`, as
+/// have the shells of any sibling ops, so every operand resolves to its clone
+/// (or, if defined outside the cloned scope, to the original via
+/// [IrMapping::lookup_value_or_default]). Cloning the nested regions is deferred
+/// to here too, matching MLIR's `Region::cloneInto`.
+fn fill_operation(
+    op: Ptr<Operation>,
+    ctx: &mut Context,
+    rewriter: &mut dyn Rewriter,
+    mapper: &mut IrMapping,
+) {
+    let new_op = mapper
+        .lookup_op(op)
+        .expect("op shell must be created before it is filled");
+
+    // Operands, remapped through the now-complete mapping and pushed in order.
+    let operands: Vec<Value> = op
+        .deref(ctx)
+        .operands()
+        .map(|v| mapper.lookup_value_or_default(v))
+        .collect();
+    for operand in operands {
+        Operation::push_operand(new_op, ctx, operand);
+    }
+
+    // Clone the blocks of each region into the corresponding (empty) region of
+    // the clone.
+    let num_regions = op.deref(ctx).num_regions();
+    for region_idx in 0..num_regions {
+        let src_region = op.deref(ctx).get_region(region_idx);
+        let dest_region = new_op.deref(ctx).get_region(region_idx);
+        clone_region_into(src_region, dest_region, ctx, rewriter, mapper);
+    }
+}
+
+/// Clone every block of `src_region` into `dest_region`, appended at its end,
+/// remapping through `mapper`. The block order is irrelevant; see
+/// [clone_blocks_into].
 pub fn clone_region_into(
     src_region: Ptr<Region>,
     dest_region: Ptr<Region>,
     ctx: &mut Context,
+    rewriter: &mut dyn Rewriter,
     mapper: &mut IrMapping,
 ) {
     let blocks: Vec<Ptr<BasicBlock>> = src_region.deref(ctx).iter(ctx).collect();
-    clone_blocks_into(&blocks, dest_region, ctx, mapper);
+    clone_blocks_into(&blocks, dest_region, ctx, rewriter, mapper);
 }
 
 /// Clone `blocks` (and their operations) into `dest_region`, appended at its end
-/// in the given order, remapping through `mapper`.
+/// in the given order, remapping through `mapper`. New blocks and ops are
+/// inserted through `rewriter`, so any listener it carries is notified.
 ///
-/// Two-phase: all clone blocks and their block arguments are created and
-/// recorded first, then operations are cloned. This lets branch successors and
-/// block-argument references resolve even when they point forward in `blocks`.
-/// Values and blocks absent from `mapper` are left unchanged
+/// Cloning is **three-phase**, so the result does not depend on the order of
+/// `blocks`:
+///
+/// 1. Create every clone block and its block arguments, and record them.
+/// 2. Create every clone op as a *shell* (correct results and successors, but no
+///    operands and empty regions), and record each op and its results.
+/// 3. Wire each clone op's operands and clone its nested regions.
+///
+/// Because every block, block argument and op result is recorded (phases 1-2)
+/// before any operand or successor is wired (phase 3), a reference that points
+/// "forward" in `blocks` -- a branch to a later block, a back-edge, or an
+/// operand whose def is cloned later -- still resolves to its clone. Values and
+/// blocks absent from `mapper` are left unchanged
 /// ([IrMapping::lookup_value_or_default]), so uses of values defined outside
-/// `blocks` correctly keep pointing at the originals.
+/// `blocks` keep pointing at the originals.
 ///
-/// `blocks` should be given in a dominance-respecting order (for example,
-/// reverse post-order) so that an operation result is cloned before its uses;
-/// values that flow across a back-edge ride block arguments, which are mapped in
-/// phase one and so resolve regardless of order.
+/// `rewriter`'s insertion point is saved on entry and restored on return.
 ///
 /// Op and block attributes (op result names, block debug info, block argument
 /// names) are copied, and so is the block label. The label is a block's
@@ -197,8 +261,11 @@ pub fn clone_blocks_into(
     blocks: &[Ptr<BasicBlock>],
     dest_region: Ptr<Region>,
     ctx: &mut Context,
+    rewriter: &mut dyn Rewriter,
     mapper: &mut IrMapping,
 ) {
+    let saved_insertion_point = rewriter.get_insertion_point();
+
     // Phase 1: create the clone blocks and their arguments, and record them.
     for &src_block in blocks {
         let (arg_types, label, attrs) = {
@@ -210,12 +277,15 @@ pub fn clone_blocks_into(
                 block_ref.attributes.clone(),
             )
         };
-        // Copy the label and attributes, mirroring how op attributes (result
-        // names and so on) are cloned. The label is the block's `given_name`;
-        // pliron keeps each block's `unique_name` distinct by suffixing a fresh
-        // id, so cloning the same block several times (an unrolled loop body, say)
-        // yields distinct blocks that still show which block they came from.
-        let new_block = BasicBlock::new(ctx, label, arg_types);
+        let new_block = rewriter.create_block(
+            ctx,
+            BlockInsertionPoint::AtRegionEnd(dest_region),
+            label,
+            arg_types,
+        );
+        // `create_block` takes only the label and argument types, so the rest of
+        // the block's attributes (debug info, argument names, ...) are copied
+        // here, mirroring how op attributes are cloned.
         new_block.deref_mut(ctx).attributes = attrs;
 
         let old_args: Vec<Value> = src_block.deref(ctx).arguments().collect();
@@ -224,19 +294,31 @@ pub fn clone_blocks_into(
             mapper.map_value(old, new);
         }
 
-        new_block.insert_at_back(dest_region, ctx);
         mapper.map_block(src_block, new_block);
     }
 
-    // Phase 2: clone each block's operations into its mapped clone.
+    // Phase 2: create each block's op shells (no operands, empty regions) and
+    // record their results, so later phases can refer to them in any order.
     for &src_block in blocks {
         let new_block = mapper
             .lookup_block(src_block)
             .expect("block was mapped in phase one");
+        rewriter.set_insertion_point(OpInsertionPoint::AtBlockEnd(new_block));
         let ops: Vec<Ptr<Operation>> = src_block.deref(ctx).iter(ctx).collect();
         for src_op in ops {
-            let new_op = clone_operation(src_op, ctx, mapper);
-            new_op.insert_at_back(new_block, ctx);
+            let shell = clone_op_shell(src_op, ctx, mapper);
+            rewriter.append_operation(ctx, shell);
         }
     }
+
+    // Phase 3: wire operands and clone nested regions, now that every op result
+    // in `blocks` is recorded.
+    for &src_block in blocks {
+        let ops: Vec<Ptr<Operation>> = src_block.deref(ctx).iter(ctx).collect();
+        for src_op in ops {
+            fill_operation(src_op, ctx, rewriter, mapper);
+        }
+    }
+
+    rewriter.set_insertion_point(saved_insertion_point);
 }

--- a/src/irbuild/cloning.rs
+++ b/src/irbuild/cloning.rs
@@ -26,8 +26,8 @@ use crate::{
     basic_block::BasicBlock,
     context::{Context, Ptr},
     irbuild::{
-        inserter::{BlockInsertionPoint, OpInsertionPoint},
-        rewriter::Rewriter,
+        inserter::{BlockInsertionPoint, Inserter, OpInsertionPoint},
+        rewriter::{Rewriter, ScopedRewriter},
     },
     linked_list::ContainsLinkedList,
     location::Located,
@@ -134,7 +134,7 @@ pub fn clone_operation(
 ///
 /// The returned op is **unlinked**.
 fn clone_op_shell(op: Ptr<Operation>, ctx: &mut Context, mapper: &mut IrMapping) -> Ptr<Operation> {
-    let (concrete_op, result_types, successors, num_regions, attributes, loc) = {
+    let (concrete_op, result_types, successors, num_operands, num_regions, attributes, loc) = {
         let op_ref = op.deref(ctx);
         let successors: Vec<Ptr<BasicBlock>> = op_ref
             .successors()
@@ -144,6 +144,7 @@ fn clone_op_shell(op: Ptr<Operation>, ctx: &mut Context, mapper: &mut IrMapping)
             op_ref.concrete_op_info(),
             op_ref.result_types().collect::<Vec<_>>(),
             successors,
+            op_ref.get_num_operands(),
             op_ref.num_regions(),
             op_ref.attributes.clone(),
             op_ref.loc(),
@@ -155,7 +156,7 @@ fn clone_op_shell(op: Ptr<Operation>, ctx: &mut Context, mapper: &mut IrMapping)
         ctx,
         concrete_op,
         result_types,
-        Vec::new(),
+        Vec::with_capacity(num_operands),
         successors,
         num_regions,
     );
@@ -216,8 +217,10 @@ fn fill_operation(
 }
 
 /// Clone every block of `src_region` into `dest_region`, appended at its end,
-/// remapping through `mapper`. The block order is irrelevant; see
-/// [clone_blocks_into].
+/// remapping through `mapper`.
+///
+/// New blocks and ops are inserted through `rewriter`, so any listener it carries is notified.
+/// `rewriter`'s insertion point is saved on entry and restored on return.
 pub fn clone_region_into(
     src_region: Ptr<Region>,
     dest_region: Ptr<Region>,
@@ -230,33 +233,26 @@ pub fn clone_region_into(
 }
 
 /// Clone `blocks` (and their operations) into `dest_region`, appended at its end
-/// in the given order, remapping through `mapper`. New blocks and ops are
-/// inserted through `rewriter`, so any listener it carries is notified.
+/// in the given order, remapping through `mapper`.
 ///
-/// Cloning is **three-phase**, so the result does not depend on the order of
-/// `blocks`:
-///
-/// 1. Create every clone block and its block arguments, and record them.
-/// 2. Create every clone op as a *shell* (correct results and successors, but no
-///    operands and empty regions), and record each op and its results.
-/// 3. Wire each clone op's operands and clone its nested regions.
-///
-/// Because every block, block argument and op result is recorded (phases 1-2)
-/// before any operand or successor is wired (phase 3), a reference that points
-/// "forward" in `blocks` -- a branch to a later block, a back-edge, or an
-/// operand whose def is cloned later -- still resolves to its clone. Values and
-/// blocks absent from `mapper` are left unchanged
-/// ([IrMapping::lookup_value_or_default]), so uses of values defined outside
-/// `blocks` keep pointing at the originals.
-///
+/// New blocks and ops are inserted through `rewriter`, so any listener it carries is notified.
 /// `rewriter`'s insertion point is saved on entry and restored on return.
-///
-/// Op and block attributes (op result names, block debug info, block argument
-/// names) are copied, and so is the block label. The label is a block's
-/// `given_name`; pliron derives each block's `unique_name` by suffixing a fresh
-/// per-block id, so cloning one block several times (an unrolled loop body, say)
-/// still yields distinct blocks while keeping the original's label, which makes
-/// the cloned IR easier to read.
+//
+// Cloning is **three-phase**, so the result does not depend on the order of
+// `blocks`:
+//
+// 1. Create every clone block and its block arguments, and record them.
+// 2. Create every clone op as a *shell* (correct results and successors, but no
+//    operands and empty regions), and record each op and its results.
+// 3. Wire each clone op's operands and clone its nested regions.
+//
+// Because every block, block argument and op result is recorded (phases 1-2)
+// before any operand or successor is wired (phase 3), a reference that points
+// "forward" in `blocks` -- a branch to a later block, a back-edge, or an
+// operand whose def is cloned later -- still resolves to its clone. Values and
+// blocks absent from `mapper` are left unchanged
+// ([IrMapping::lookup_value_or_default]), so uses of values defined outside
+// `blocks` keep pointing at the originals.
 pub fn clone_blocks_into(
     blocks: &[Ptr<BasicBlock>],
     dest_region: Ptr<Region>,
@@ -264,7 +260,7 @@ pub fn clone_blocks_into(
     rewriter: &mut dyn Rewriter,
     mapper: &mut IrMapping,
 ) {
-    let saved_insertion_point = rewriter.get_insertion_point();
+    let mut rewriter = ScopedRewriter::new(rewriter, OpInsertionPoint::Unset);
 
     // Phase 1: create the clone blocks and their arguments, and record them.
     for &src_block in blocks {
@@ -316,9 +312,7 @@ pub fn clone_blocks_into(
     for &src_block in blocks {
         let ops: Vec<Ptr<Operation>> = src_block.deref(ctx).iter(ctx).collect();
         for src_op in ops {
-            fill_operation(src_op, ctx, rewriter, mapper);
+            fill_operation(src_op, ctx, &mut rewriter, mapper);
         }
     }
-
-    rewriter.set_insertion_point(saved_insertion_point);
 }

--- a/src/irbuild/mod.rs
+++ b/src/irbuild/mod.rs
@@ -1,5 +1,6 @@
 //! Utilities for building and modifying IR.
 
+pub mod cloning;
 pub mod dialect_conversion;
 pub mod inserter;
 pub mod listener;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -514,10 +514,8 @@ impl Operation {
         self.regions.iter().cloned()
     }
 
-    /// The [ConcreteOpInfo] needed to reconstruct an operation of this op's
-    /// concrete kind. Used by IR cloning ([crate::irbuild::cloning]) to rebuild
-    /// an operation of the same kind via [Operation::new]. `ConcreteOpInfo` is
-    /// crate-internal, so this accessor is too.
+    /// Get [ConcreteOpInfo], useful for creating a [new](Operation::new) operation
+    /// of the same kind.
     pub(crate) fn concrete_op_info(&self) -> ConcreteOpInfo {
         self.concrete_op
     }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -514,6 +514,14 @@ impl Operation {
         self.regions.iter().cloned()
     }
 
+    /// The [ConcreteOpInfo] needed to reconstruct an operation of this op's
+    /// concrete kind. Used by IR cloning ([crate::irbuild::cloning]) to rebuild
+    /// an operation of the same kind via [Operation::new]. `ConcreteOpInfo` is
+    /// crate-internal, so this accessor is too.
+    pub(crate) fn concrete_op_info(&self) -> ConcreteOpInfo {
+        self.concrete_op
+    }
+
     /// Drop all uses that this operation holds.
     pub fn drop_all_uses(ptr: Ptr<Self>, ctx: &Context) {
         // The operands cease to be a use of their definitions.

--- a/tests/cloning.rs
+++ b/tests/cloning.rs
@@ -4,6 +4,7 @@ use common::{ConstantOp, ReturnOp, const_ret_in_mod};
 use pliron::{
     basic_block::BasicBlock,
     builtin::{
+        attributes::IntegerAttr,
         op_interfaces::{
             IsTerminatorInterface, OneRegionInterface, OneResultInterface,
             SingleBlockRegionInterface,
@@ -11,12 +12,15 @@ use pliron::{
         ops::{FuncOp, ModuleOp},
         types::{FunctionType, IntegerType, Signedness},
     },
+    common_traits::Named,
     context::{Context, Ptr},
     derive::pliron_op,
+    identifier::Identifier,
     irbuild::cloning::{IrMapping, clone_blocks_into, clone_operation},
     op::Op,
     operation::{Operation, verify_operation},
     result::Result,
+    utils::apint::{APInt, bw},
 };
 
 #[cfg(target_family = "wasm")]
@@ -283,6 +287,56 @@ fn clone_blocks_keeps_external_value_shared() -> Result<()> {
     assert_eq!(b2_term.deref(ctx).get_operand(0), c_val);
     // ...and the mapping has no entry for that external value.
     assert_eq!(mapper.lookup_value(c_val), None);
+
+    Ok(())
+}
+
+/// The clone carries over the source block's attributes (debug info, block
+/// argument names, ...) and its label, the same way op attributes are copied.
+/// The label is the block's `given_name`; the clone gets a fresh `unique_name`
+/// (label + a new id), so it stays a distinct block while still showing where it
+/// came from.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_blocks_copies_block_label_and_attributes() -> Result<()> {
+    let ctx = &mut Context::new();
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+
+    let module = ModuleOp::new(ctx, "m".try_into().unwrap());
+    let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+    let func = FuncOp::new(ctx, "foo".try_into().unwrap(), func_ty);
+    module.append_operation(ctx, func.get_operation(), 0);
+    let region = func.get_region(ctx);
+
+    // Give the source block a label and an attribute (a stand-in for block
+    // debug info).
+    let src = func.get_entry_block(ctx);
+    let label: Identifier = "myblock".try_into().unwrap();
+    src.deref_mut(ctx).set_label(ctx, Some(label.clone()));
+    let key: Identifier = "test_block_attr".try_into().unwrap();
+    src.deref_mut(ctx).attributes.set(
+        key.clone(),
+        IntegerAttr::new(i64_ty, APInt::from_u64(42, bw(64))),
+    );
+
+    let mut mapper = IrMapping::new();
+    clone_blocks_into(&[src], region, ctx, &mut mapper);
+    let clone = mapper.lookup_block(src).expect("block should be mapped");
+
+    let clone_ref = clone.deref(ctx);
+    // The clone carries the same attribute.
+    let copied = clone_ref
+        .attributes
+        .get::<IntegerAttr>(&key)
+        .expect("block attribute should be copied to the clone");
+    assert_eq!(copied.value().to_u64(), 42);
+    // ... and the same label (given_name), but a distinct unique_name.
+    assert_eq!(clone_ref.given_name(ctx), Some(label));
+    assert_ne!(
+        clone_ref.unique_name(ctx),
+        src.deref(ctx).unique_name(ctx),
+        "the clone must be a distinct block with its own unique_name"
+    );
 
     Ok(())
 }

--- a/tests/cloning.rs
+++ b/tests/cloning.rs
@@ -1,0 +1,288 @@
+//! Tests for IR cloning ([pliron::irbuild::cloning]).
+
+use common::{ConstantOp, ReturnOp, const_ret_in_mod};
+use pliron::{
+    basic_block::BasicBlock,
+    builtin::{
+        op_interfaces::{
+            IsTerminatorInterface, OneRegionInterface, OneResultInterface,
+            SingleBlockRegionInterface,
+        },
+        ops::{FuncOp, ModuleOp},
+        types::{FunctionType, IntegerType, Signedness},
+    },
+    context::{Context, Ptr},
+    derive::pliron_op,
+    irbuild::cloning::{IrMapping, clone_blocks_into, clone_operation},
+    op::Op,
+    operation::{Operation, verify_operation},
+    result::Result,
+};
+
+#[cfg(target_family = "wasm")]
+use wasm_bindgen_test::*;
+
+mod common;
+
+/// A minimal terminator that carries successors, so a test can build a small CFG
+/// to clone. (The test dialect's other ops are not branch-like.)
+#[pliron_op(name = "test.br", format, interfaces = [IsTerminatorInterface], verifier = "succ")]
+struct BranchOp {}
+
+/// The single successor of a terminator (asserting there is exactly one).
+fn sole_successor(ctx: &Context, term: Ptr<Operation>) -> Ptr<BasicBlock> {
+    let term_ref = term.deref(ctx);
+    let mut succs = term_ref.successors();
+    let first = succs.next().expect("terminator should have a successor");
+    assert!(succs.next().is_none(), "expected exactly one successor");
+    first
+}
+
+/// Cloning a function deep-copies its body and remaps intra-region operands:
+/// the cloned `return` must use the cloned constant, while the original is left
+/// untouched.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_function_remaps_operands() -> Result<()> {
+    let ctx = &mut Context::new();
+
+    // Builds a module with `fn foo() { c0 = const 0; return c0 }`.
+    let (_module, func, const_op, ret_op) = const_ret_in_mod(ctx)?;
+
+    let mut mapper = IrMapping::new();
+    let cloned_func = clone_operation(func.get_operation(), ctx, &mut mapper);
+
+    // The clone is a distinct operation, recorded in the mapping.
+    assert_ne!(cloned_func, func.get_operation());
+    assert_eq!(mapper.lookup_op(func.get_operation()), Some(cloned_func));
+
+    // The constant's result maps to a fresh value in the clone.
+    let orig_const_val = const_op.get_operation().deref(ctx).get_result(0);
+    let cloned_const_val = mapper
+        .lookup_value(orig_const_val)
+        .expect("constant result should be mapped");
+    assert_ne!(orig_const_val, cloned_const_val);
+
+    // The cloned return uses the cloned constant; the original is unchanged.
+    let cloned_ret = mapper
+        .lookup_op(ret_op.get_operation())
+        .expect("return should be mapped");
+    assert_eq!(cloned_ret.deref(ctx).get_operand(0), cloned_const_val);
+    assert_eq!(
+        ret_op.get_operation().deref(ctx).get_operand(0),
+        orig_const_val
+    );
+
+    // The clone is a structurally valid operation in its own right.
+    verify_operation(cloned_func, ctx)?;
+
+    Ok(())
+}
+
+/// Cloning the same op twice with independent mappings yields independent
+/// clones (no shared state leaks through [IrMapping]).
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_is_independent_per_mapping() -> Result<()> {
+    let ctx = &mut Context::new();
+    let (_module, func, _const_op, _ret_op) = const_ret_in_mod(ctx)?;
+
+    let first = clone_operation(func.get_operation(), ctx, &mut IrMapping::new());
+    let second = clone_operation(func.get_operation(), ctx, &mut IrMapping::new());
+
+    assert_ne!(first, func.get_operation());
+    assert_ne!(second, func.get_operation());
+    assert_ne!(first, second);
+
+    Ok(())
+}
+
+/// Cloning a set of blocks is two-phase: every clone block and its block
+/// arguments are recorded first, then ops are cloned. So a branch that points
+/// "forward" to a later block, and an op that uses a block argument, both resolve
+/// to their clones. We build
+///
+/// ```text
+///   A:        c = const 7;  br [c] -> B
+///   B(arg):   return arg
+/// ```
+///
+/// clone both blocks, and check the clone of A branches to the clone of B (the
+/// forward reference is resolved), carries the cloned constant (operand
+/// remapped), and the clone of B returns its own fresh argument (block-arg
+/// remapped).
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_blocks_remaps_branches_and_block_args() -> Result<()> {
+    let ctx = &mut Context::new();
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+
+    let module = ModuleOp::new(ctx, "m".try_into().unwrap());
+    let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+    let func = FuncOp::new(ctx, "foo".try_into().unwrap(), func_ty);
+    module.append_operation(ctx, func.get_operation(), 0);
+    let region = func.get_region(ctx);
+
+    // Block A is the entry: `c = const 7; br [c] -> B`.
+    let block_a = func.get_entry_block(ctx);
+    let c = ConstantOp::new(ctx, 7);
+    c.get_operation().insert_at_back(block_a, ctx);
+
+    // Block B takes one argument and returns it.
+    let block_b = BasicBlock::new(ctx, None, vec![i64_ty.into()]);
+    block_b.insert_at_back(region, ctx);
+    let b_arg = block_b.deref(ctx).get_argument(0);
+    ReturnOp::new(ctx, b_arg)
+        .get_operation()
+        .insert_at_back(block_b, ctx);
+
+    // A's branch carries `c` to B (B is listed after A, so this is a forward ref).
+    let br = Operation::new(
+        ctx,
+        BranchOp::get_concrete_op_info(),
+        vec![],
+        vec![c.get_result(ctx)],
+        vec![block_b],
+        0,
+    );
+    br.insert_at_back(block_a, ctx);
+
+    // Clone both blocks (A before B, i.e. reverse-post-order) into the region.
+    let mut mapper = IrMapping::new();
+    clone_blocks_into(&[block_a, block_b], region, ctx, &mut mapper);
+
+    let a2 = mapper.lookup_block(block_a).expect("A should be mapped");
+    let b2 = mapper.lookup_block(block_b).expect("B should be mapped");
+    assert_ne!(a2, block_a);
+    assert_ne!(b2, block_b);
+
+    // The constant was cloned to a fresh value.
+    let c2 = mapper
+        .lookup_value(c.get_result(ctx))
+        .expect("constant result should be mapped");
+    assert_ne!(c2, c.get_result(ctx));
+
+    // A's clone branches to B's clone (forward reference resolved), passing the
+    // cloned constant (operand remapped).
+    let a2_term = a2
+        .deref(ctx)
+        .get_terminator(ctx)
+        .expect("A's clone has a terminator");
+    assert_eq!(sole_successor(ctx, a2_term), b2);
+    assert_eq!(a2_term.deref(ctx).get_operand(0), c2);
+
+    // B's clone has its own fresh argument, and its return reads that argument.
+    let b2_arg = b2.deref(ctx).get_argument(0);
+    assert_eq!(mapper.lookup_value(b_arg), Some(b2_arg));
+    let b2_term = b2
+        .deref(ctx)
+        .get_terminator(ctx)
+        .expect("B's clone has a terminator");
+    assert_eq!(b2_term.deref(ctx).get_operand(0), b2_arg);
+
+    Ok(())
+}
+
+/// The two-phase clone also resolves *back* references (a block branching to an
+/// earlier block in the list), not just forward ones. Build a two-block loop
+/// `A -> B -> A`, clone both, and check the clone of B branches back to the clone
+/// of A, not the original A.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_blocks_resolves_back_edge() -> Result<()> {
+    let ctx = &mut Context::new();
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+
+    let module = ModuleOp::new(ctx, "m".try_into().unwrap());
+    let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+    let func = FuncOp::new(ctx, "foo".try_into().unwrap(), func_ty);
+    module.append_operation(ctx, func.get_operation(), 0);
+    let region = func.get_region(ctx);
+
+    // A branches to B; B branches back to A.
+    let block_a = func.get_entry_block(ctx);
+    let block_b = BasicBlock::new(ctx, None, vec![]);
+    block_b.insert_at_back(region, ctx);
+    Operation::new(
+        ctx,
+        BranchOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![block_b],
+        0,
+    )
+    .insert_at_back(block_a, ctx);
+    Operation::new(
+        ctx,
+        BranchOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![block_a],
+        0,
+    )
+    .insert_at_back(block_b, ctx);
+
+    let mut mapper = IrMapping::new();
+    clone_blocks_into(&[block_a, block_b], region, ctx, &mut mapper);
+
+    let a2 = mapper.lookup_block(block_a).expect("A should be mapped");
+    let b2 = mapper.lookup_block(block_b).expect("B should be mapped");
+
+    // A' -> B' (forward) and B' -> A' (back-edge), both resolved to the clones.
+    let a2_term = a2.deref(ctx).get_terminator(ctx).expect("A' terminator");
+    let b2_term = b2.deref(ctx).get_terminator(ctx).expect("B' terminator");
+    assert_eq!(sole_successor(ctx, a2_term), b2);
+    assert_eq!(sole_successor(ctx, b2_term), a2);
+
+    Ok(())
+}
+
+/// A value defined outside the cloned set must stay shared (MLIR's
+/// `lookupOrDefault`): the clone keeps pointing at the original, and the mapping
+/// has no entry for it. Build `A: c = const 7; br -> B` and `B: return c`, but
+/// clone ONLY B. B's clone must still return A's original constant.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_blocks_keeps_external_value_shared() -> Result<()> {
+    let ctx = &mut Context::new();
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+
+    let module = ModuleOp::new(ctx, "m".try_into().unwrap());
+    let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+    let func = FuncOp::new(ctx, "foo".try_into().unwrap(), func_ty);
+    module.append_operation(ctx, func.get_operation(), 0);
+    let region = func.get_region(ctx);
+
+    // A defines the constant and branches to B; B returns it.
+    let block_a = func.get_entry_block(ctx);
+    let c = ConstantOp::new(ctx, 7);
+    c.get_operation().insert_at_back(block_a, ctx);
+    let c_val = c.get_result(ctx);
+    let block_b = BasicBlock::new(ctx, None, vec![]);
+    block_b.insert_at_back(region, ctx);
+    Operation::new(
+        ctx,
+        BranchOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![block_b],
+        0,
+    )
+    .insert_at_back(block_a, ctx);
+    ReturnOp::new(ctx, c_val)
+        .get_operation()
+        .insert_at_back(block_b, ctx);
+
+    // Clone ONLY B; the constant `c` lives in A, outside the cloned set.
+    let mut mapper = IrMapping::new();
+    clone_blocks_into(&[block_b], region, ctx, &mut mapper);
+
+    let b2 = mapper.lookup_block(block_b).expect("B should be mapped");
+    let b2_term = b2.deref(ctx).get_terminator(ctx).expect("B' terminator");
+    // The clone still returns A's original constant (shared, not remapped)...
+    assert_eq!(b2_term.deref(ctx).get_operand(0), c_val);
+    // ...and the mapping has no entry for that external value.
+    assert_eq!(mapper.lookup_value(c_val), None);
+
+    Ok(())
+}

--- a/tests/cloning.rs
+++ b/tests/cloning.rs
@@ -16,7 +16,11 @@ use pliron::{
     context::{Context, Ptr},
     derive::pliron_op,
     identifier::Identifier,
-    irbuild::cloning::{IrMapping, clone_blocks_into, clone_operation},
+    irbuild::{
+        cloning::{IrMapping, clone_blocks_into, clone_operation},
+        listener::{DummyListener, Recorder, RecorderEvent},
+        rewriter::IRRewriter,
+    },
     op::Op,
     operation::{Operation, verify_operation},
     result::Result,
@@ -54,7 +58,8 @@ fn clone_function_remaps_operands() -> Result<()> {
     let (_module, func, const_op, ret_op) = const_ret_in_mod(ctx)?;
 
     let mut mapper = IrMapping::new();
-    let cloned_func = clone_operation(func.get_operation(), ctx, &mut mapper);
+    let mut rewriter = IRRewriter::<DummyListener>::default();
+    let cloned_func = clone_operation(func.get_operation(), ctx, &mut rewriter, &mut mapper);
 
     // The clone is a distinct operation, recorded in the mapping.
     assert_ne!(cloned_func, func.get_operation());
@@ -91,8 +96,19 @@ fn clone_is_independent_per_mapping() -> Result<()> {
     let ctx = &mut Context::new();
     let (_module, func, _const_op, _ret_op) = const_ret_in_mod(ctx)?;
 
-    let first = clone_operation(func.get_operation(), ctx, &mut IrMapping::new());
-    let second = clone_operation(func.get_operation(), ctx, &mut IrMapping::new());
+    let mut rewriter = IRRewriter::<DummyListener>::default();
+    let first = clone_operation(
+        func.get_operation(),
+        ctx,
+        &mut rewriter,
+        &mut IrMapping::new(),
+    );
+    let second = clone_operation(
+        func.get_operation(),
+        ctx,
+        &mut rewriter,
+        &mut IrMapping::new(),
+    );
 
     assert_ne!(first, func.get_operation());
     assert_ne!(second, func.get_operation());
@@ -151,9 +167,11 @@ fn clone_blocks_remaps_branches_and_block_args() -> Result<()> {
     );
     br.insert_at_back(block_a, ctx);
 
-    // Clone both blocks (A before B, i.e. reverse-post-order) into the region.
+    // Clone both blocks into the region. The order is irrelevant (the clone is
+    // three-phase), but pass them A-before-B here.
     let mut mapper = IrMapping::new();
-    clone_blocks_into(&[block_a, block_b], region, ctx, &mut mapper);
+    let mut rewriter = IRRewriter::<DummyListener>::default();
+    clone_blocks_into(&[block_a, block_b], region, ctx, &mut rewriter, &mut mapper);
 
     let a2 = mapper.lookup_block(block_a).expect("A should be mapped");
     let b2 = mapper.lookup_block(block_b).expect("B should be mapped");
@@ -227,7 +245,8 @@ fn clone_blocks_resolves_back_edge() -> Result<()> {
     .insert_at_back(block_b, ctx);
 
     let mut mapper = IrMapping::new();
-    clone_blocks_into(&[block_a, block_b], region, ctx, &mut mapper);
+    let mut rewriter = IRRewriter::<DummyListener>::default();
+    clone_blocks_into(&[block_a, block_b], region, ctx, &mut rewriter, &mut mapper);
 
     let a2 = mapper.lookup_block(block_a).expect("A should be mapped");
     let b2 = mapper.lookup_block(block_b).expect("B should be mapped");
@@ -237,6 +256,108 @@ fn clone_blocks_resolves_back_edge() -> Result<()> {
     let b2_term = b2.deref(ctx).get_terminator(ctx).expect("B' terminator");
     assert_eq!(sole_successor(ctx, a2_term), b2);
     assert_eq!(sole_successor(ctx, b2_term), a2);
+
+    Ok(())
+}
+
+/// The clone is **order-independent** for op results too, not just block
+/// arguments and branches: even when blocks are given in a non-dominance order
+/// (a use listed before its def), a cross-block op-result operand still resolves
+/// to the clone, not the original. Build
+///
+/// ```text
+///   A:   c = const 7;  br -> B
+///   B:   return c
+/// ```
+///
+/// and clone both blocks in the order `[B, A]` (B, the use, before A, the def).
+/// A single-pass clone would wire B's `return` to A's *original* constant
+/// (silently leaving the clone pointing into the source IR); the three-phase
+/// clone records the cloned constant before wiring any operand, so it resolves
+/// to the clone.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_blocks_resolves_op_result_forward_ref_in_any_order() -> Result<()> {
+    let ctx = &mut Context::new();
+    let i64_ty = IntegerType::get(ctx, 64, Signedness::Signed);
+
+    let module = ModuleOp::new(ctx, "m".try_into().unwrap());
+    let func_ty = FunctionType::get(ctx, vec![], vec![i64_ty.into()]);
+    let func = FuncOp::new(ctx, "foo".try_into().unwrap(), func_ty);
+    module.append_operation(ctx, func.get_operation(), 0);
+    let region = func.get_region(ctx);
+
+    // A defines the constant and branches to B; B returns it. `c` is an op result
+    // in A used by an op in B (a cross-block use, legal because A dominates B).
+    let block_a = func.get_entry_block(ctx);
+    let c = ConstantOp::new(ctx, 7);
+    c.get_operation().insert_at_back(block_a, ctx);
+    let c_val = c.get_result(ctx);
+    let block_b = BasicBlock::new(ctx, None, vec![]);
+    block_b.insert_at_back(region, ctx);
+    Operation::new(
+        ctx,
+        BranchOp::get_concrete_op_info(),
+        vec![],
+        vec![],
+        vec![block_b],
+        0,
+    )
+    .insert_at_back(block_a, ctx);
+    ReturnOp::new(ctx, c_val)
+        .get_operation()
+        .insert_at_back(block_b, ctx);
+
+    // Pass the blocks in the "wrong" (non-dominance) order: B before A.
+    let mut mapper = IrMapping::new();
+    let mut rewriter = IRRewriter::<DummyListener>::default();
+    clone_blocks_into(&[block_b, block_a], region, ctx, &mut rewriter, &mut mapper);
+
+    let c2 = mapper
+        .lookup_value(c_val)
+        .expect("constant result should be mapped");
+    assert_ne!(c2, c_val, "the constant must be cloned to a fresh value");
+
+    let b2 = mapper.lookup_block(block_b).expect("B should be mapped");
+    let b2_term = b2.deref(ctx).get_terminator(ctx).expect("B' terminator");
+    // B's clone returns the *cloned* constant, not A's original.
+    assert_eq!(b2_term.deref(ctx).get_operand(0), c2);
+    assert_ne!(b2_term.deref(ctx).get_operand(0), c_val);
+
+    Ok(())
+}
+
+/// Cloning inserts the new blocks and ops through the rewriter, so a listener it
+/// carries is notified for each one. A raw linked-list insertion would bypass
+/// the listener entirely. Clone a single block `c = const 7; return c` with a
+/// recording rewriter and check it saw one inserted block and two inserted ops.
+#[test]
+#[cfg_attr(target_family = "wasm", wasm_bindgen_test)]
+fn clone_blocks_notifies_rewriter_listener() -> Result<()> {
+    let ctx = &mut Context::new();
+
+    let (_module, func, _const_op, _ret_op) = const_ret_in_mod(ctx)?;
+    let region = func.get_region(ctx);
+    let src = func.get_entry_block(ctx);
+
+    let mut mapper = IrMapping::new();
+    let mut rewriter = IRRewriter::<Recorder>::default();
+    clone_blocks_into(&[src], region, ctx, &mut rewriter, &mut mapper);
+
+    let mut inserted_blocks = 0;
+    let mut inserted_ops = 0;
+    for event in &rewriter.get_listener().events {
+        match event {
+            RecorderEvent::InsertedBlock(_) => inserted_blocks += 1,
+            RecorderEvent::InsertedOperation(_) => inserted_ops += 1,
+            other => panic!("unexpected event during cloning: {other:?}"),
+        }
+    }
+    assert_eq!(inserted_blocks, 1, "one cloned block should be notified");
+    assert_eq!(
+        inserted_ops, 2,
+        "both cloned ops (constant + return) should be notified"
+    );
 
     Ok(())
 }
@@ -279,7 +400,8 @@ fn clone_blocks_keeps_external_value_shared() -> Result<()> {
 
     // Clone ONLY B; the constant `c` lives in A, outside the cloned set.
     let mut mapper = IrMapping::new();
-    clone_blocks_into(&[block_b], region, ctx, &mut mapper);
+    let mut rewriter = IRRewriter::<DummyListener>::default();
+    clone_blocks_into(&[block_b], region, ctx, &mut rewriter, &mut mapper);
 
     let b2 = mapper.lookup_block(block_b).expect("B should be mapped");
     let b2_term = b2.deref(ctx).get_terminator(ctx).expect("B' terminator");
@@ -320,7 +442,8 @@ fn clone_blocks_copies_block_label_and_attributes() -> Result<()> {
     );
 
     let mut mapper = IrMapping::new();
-    clone_blocks_into(&[src], region, ctx, &mut mapper);
+    let mut rewriter = IRRewriter::<DummyListener>::default();
+    clone_blocks_into(&[src], region, ctx, &mut rewriter, &mut mapper);
     let clone = mapper.lookup_block(src).expect("block should be mapped");
 
     let clone_ref = clone.deref(ctx);


### PR DESCRIPTION
Adds an IR cloning capability, modeled on MLIR's `IRMapping` + `Operation::clone(mapper)` / `Region::cloneInto(mapper)`. I use this for a loop-unrolling pass downstream (duplicating ops and multi-block loop bodies with operand/branch remapping), and it believe its generally useful, so putting it up.

What's in `irbuild::cloning`:

- `IrMapping`: three independent maps (values, blocks, ops). Lookups fall back to the original (MLIR's `lookupOrDefault`), so anything defined outside the cloned scope stays shared.
- `clone_operation`: deep-clones an op and its regions, remapping operands and successors. Returns an unlinked op (caller inserts it), and records the op and its results so later clones can refer to them.
- `clone_region_into` / `clone_blocks_into`: clone a region / a set of blocks into a destination region. Two-phase (create and map all clone blocks + block args first, then clone ops), so forward branch/block-arg references and back-edges resolve. Pass blocks in a dominance-respecting (RPO) order.
- A small `pub(crate) Operation::concrete_op_info()` accessor so cloning can rebuild an op of the same concrete kind via `Operation::new`.

**CI and tests:**
- `no_std`-safe; fmt/clippy/doc clean. 
- Tests in `tests/cloning.rs` cover operand remap, per-mapping independence, the two-phase forward branch + block-arg remap, back-edge resolution, and `lookupOrDefault` sharing of a value defined outside the cloned set.

~~One fidelity note (also in the docs): op attributes are copied (including op result names), but block attributes (labels, block debug info) are not; the clone blocks are fresh.~~
