### PR TITLE
implemented `ConstFoldInterface` for `ICmp`, `SExt`, and `ZExt`

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -10,6 +10,7 @@ use pliron::{
     builtin::{
         attributes::IntegerAttr,
         op_interfaces::{BranchOpInterface, OneResultInterface},
+        types::{IntegerType, Signedness},
     },
     context::{Context, Ptr},
     derive::op_interface_impl,
@@ -23,13 +24,13 @@ use pliron::{
         },
     },
     result::Result,
-    utils::apint::APInt,
+    utils::apint::{APInt, bw},
     value::Value,
 };
 
 use crate::{
-    attributes::IntegerOverflowFlagsAttr,
-    op_interfaces::{IntBinArithOpWithOverflowFlag, PointerTypeResult},
+    attributes::{ICmpPredicateAttr, IntegerOverflowFlagsAttr},
+    op_interfaces::{IntBinArithOpWithOverflowFlag, NNegFlag, PointerTypeResult},
     ops::{
         AShrOp, AddOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp, CondBrOp, ExtractElementOp,
         ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp,
@@ -266,6 +267,23 @@ fn is_signed_div_ub(lhs: &APInt, rhs: &APInt) -> bool {
     let bw = NonZero::new(rhs.bw()).expect("operand has zero bitwidth");
     // `-1` is the all-ones bit pattern, i.e. the unsigned max.
     rhs.is_zero() || (*lhs == APInt::imin(bw) && *rhs == APInt::umax(bw))
+}
+
+/// Evaluate an integer comparison `lhs <pred> rhs`. `lhs` and `rhs` must have
+/// the same bitwidth.
+fn eval_icmp(pred: &ICmpPredicateAttr, lhs: &APInt, rhs: &APInt) -> bool {
+    match pred {
+        ICmpPredicateAttr::EQ => lhs == rhs,
+        ICmpPredicateAttr::NE => lhs != rhs,
+        ICmpPredicateAttr::SLT => lhs.slt(rhs),
+        ICmpPredicateAttr::SLE => lhs.sle(rhs),
+        ICmpPredicateAttr::SGT => lhs.sgt(rhs),
+        ICmpPredicateAttr::SGE => lhs.sge(rhs),
+        ICmpPredicateAttr::ULT => lhs.ult(rhs),
+        ICmpPredicateAttr::ULE => lhs.ule(rhs),
+        ICmpPredicateAttr::UGT => lhs.ugt(rhs),
+        ICmpPredicateAttr::UGE => lhs.uge(rhs),
+    }
 }
 
 /// Constant fold this binary integer operation into a singleton vector
@@ -560,6 +578,106 @@ impl ConstFoldInterface for AShrOp {
             }
             None => vec![None],
         }
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for ICmpOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let Some((lhs, rhs)) = get_int_bin_operands(ops) else {
+            return vec![None];
+        };
+        let result = eval_icmp(&self.predicate(ctx), &lhs.value(), &rhs.value());
+        let bool_ty = IntegerType::get_existing(ctx, 1, Signedness::Signless)
+            .expect("i1 type must exist: it is the result type of this op");
+        let res = Box::new(IntegerAttr::new(
+            bool_ty,
+            APInt::from_u8(result as u8, bw(1)),
+        )) as AttrObj;
+        vec![Some(res)]
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for SExtOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(operand)] = ops else {
+            return vec![None];
+        };
+        let operand = operand
+            .downcast_ref::<IntegerAttr>()
+            .expect("invalid operand type: typecheck before optimizing");
+        let res_ty = self.result_type(ctx);
+        let dest_width = res_ty
+            .deref(ctx)
+            .downcast_ref::<IntegerType>()
+            .expect("sext result must be an integer type")
+            .width();
+        let dest_ty = IntegerType::get_existing(ctx, dest_width, Signedness::Signless)
+            .expect("result type must exist: it is the result type of this op");
+        let extended = operand
+            .value()
+            .sext(NonZero::new(dest_width as usize).expect("result has zero bitwidth"));
+        let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;
+        vec![Some(res)]
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for ZExtOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(operand)] = ops else {
+            return vec![None];
+        };
+        let operand = operand
+            .downcast_ref::<IntegerAttr>()
+            .expect("invalid operand type: typecheck before optimizing");
+        // `zext nneg` asserts the operand is non-negative; if it isn't, the
+        // result is poison, so we must not fold it to a concrete value.
+        let value = operand.value();
+        if self.nneg(ctx)
+            && value.slt(&APInt::zero(
+                NonZero::new(value.bw()).expect("operand has zero bitwidth"),
+            ))
+        {
+            return vec![None];
+        }
+        let res_ty = self.result_type(ctx);
+        let dest_width = res_ty
+            .deref(ctx)
+            .downcast_ref::<IntegerType>()
+            .expect("zext result must be an integer type")
+            .width();
+        let dest_ty = IntegerType::get_existing(ctx, dest_width, Signedness::Signless)
+            .expect("result type must exist: it is the result type of this op");
+        let extended =
+            value.zext(NonZero::new(dest_width as usize).expect("result has zero bitwidth"));
+        let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;
+        vec![Some(res)]
     }
     fn fold_in_place(
         &self,

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -950,3 +950,232 @@ fn ashr_does_not_fold_when_shift_amount_exceeds_bitwidth() -> Result<()> {
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// llvm.icmp
+// ---------------------------------------------------------------------------
+
+#[test]
+fn icmp_eq_folds_to_true() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        c = llvm.icmp a <EQ> b : builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<1: i1>"));
+    Ok(())
+}
+
+#[test]
+fn icmp_eq_folds_to_false() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8;
+        c = llvm.icmp a <EQ> b : builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<0: i1>"));
+    Ok(())
+}
+
+/// 0xff is -1 signed, so `slt 0` is true.
+#[test]
+fn icmp_signed_predicate_treats_high_bit_as_negative() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        c = llvm.icmp a <SLT> b : builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<1: i1>"));
+    Ok(())
+}
+
+/// 0xff is 255 unsigned, so `ult 0` is false (the same operands compare
+/// oppositely to the signed predicate above).
+#[test]
+fn icmp_unsigned_predicate_treats_high_bit_as_large() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        b = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8;
+        c = llvm.icmp a <ULT> b : builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<0: i1>"));
+    Ok(())
+}
+
+#[test]
+fn icmp_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i1 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        b = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        c = llvm.icmp x <EQ> b : builtin.integer i1;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.sext
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sext_folds_non_negative_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        c = llvm.sext a to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<5: i16>"));
+    Ok(())
+}
+
+/// A negative value replicates the sign bit:
+/// -1 (i8, 0xff) -> -1 (i16, 0xffff == 65535 unsigned).
+#[test]
+fn sext_folds_negative_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        c = llvm.sext a to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<65535: i16>"));
+    Ok(())
+}
+
+#[test]
+fn sext_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        c = llvm.sext x to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.zext
+// ---------------------------------------------------------------------------
+
+/// A non-negative value extends with zeros: 5 (i8) -> 5 (i16).
+#[test]
+fn zext_folds_non_negative_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        c = llvm.zext <nneg=false> a to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<5: i16>"));
+    Ok(())
+}
+
+/// The high bit is not replicated: 255 (i8, 0xff) zero-extends to 255 (i16),
+/// not 65535 as `sext` would produce.
+#[test]
+fn zext_folds_high_bit_set_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        c = llvm.zext <nneg=false> a to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<255: i16>"));
+    Ok(())
+}
+
+/// `zext nneg` of a value whose sign bit is set (255 == -1 signed) is poison,
+/// so it must not be folded to a concrete value.
+#[test]
+fn zext_nneg_does_not_fold_negative_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8;
+        c = llvm.zext <nneg=true> a to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+/// `zext nneg` still folds when the operand really is non-negative.
+#[test]
+fn zext_nneg_folds_non_negative_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8;
+        c = llvm.zext <nneg=true> a to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<5: i16>"));
+    Ok(())
+}
+
+#[test]
+fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.integer i16 (builtin.integer i8) variadic = false> [] {
+        ^entry(x: builtin.integer i8):
+        c = llvm.zext <nneg=false> x to builtin.integer i16;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}

