### PR TITLE
implement ConstFoldInterface for `fneg`, `fadd`, and `fsub`

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -5,9 +5,10 @@ use thiserror::Error;
 
 use pliron::{
     arg_err,
-    attribute::AttrObj,
+    attribute::{Attribute, AttrObj, attr_cast},
     basic_block::BasicBlock,
     builtin::{
+        attr_interfaces::FloatAttr,
         attributes::IntegerAttr,
         op_interfaces::{BranchOpInterface, OneResultInterface},
         types::{IntegerType, Signedness},
@@ -299,6 +300,29 @@ fn check_fold_int_bin_op(
         lhs.get_type(),
         combine(&lhs.value(), &rhs.value()),
     )) as AttrObj;
+    vec![Some(res)]
+}
+
+/// Constant fold a binary floating-point operation into a singleton vector
+/// containing its result if both operands are constant, or None otherwise.
+///
+/// `combine` computes the result with the default IEEE rounding mode. Because
+/// the result type equals the operand type, the produced [FloatAttr] already
+/// carries the correct type.
+fn check_fold_float_bin_op(
+    operand_attrs: &[Option<AttrObj>],
+    combine: impl Fn(&dyn FloatAttr, &dyn FloatAttr) -> Box<dyn FloatAttr>,
+) -> Vec<Option<AttrObj>> {
+    assert!(operand_attrs.len() == 2);
+    let [Some(lhs), Some(rhs)] = operand_attrs else {
+        return vec![None];
+    };
+    let lhs = attr_cast::<dyn FloatAttr>(&**lhs)
+        .expect("invalid operand type: typecheck before optimizing");
+    let rhs = attr_cast::<dyn FloatAttr>(&**rhs)
+        .expect("invalid operand type: typecheck before optimizing");
+    let res = combine(lhs, rhs);
+    let res = pliron::dyn_clone::clone_box(&*res as &dyn Attribute);
     vec![Some(res)]
 }
 