--- a/src/utils/apint.rs
+++ b/src/utils/apint.rs
@@ -229,6 +229,23 @@ impl APInt {
         APInt { value }
     }
 
+    /// Sign-extend (or truncate) `self` to `width` bits. When `width` is larger
+    /// than the current bitwidth, the sign bit is replicated into the new high
+    /// bits.
+    pub fn sext(&self, width: NonZero<usize>) -> APInt {
+        let mut value = Awi::zero(width);
+        value.sign_resize_(&self.value);
+        APInt { value }
+    }
+
+    /// Zero-extend (or truncate) `self` to `width` bits. When `width` is larger
+    /// than the current bitwidth, the new high bits are filled with zeros.
+    pub fn zext(&self, width: NonZero<usize>) -> APInt {
+        let mut value = Awi::zero(width);
+        value.zero_resize_(&self.value);
+        APInt { value }
+    }
+
     /// Left-shift `self` by `rhs` bits, reporting whether the result
     /// overflowed. They must have the same bitwidth, and the shift amount `rhs`
     /// must be less than the bitwidth (a shift amount `>=` the bitwidth is
@@ -385,6 +402,106 @@ impl APInt {
         self.value
             .ult(&rhs.value)
             .expect("APInt::ult: bitwidth mismatch")
+    }
+
+    /// Unsigned less-than-or-equal comparison. They must have the same bitwidth.
+    pub fn ule(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::ule: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .ule(&rhs.value)
+            .expect("APInt::ule: bitwidth mismatch")
+    }
+
+    /// Unsigned greater-than comparison. They must have the same bitwidth.
+    pub fn ugt(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::ugt: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .ugt(&rhs.value)
+            .expect("APInt::ugt: bitwidth mismatch")
+    }
+
+    /// Unsigned greater-than-or-equal comparison. They must have the same
+    /// bitwidth.
+    pub fn uge(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::uge: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .uge(&rhs.value)
+            .expect("APInt::uge: bitwidth mismatch")
+    }
+
+    /// Signed less-than comparison. They must have the same bitwidth.
+    pub fn slt(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::slt: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .ilt(&rhs.value)
+            .expect("APInt::slt: bitwidth mismatch")
+    }
+
+    /// Signed less-than-or-equal comparison. They must have the same bitwidth.
+    pub fn sle(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::sle: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .ile(&rhs.value)
+            .expect("APInt::sle: bitwidth mismatch")
+    }
+
+    /// Signed greater-than comparison. They must have the same bitwidth.
+    pub fn sgt(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::sgt: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .igt(&rhs.value)
+            .expect("APInt::sgt: bitwidth mismatch")
+    }
+
+    /// Signed greater-than-or-equal comparison. They must have the same
+    /// bitwidth.
+    pub fn sge(&self, rhs: &APInt) -> bool {
+        assert_eq!(
+            self.bw(),
+            rhs.bw(),
+            "APInt::sge: bitwidth mismatch ({} vs {})",
+            self.bw(),
+            rhs.bw()
+        );
+        self.value
+            .ige(&rhs.value)
+            .expect("APInt::sge: bitwidth mismatch")
     }
 
     /// Get unsigned max value