@@ -678,6 +702,58 @@ impl ConstFoldInterface for ZExtOp {
             value.zext(NonZero::new(dest_width as usize).expect("result has zero bitwidth"));
         let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;
         vec![Some(res)]
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FNegOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        let [Some(operand)] = ops else {
+            return vec![None];
+        };
+        let float_val = attr_cast::<dyn FloatAttr>(&**operand)
+            .expect("invalid operand type: typecheck before optimizing");
+        let negated = float_val.neg();
+        let res = pliron::dyn_clone::clone_box(&*negated as &dyn Attribute);
+        vec![Some(res)]
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FAddOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_bin_op(ops, |lhs, rhs| lhs.add(rhs).value)
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FSubOp {
+    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_bin_op(ops, |lhs, rhs| lhs.sub(rhs).value)
     }
     fn fold_in_place(
         &self,

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use pliron::{
     arg_err,
-    attribute::{Attribute, AttrObj, attr_cast},
+    attribute::{AttrObj, Attribute, attr_cast},
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::FloatAttr,

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -305,10 +305,6 @@ fn check_fold_int_bin_op(
 
 /// Constant fold a binary floating-point operation into a singleton vector
 /// containing its result if both operands are constant, or None otherwise.
-///
-/// `combine` computes the result with the default IEEE rounding mode. Because
-/// the result type equals the operand type, the produced [FloatAttr] already
-/// carries the correct type.
 fn check_fold_float_bin_op(
     operand_attrs: &[Option<AttrObj>],
     combine: impl Fn(&dyn FloatAttr, &dyn FloatAttr) -> Box<dyn FloatAttr>,

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -30,8 +30,8 @@ use pliron::{
 };
 
 use crate::{
-    attributes::{ICmpPredicateAttr, IntegerOverflowFlagsAttr},
-    op_interfaces::{IntBinArithOpWithOverflowFlag, NNegFlag, PointerTypeResult},
+    attributes::{FastmathFlags, FastmathFlagsAttr, ICmpPredicateAttr, IntegerOverflowFlagsAttr},
+    op_interfaces::{FastMathFlags, IntBinArithOpWithOverflowFlag, NNegFlag, PointerTypeResult},
     ops::{
         AShrOp, AddOp, AddressOfOp, AllocaOp, AndOp, BitcastOp, BrOp, CondBrOp, ExtractElementOp,
         ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp,
@@ -303,10 +303,20 @@ fn check_fold_int_bin_op(
     vec![Some(res)]
 }
 
+/// Returns `true` if the fast-math `flags` make a constant fold involving
+/// `values` (the operands together with the computed result) undefined
+/// behavior, so it must not be folded to a concrete value.
+fn fast_math_forbids_fold(flags: FastmathFlagsAttr, values: &[&dyn FloatAttr]) -> bool {
+    let flags = flags.0;
+    (flags.contains(FastmathFlags::NNAN) && values.iter().any(|v| v.is_nan()))
+        || (flags.contains(FastmathFlags::NINF) && values.iter().any(|v| v.is_infinite()))
+}
+
 /// Constant fold a binary floating-point operation into a singleton vector
 /// containing its result if both operands are constant, or None otherwise.
 fn check_fold_float_bin_op(
     operand_attrs: &[Option<AttrObj>],
+    flags: FastmathFlagsAttr,
     combine: impl Fn(&dyn FloatAttr, &dyn FloatAttr) -> Box<dyn FloatAttr>,
 ) -> Vec<Option<AttrObj>> {
     assert!(operand_attrs.len() == 2);
@@ -318,6 +328,9 @@ fn check_fold_float_bin_op(
     let rhs = attr_cast::<dyn FloatAttr>(&**rhs)
         .expect("invalid operand type: typecheck before optimizing");
     let res = combine(lhs, rhs);
+    if fast_math_forbids_fold(flags, &[lhs, rhs, &*res]) {
+        return vec![None];
+    }
     let res = pliron::dyn_clone::clone_box(&*res as &dyn Attribute);
     vec![Some(res)]
 }
@@ -711,13 +724,18 @@ impl ConstFoldInterface for ZExtOp {
 
 #[op_interface_impl]
 impl ConstFoldInterface for FNegOp {
-    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
         let [Some(operand)] = ops else {
             return vec![None];
         };
         let float_val = attr_cast::<dyn FloatAttr>(&**operand)
             .expect("invalid operand type: typecheck before optimizing");
         let negated = float_val.neg();
+        // Negation cannot create or destroy NaN/Inf, so checking the operand
+        // covers the result too.
+        if fast_math_forbids_fold(self.fast_math_flags(ctx), &[float_val]) {
+            return vec![None];
+        }
         let res = pliron::dyn_clone::clone_box(&*negated as &dyn Attribute);
         vec![Some(res)]
     }
@@ -733,8 +751,10 @@ impl ConstFoldInterface for FNegOp {
 
 #[op_interface_impl]
 impl ConstFoldInterface for FAddOp {
-    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
-        check_fold_float_bin_op(ops, |lhs, rhs| lhs.add(rhs).value)
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_bin_op(ops, self.fast_math_flags(ctx), |lhs, rhs| {
+            lhs.add(rhs).value
+        })
     }
     fn fold_in_place(
         &self,
@@ -748,8 +768,10 @@ impl ConstFoldInterface for FAddOp {
 
 #[op_interface_impl]
 impl ConstFoldInterface for FSubOp {
-    fn check_fold(&self, _ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
-        check_fold_float_bin_op(ops, |lhs, rhs| lhs.sub(rhs).value)
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_bin_op(ops, self.fast_math_flags(ctx), |lhs, rhs| {
+            lhs.sub(rhs).value
+        })
     }
     fn fold_in_place(
         &self,

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -3623,7 +3623,7 @@ pub enum SelectOpVerifyErr {
 /// | `res` | float |
 #[pliron_op(
     name = "llvm.fneg",
-    format = "attr($llvm_fast_math_flags, $FastmathFlagsAttr) $0 ` : ` type($0)",
+    format = "attr($llvm_fast_math_flags, $FastmathFlagsAttr) ` ` $0 ` : ` type($0)",
     interfaces = [
         OneResultInterface,
         OneOpdInterface,

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1179,3 +1179,276 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// llvm.fneg
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fneg_folds_constant() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        c = llvm.fneg <> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("-2.5"));
+    Ok(())
+}
+
+#[test]
+fn fneg_folds_negative_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single -0.0> : builtin.fp32;
+        c = llvm.fneg <> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    // The result is positive zero; it must not still be -0.0.
+    assert!(after.contains("<builtin.single 0> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn fneg_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        c = llvm.fneg <> x : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fneg_folds_positive_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fneg <> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single -Inf> : builtin.fp32").count(), 1);
+    Ok(())
+}
+
+#[test]
+fn fneg_folds_negative_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single -Inf> : builtin.fp32;
+        c = llvm.fneg <> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single +Inf> : builtin.fp32").count(), 1);
+    Ok(())
+}
+
+#[test]
+fn fneg_folds_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        c = llvm.fneg <> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 2);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.fadd
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fadd_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fadd <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 6.5> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn fadd_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fadd <> x, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fadd_folds_infinity_and_finite() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        c = llvm.fadd <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single +Inf> : builtin.fp32").count(), 2);
+    Ok(())
+}
+
+#[test]
+fn fadd_folds_opposite_infinities_to_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single -Inf> : builtin.fp32;
+        c = llvm.fadd <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 1);
+    Ok(())
+}
+
+#[test]
+fn fadd_folds_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        b = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        c = llvm.fadd <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 2);
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.fsub
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fsub_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 10.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        c = llvm.fsub <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 7.5> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn fsub_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        b = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        c = llvm.fsub <> x, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fsub_folds_finite_minus_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fsub <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single -Inf> : builtin.fp32").count(), 1);
+    Ok(())
+}
+
+#[test]
+fn fsub_folds_equal_infinities_to_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fsub <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 1);
+    Ok(())
+}
+
+#[test]
+fn fsub_folds_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        b = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        c = llvm.fsub <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 2);
+    Ok(())
+}

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1243,7 +1243,12 @@ fn fneg_folds_positive_infinity() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single -Inf> : builtin.fp32").count(), 1);
+    assert_eq!(
+        after
+            .matches("<builtin.single -Inf> : builtin.fp32")
+            .count(),
+        1
+    );
     Ok(())
 }
 
@@ -1259,7 +1264,12 @@ fn fneg_folds_negative_infinity() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single +Inf> : builtin.fp32").count(), 1);
+    assert_eq!(
+        after
+            .matches("<builtin.single +Inf> : builtin.fp32")
+            .count(),
+        1
+    );
     Ok(())
 }
 
@@ -1275,7 +1285,10 @@ fn fneg_folds_nan() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 2);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        2
+    );
     Ok(())
 }
 
@@ -1328,7 +1341,12 @@ fn fadd_folds_infinity_and_finite() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single +Inf> : builtin.fp32").count(), 2);
+    assert_eq!(
+        after
+            .matches("<builtin.single +Inf> : builtin.fp32")
+            .count(),
+        2
+    );
     Ok(())
 }
 
@@ -1345,7 +1363,10 @@ fn fadd_folds_opposite_infinities_to_nan() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 1);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        1
+    );
     Ok(())
 }
 
@@ -1362,7 +1383,10 @@ fn fadd_folds_nan() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 2);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        2
+    );
     Ok(())
 }
 
@@ -1415,7 +1439,12 @@ fn fsub_folds_finite_minus_infinity() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single -Inf> : builtin.fp32").count(), 1);
+    assert_eq!(
+        after
+            .matches("<builtin.single -Inf> : builtin.fp32")
+            .count(),
+        1
+    );
     Ok(())
 }
 
@@ -1432,7 +1461,10 @@ fn fsub_folds_equal_infinities_to_nan() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 1);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        1
+    );
     Ok(())
 }
 
@@ -1449,6 +1481,9 @@ fn fsub_folds_nan() -> Result<()> {
     "#;
     let (status, _before, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<builtin.single NaN> : builtin.fp32").count(), 2);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        2
+    );
     Ok(())
 }

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1292,6 +1292,52 @@ fn fneg_folds_nan() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn fneg_nnan_does_not_fold_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        c = llvm.fneg <NNAN> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fneg_ninf_does_not_fold_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fneg <NINF> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fneg_nnan_still_folds_finite() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        c = llvm.fneg <NNAN> a : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("-2.5"));
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // llvm.fadd
 // ---------------------------------------------------------------------------
@@ -1390,6 +1436,55 @@ fn fadd_folds_nan() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn fadd_ninf_does_not_fold_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        c = llvm.fadd <NINF> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fadd_nnan_does_not_fold_nan_result() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single -Inf> : builtin.fp32;
+        c = llvm.fadd <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fadd_nnan_still_folds_finite() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fadd <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 6.5> : builtin.fp32"));
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // llvm.fsub
 // ---------------------------------------------------------------------------
@@ -1485,5 +1580,21 @@ fn fsub_folds_nan() -> Result<()> {
         after.matches("<builtin.single NaN> : builtin.fp32").count(),
         2
     );
+    Ok(())
+}
+
+#[test]
+fn fsub_nnan_does_not_fold_nan_result() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fsub <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }

--- a/src/builtin/attributes.rs
+++ b/src/builtin/attributes.rs
@@ -403,6 +403,30 @@ impl FloatAttr for FPDoubleAttr {
     }
 }
 
+#[attr_interface_impl]
+impl MaterializableAttr for FPHalfAttr {
+    fn materialize(&self, ctx: &mut Context) -> Ptr<Operation> {
+        let const_op = ConstantOp::new(ctx, Box::new(self.clone()));
+        const_op.get_operation()
+    }
+}
+
+#[attr_interface_impl]
+impl MaterializableAttr for FPSingleAttr {
+    fn materialize(&self, ctx: &mut Context) -> Ptr<Operation> {
+        let const_op = ConstantOp::new(ctx, Box::new(self.clone()));
+        const_op.get_operation()
+    }
+}
+
+#[attr_interface_impl]
+impl MaterializableAttr for FPDoubleAttr {
+    fn materialize(&self, ctx: &mut Context) -> Ptr<Operation> {
+        let const_op = ConstantOp::new(ctx, Box::new(self.clone()));
+        const_op.get_operation()
+    }
+}
+
 /// An attribute that is a dictionary of other attributes.
 /// Similar to MLIR's [DictionaryAttr](https://mlir.llvm.org/docs/Dialects/Builtin/#dictionaryattr),
 #[pliron_attr(name = "builtin.dict", verifier = "succ")]