@@ -946,6 +1063,41 @@ mod tests {
     }
 
     #[test]
+    fn test_sext() {
+        // A non-negative value extends with zeros: 5 (i4) -> 5 (i8).
+        let res = APInt::from_i8(5, bw(4)).sext(bw(8));
+        assert_eq!(res.bw(), 8);
+        assert_eq!(res.to_i8(), 5);
+
+        // A negative value replicates the sign bit: -1 (i4) -> -1 (i8) == 0xff.
+        let res = APInt::from_i8(-1, bw(4)).sext(bw(8));
+        assert_eq!(res.bw(), 8);
+        assert_eq!(res.to_i8(), -1);
+        assert_eq!(res.to_u8(), 0xff);
+
+        // -3 (i4, 0b1101) sign-extends to -3 (i8, 0b11111101).
+        let res = APInt::from_i8(-3, bw(4)).sext(bw(8));
+        assert_eq!(res.to_i8(), -3);
+    }
+
+    #[test]
+    fn test_zext() {
+        // A non-negative value extends with zeros: 5 (i4) -> 5 (i8).
+        let res = APInt::from_i8(5, bw(4)).zext(bw(8));
+        assert_eq!(res.bw(), 8);
+        assert_eq!(res.to_u8(), 5);
+
+        // The sign bit is not replicated: -1 (i4, 0xf) -> 15 (i8), not -1.
+        let res = APInt::from_i8(-1, bw(4)).zext(bw(8));
+        assert_eq!(res.bw(), 8);
+        assert_eq!(res.to_u8(), 15);
+
+        // -3 (i4, 0b1101 == 13 unsigned) zero-extends to 13 (i8).
+        let res = APInt::from_i8(-3, bw(4)).zext(bw(8));
+        assert_eq!(res.to_u8(), 13);
+    }
+
+    #[test]
     fn test_udiv() {
         let width = bw(4);
 
@@ -973,19 +1125,37 @@ mod tests {
     }
 
     #[test]
-    fn test_ult() {
+    fn test_unsigned_cmp() {
         let width = bw(4);
+        let one = APInt::from_u8(1, width);
+        let four = APInt::from_u8(4, width);
+        let four2 = APInt::from_u8(4, width);
 
-        // Strictly less / greater.
-        assert!(APInt::from_u8(3, width).ult(&APInt::from_u8(5, width)));
-        assert!(!APInt::from_u8(5, width).ult(&APInt::from_u8(3, width)));
+        assert!(one.ult(&four) && !four.ult(&four2) && !four.ult(&one));
+        assert!(one.ule(&four) && four.ule(&four2) && !four.ule(&one));
+        assert!(four.ugt(&one) && !one.ugt(&four) && !four.ugt(&four2));
+        assert!(four.uge(&one) && four.uge(&four2) && !one.uge(&four));
 
-        // Equal values are not less-than.
-        assert!(!APInt::from_u8(4, width).ult(&APInt::from_u8(4, width)));
+        // 0xf == 15 is the largest under the unsigned interpretation.
+        let high = APInt::from_u8(0xf, width);
+        assert!(high.ugt(&four) && high.uge(&four) && !high.ule(&four));
+    }
 
-        // Unsigned interpretation: 0xf == 15 is the largest, not -1.
-        assert!(APInt::from_u8(1, width).ult(&APInt::from_u8(0xf, width)));
-        assert!(!APInt::from_u8(0xf, width).ult(&APInt::from_u8(1, width)));
+    #[test]
+    fn test_signed_cmp() {
+        let width = bw(4);
+        let neg_one = APInt::from_i8(-1, width);
+        let one = APInt::from_i8(1, width);
+        let neg_one2 = APInt::from_i8(-1, width);
+
+        assert!(neg_one.slt(&one) && !one.slt(&neg_one));
+        assert!(neg_one.sle(&one) && neg_one.sle(&neg_one2) && !one.sle(&neg_one));
+        assert!(one.sgt(&neg_one) && !neg_one.sgt(&one));
+        assert!(one.sge(&neg_one) && neg_one.sge(&neg_one2) && !neg_one.sge(&one));
+
+        // The same bit pattern compares oppositely signed vs unsigned: -1 is the
+        // smallest signed value but the largest unsigned (0xf).
+        assert!(neg_one.slt(&one) && neg_one.ugt(&one));
     }
 
     #[test]


### PR DESCRIPTION
This PR works toward https://github.com/pliron-org/pliron/issues/118 but does not close it.

It implements `ConstFoldInterface` for the `icmp`, `sext`, and `zext` operations of the `llvm` dialect.

## icmp

The `icmp` instruction is integer comparison. It has an attribute determining whether the comparison is `eq`, `lt`, `slt`, `sle`, `ult`, etc. Constant folding is for this operation is straightforward.

## sext

Sign extends an integer operand to a specified target type. Constant folding for this operation is straightforward.

## zext

Zero extends an integer operand to a specified target type. If its `nneg` attribute is set and so is the sign bit of its operand, then the operation would produce `poison` at runtime, so we avoid folding such cases.