--- a/src/utils/apfloat.rs
+++ b/src/utils/apfloat.rs
@@ -95,17 +95,19 @@ pub fn float_parse<'a, T: Float>(
     _arg: (),
 ) -> ParseResult<'a, T> {
     // Parse characters allowed in a float literal.
-    // Digits, decimal point, exponent, and sign.
+    // Digits, decimal point, exponent, and sign, plus the letters and
+    // that appear in the special values `+Inf`, `-Inf`, and `NaN`.
 
     let loc = state_stream.loc();
 
     let mut allowed_chars = combine::many1::<String, _, _>(
-        char::digit()
-            .or(char::char('E'))
-            .or(char::char('e'))
+        char::letter()
+            .or(char::digit())
             .or(char::char('+'))
             .or(char::char('-'))
-            .or(char::char('.')),
+            .or(char::char('.'))
+            .or(char::char('('))
+            .or(char::char(')')),
     );
 
     let (f_str, _) = allowed_chars
@@ -901,6 +903,38 @@ mod tests {
         for v in values {
             print_and_parse(v, &mut Context::default())
         }
+        Ok(())
+    }
+
+    /// The printed forms of infinity (`+Inf`/`-Inf`) must round-trip through the
+    /// parser.
+    #[test]
+    fn test_single_print_parse_infinity() -> Result<(), ParseError> {
+        let ctx = &mut Context::default();
+        print_and_parse(Single::from_str("+Inf")?, ctx);
+        print_and_parse(Single::from_str("-Inf")?, ctx);
+        Ok(())
+    }
+
+    /// NaN prints as `NaN`, which must parse back to a NaN. NaN is not equal to
+    /// itself, so this checks the category rather than using `print_and_parse`.
+    #[test]
+    fn test_single_print_parse_nan() -> Result<(), ParseError> {
+        use rustc_apfloat::Float;
+
+        let ctx = &mut Context::default();
+        let nan = Single::from_str("NaN")?;
+        let s = nan.disp(ctx).to_string();
+        let parsed = {
+            let mut state_stream = state_stream_from_iterator(
+                s.chars(),
+                parsable::State::new(ctx, location::Source::InMemory),
+            );
+            Single::parse(&mut state_stream, ())
+                .unwrap_or_else(|e| panic!("{}\nError parsing {}", e.into_inner().error, s))
+                .0
+        };
+        assert!(parsed.is_nan(), "Failed to round-trip NaN, got {}", parsed.disp(ctx));
         Ok(())
     }
 

--- a/src/utils/apfloat.rs
+++ b/src/utils/apfloat.rs
@@ -105,9 +105,7 @@ pub fn float_parse<'a, T: Float>(
             .or(char::digit())
             .or(char::char('+'))
             .or(char::char('-'))
-            .or(char::char('.'))
-            .or(char::char('('))
-            .or(char::char(')')),
+            .or(char::char('.')),
     );
 
     let (f_str, _) = allowed_chars

--- a/src/utils/apfloat.rs
+++ b/src/utils/apfloat.rs
@@ -934,7 +934,11 @@ mod tests {
                 .unwrap_or_else(|e| panic!("{}\nError parsing {}", e.into_inner().error, s))
                 .0
         };
-        assert!(parsed.is_nan(), "Failed to round-trip NaN, got {}", parsed.disp(ctx));
+        assert!(
+            parsed.is_nan(),
+            "Failed to round-trip NaN, got {}",
+            parsed.disp(ctx)
+        );
         Ok(())
     }
 


### PR DESCRIPTION
This PR works toward https://github.com/pliron-org/pliron/issues/115 but does not close the issue.

It implements `ConstFoldInterface` for the llvm dialect's `fneg`, `fadd`, and `fsub`.

## Parsing `+Inf`, `-Inf`, and `NaN`

Previously, pliron did not have the ability to parse the special floating-point values `+Inf`, `-Inf`, and `NaN`. Given that these are important special-case values which we want to include in tests, the parser was modified to recognize them.

## Minor fix: Parsing `fneg` operations

The format string for `fneg` did not include a space after its attribute section `< ... >`. This PR includes a fix that adds the space.

## `nnan` and `ninf`

All three operations have `nnan` and `ninf` flags. If `nnan` is true, the operation's behavior is undefined if any argument or result is `NaN`. Likewise `ninf` produces undefined behavior when any operation or result is equal to `+Inf` or `-Inf`.

In such cases, the const folding implementations will refrain from performing any folding.
