### PR TITLE
add return op and unmaterialized conversion cast op and HasTerminator interface

### DIFF
--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -51,45 +51,44 @@ pub enum HasTerminatorInterfaceVerifyErr {
     NoTerminatorError,
 }
 #[op_interface]
-pub trait HasTerminatorInterface<T: Op + IsTerminatorInterface>: AtMostOneRegionInterface {
+pub trait HasTerminatorInterface<T: Op + IsTerminatorInterface> {
     fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
     where
         Self: Sized,
     {
-        let Some(region) = op_cast::<dyn AtMostOneRegionInterface>(op)
-            .expect("Trait system statically implies OneRegionInterface")
-            .get_region(ctx)
-        else {
-            return Ok(());
-        };
-
-        for block in region.deref(ctx).iter(ctx) {
-            // `get_tail` yields a `Ptr<Operation>`; materialize an `Op` trait
-            // object so we can cast it to interfaces / concrete op types.
-            let tail_op = block.deref(ctx).get_tail().ok_or_else(|| {
-                verify_error!(op.loc(ctx), HasTerminatorInterfaceVerifyErr::NoTerminatorError)
-            })?;
-            let tail_op = Operation::get_op_dyn(tail_op, ctx);
-
-
-            // if we have a block we need to have a terminator
-            op_cast::<dyn IsTerminatorInterface>(&*tail_op).ok_or_else(|| {
-                verify_error!(
-                    tail_op.loc(ctx),
-                    HasTerminatorInterfaceVerifyErr::NoTerminatorError
-                )
-            })?;
-
-            // the terminator needs to be of an exact specific type
-            tail_op.is::<T>().then_some(()).ok_or_else(|| {
-                verify_error!(
-                    tail_op.loc(ctx),
-                    HasTerminatorInterfaceVerifyErr::WrongTerminatorError(
-                        T::get_opid_static().disp(ctx).to_string(),
-                        tail_op.get_opid().disp(ctx).to_string(),
+        // Every block of every region must end with a terminator of type `T`.
+        let regions: Vec<Ptr<Region>> = op.get_operation().deref(ctx).regions().collect();
+        for region in regions {
+            for block in region.deref(ctx).iter(ctx) {
+                // `get_tail` yields a `Ptr<Operation>`; materialize an `Op` trait
+                // object so we can cast it to interfaces / concrete op types.
+                let tail_op = block.deref(ctx).get_tail().ok_or_else(|| {
+                    verify_error!(
+                        op.loc(ctx),
+                        HasTerminatorInterfaceVerifyErr::NoTerminatorError
                     )
-                )
-            })?;
+                })?;
+                let tail_op = Operation::get_op_dyn(tail_op, ctx);
+
+                // if we have a block we need to have a terminator
+                op_cast::<dyn IsTerminatorInterface>(&*tail_op).ok_or_else(|| {
+                    verify_error!(
+                        tail_op.loc(ctx),
+                        HasTerminatorInterfaceVerifyErr::NoTerminatorError
+                    )
+                })?;
+
+                // the terminator needs to be of an exact specific type
+                tail_op.is::<T>().then_some(()).ok_or_else(|| {
+                    verify_error!(
+                        tail_op.loc(ctx),
+                        HasTerminatorInterfaceVerifyErr::WrongTerminatorError(
+                            T::get_opid_static().disp(ctx).to_string(),
+                            tail_op.get_opid().disp(ctx).to_string(),
+                        )
+                    )
+                })?;
+            }
         }
         Ok(())
     }

--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -44,6 +44,59 @@ pub trait IsTerminatorInterface {
 }
 
 #[derive(Error, Debug)]
+pub enum HasTerminatorInterfaceVerifyErr {
+    #[error("Wrong Terminator OpType. Expected {0}, but found {1} at block")]
+    WrongTerminatorError(String, String),
+    #[error("No terminator found for op")]
+    NoTerminatorError,
+}
+#[op_interface]
+pub trait HasTerminatorInterface<T: Op + IsTerminatorInterface>: AtMostOneRegionInterface {
+    fn verify(op: &dyn Op, ctx: &Context) -> Result<()>
+    where
+        Self: Sized,
+    {
+        let Some(region) = op_cast::<dyn AtMostOneRegionInterface>(op)
+            .expect("Trait system statically implies OneRegionInterface")
+            .get_region(ctx)
+        else {
+            return Ok(());
+        };
+
+        for block in region.deref(ctx).iter(ctx) {
+            let Some(tail_op) = block.deref(ctx).get_tail() else {
+                return verify_err!(
+                    op.loc(ctx),
+                    HasTerminatorInterfaceVerifyErr::NoTerminatorError
+                );
+            };
+
+            // `get_tail` yields a `Ptr<Operation>`; materialize an `Op` trait
+            // object so we can cast it to interfaces / concrete op types.
+            let tail_op = Operation::get_op_dyn(tail_op, ctx);
+
+            if op_cast::<dyn IsTerminatorInterface>(&*tail_op).is_none() {
+                return verify_err!(
+                    tail_op.loc(ctx),
+                    HasTerminatorInterfaceVerifyErr::NoTerminatorError
+                );
+            };
+
+            if !tail_op.is::<T>() {
+                return verify_err!(
+                    tail_op.loc(ctx),
+                    HasTerminatorInterfaceVerifyErr::WrongTerminatorError(
+                        T::get_opid_static().disp(ctx).to_string(),
+                        tail_op.get_opid().disp(ctx).to_string(),
+                    )
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Error, Debug)]
 pub enum BranchOpInterfaceVerifyErr {
     #[error("Branch Op is passing {provided} arguments, but target block expects {expected}")]
     SuccessorOperandsMismatch { provided: usize, expected: usize },

--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -64,33 +64,32 @@ pub trait HasTerminatorInterface<T: Op + IsTerminatorInterface>: AtMostOneRegion
         };
 
         for block in region.deref(ctx).iter(ctx) {
-            let Some(tail_op) = block.deref(ctx).get_tail() else {
-                return verify_err!(
-                    op.loc(ctx),
-                    HasTerminatorInterfaceVerifyErr::NoTerminatorError
-                );
-            };
-
             // `get_tail` yields a `Ptr<Operation>`; materialize an `Op` trait
             // object so we can cast it to interfaces / concrete op types.
+            let tail_op = block.deref(ctx).get_tail().ok_or_else(|| {
+                verify_error!(op.loc(ctx), HasTerminatorInterfaceVerifyErr::NoTerminatorError)
+            })?;
             let tail_op = Operation::get_op_dyn(tail_op, ctx);
 
-            if op_cast::<dyn IsTerminatorInterface>(&*tail_op).is_none() {
-                return verify_err!(
+
+            // if we have a block we need to have a terminator
+            op_cast::<dyn IsTerminatorInterface>(&*tail_op).ok_or_else(|| {
+                verify_error!(
                     tail_op.loc(ctx),
                     HasTerminatorInterfaceVerifyErr::NoTerminatorError
-                );
-            };
+                )
+            })?;
 
-            if !tail_op.is::<T>() {
-                return verify_err!(
+            // the terminator needs to be of an exact specific type
+            tail_op.is::<T>().then_some(()).ok_or_else(|| {
+                verify_error!(
                     tail_op.loc(ctx),
                     HasTerminatorInterfaceVerifyErr::WrongTerminatorError(
                         T::get_opid_static().disp(ctx).to_string(),
                         tail_op.get_opid().disp(ctx).to_string(),
                     )
-                );
-            }
+                )
+            })?;
         }
         Ok(())
     }

--- a/src/builtin/ops.rs
+++ b/src/builtin/ops.rs
@@ -10,8 +10,8 @@ use crate::{
     basic_block::BasicBlock,
     builtin::{
         op_interfaces::{
-            ATTR_KEY_SYM_NAME, NRegionsInterface, NResultsInterface, NoTerminatorInterface,
-            RegionKind, RegionKindInterface,
+            ATTR_KEY_SYM_NAME, IsTerminatorInterface, NRegionsInterface, NResultsInterface,
+            NoTerminatorInterface, RegionKind, RegionKindInterface,
         },
         ops::func_op_attr_names::ATTR_KEY_FUNC_TYPE,
         type_interfaces::FunctionTypeInterface,
@@ -34,6 +34,7 @@ use crate::{
     region::Region,
     result::Result,
     r#type::{TypeHandle, Typed, TypedHandle},
+    value::Value,
     verify_err,
 };
 use pliron::derive::{op_interface_impl, pliron_op};
@@ -283,6 +284,67 @@ impl Verify for FuncOp {
             return verify_err!(op.loc(), FuncOpTypeErr);
         }
         Ok(())
+    }
+}
+
+/// An undrealized conversion from one set of types to antoher
+/// See MLIR's [UnrealizedConversionCastOp](https://mlir.llvm.org/docs/Dialects/Builtin/#builtinunrealized_conversion_cast-unrealizedconversioncastop)
+///
+#[pliron_op(
+    name = "builtin.unrealized_conversion_cast",
+    interfaces = [
+    ],
+    format = "`%`$0 ` -> ` type($0)",
+    verifier = "succ",
+)]
+pub struct UnrealizedConversionCastOp;
+
+impl UnrealizedConversionCastOp {
+    /// Create a new [UnrealizedConversionCastOp].
+    pub fn new(ctx: &mut Context, operands: Vec<Value>, result_types: Vec<TypeHandle>) -> Self {
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            result_types,
+            operands,
+            vec![],
+            0,
+        );
+        UnrealizedConversionCastOp { op }
+    }
+}
+
+/// A minimal void terminator suitable for `builtin.func` bodies.
+///
+/// Pliron's [`FuncOp`] requires its body block to end with a terminator
+/// ([`IsTerminatorInterface`]) but ships no return-style op of its own. This
+/// op fills that gap — no operands, no results, no semantics beyond
+/// "structural terminator". For functions that return values, dialects can
+/// supply their own typed return op; this one is for the void case (the
+/// common shape in tests and in dialects whose state-passing happens through
+/// other means, e.g. the qc dialect's reference semantics).
+///
+/// See MLIR's `func.return` for the typed analogue in the func dialect.
+#[pliron_op(
+    name = "builtin.return",
+    format = "operands(CharSpace(`,`))",
+    interfaces = [IsTerminatorInterface, NResultsInterface<0>],
+    verifier = "succ",
+)]
+pub struct ReturnOp;
+
+impl ReturnOp {
+    /// Create a new [`ReturnOp`].
+    pub fn new(ctx: &mut Context, operands: Vec<Value>) -> Self {
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![],
+            operands,
+            vec![],
+            0,
+        );
+        ReturnOp { op }
     }
 }
 

--- a/tests/cloning.rs
+++ b/tests/cloning.rs
@@ -152,7 +152,7 @@ fn clone_blocks_remaps_branches_and_block_args() -> Result<()> {
     let block_b = BasicBlock::new(ctx, None, vec![i64_ty.into()]);
     block_b.insert_at_back(region, ctx);
     let b_arg = block_b.deref(ctx).get_argument(0);
-    ReturnOp::new(ctx, b_arg)
+    ReturnOp::new(ctx, vec![b_arg])
         .get_operation()
         .insert_at_back(block_b, ctx);
 
@@ -304,7 +304,7 @@ fn clone_blocks_resolves_op_result_forward_ref_in_any_order() -> Result<()> {
         0,
     )
     .insert_at_back(block_a, ctx);
-    ReturnOp::new(ctx, c_val)
+    ReturnOp::new(ctx, vec![c_val])
         .get_operation()
         .insert_at_back(block_b, ctx);
 
@@ -394,7 +394,7 @@ fn clone_blocks_keeps_external_value_shared() -> Result<()> {
         0,
     )
     .insert_at_back(block_a, ctx);
-    ReturnOp::new(ctx, c_val)
+    ReturnOp::new(ctx, vec![c_val])
         .get_operation()
         .insert_at_back(block_b, ctx);
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,8 +4,8 @@ use pliron::{
     builtin::{
         attributes::IntegerAttr,
         op_interfaces::{
-            IsTerminatorInterface, NOpdsInterface, NResultsInterface, NResultsVerifyErr,
-            OneResultInterface, SingleBlockRegionInterface,
+            NOpdsInterface, NResultsInterface, NResultsVerifyErr, OneResultInterface,
+            SingleBlockRegionInterface,
         },
         ops::{FuncOp, ModuleOp},
         types::{FunctionType, IntegerType, Signedness},
@@ -23,29 +23,9 @@ use pliron::{
     printable::{self, Printable},
     result::Result,
     utils::apint::APInt,
-    value::Value,
 };
 
-#[pliron_op(
-    name = "test.return",
-    format = "$0",
-    interfaces = [IsTerminatorInterface],
-    verifier = "succ",
-)]
-pub struct ReturnOp;
-impl ReturnOp {
-    pub fn new(ctx: &mut Context, value: Value) -> Self {
-        let op = Operation::new(
-            ctx,
-            Self::get_concrete_op_info(),
-            vec![],
-            vec![value],
-            vec![],
-            0,
-        );
-        ReturnOp { op }
-    }
-}
+pub use pliron::builtin::ops::ReturnOp;
 
 mod constant_op {
     use pliron::dict_key;
@@ -156,7 +136,7 @@ pub fn const_ret_in_mod(ctx: &mut Context) -> Result<(ModuleOp, FuncOp, Constant
     );
 
     // Return the constant.
-    let ret_op = ReturnOp::new(ctx, const_op.get_result(ctx));
+    let ret_op = ReturnOp::new(ctx, vec![const_op.get_result(ctx)]);
     ret_op.get_operation().insert_at_back(bb, ctx);
 
     verify_op(&module, ctx)?;

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -988,7 +988,7 @@ fn test_outline_printonce_attr() -> Result<()> {
                 c0_v2 = test.constant builtin.integer <0: si64> !0;
                 v0 = test.constant builtin.integer <42: si64> !1;
                 v1 = test.constant builtin.integer <44: si64> !2;
-                test.return c0_v2
+                builtin.return c0_v2
             }
         }
 
@@ -1030,7 +1030,7 @@ fn test_outline_printonce_attr() -> Result<()> {
                 c0_v3 = test.constant builtin.integer <0: si64> !2;
                 v0_v4 = test.constant builtin.integer <42: si64> !3;
                 v1_v5 = test.constant builtin.integer <44: si64> !4;
-                test.return c0_v3 !5
+                builtin.return c0_v3 !5
             } !6
         } !7
 
@@ -1122,7 +1122,7 @@ fn test_outline_attr_on_block() -> Result<()> {
             {
               ^entry_block2v1() !0:
                 c0_v0 = test.constant builtin.integer <0: si64> !1;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }
 
@@ -1155,7 +1155,7 @@ fn test_outline_attr_on_block() -> Result<()> {
             {
               ^entry_block2v1_block3v1() !1:
                 c0_v1 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_v1 !3
+                builtin.return c0_v1 !3
             } !4
         } !5
 

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -123,7 +123,7 @@ fn replace_c0_with_c1_operand() -> Result<()> {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
                 c1_v1 = test.constant builtin.integer <1: si64> !1;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }
 
@@ -145,7 +145,7 @@ fn replace_c0_with_c1_operand() -> Result<()> {
             {
               ^entry_block2v1():
                 c1_v1 = test.constant builtin.integer <1: si64> !0;
-                test.return c1_v1
+                builtin.return c1_v1
             }
         }
 
@@ -201,7 +201,7 @@ fn test_replace_within_same_def_site() {
               ^entry_block2v1():
                 c0_v2 = test.constant builtin.integer <0: si64> !0;
                 v0, v1 = test.dual_def () [] []: <() -> (builtin.integer si64, builtin.integer si64)>;
-                test.return v1
+                builtin.return v1
             }
         }
 
@@ -216,7 +216,7 @@ fn test_replace_within_same_def_site() {
         dual_arg_block.deref(ctx).get_argument(1),
     );
     dual_arg_block.insert_after(ctx, func_op.get_entry_block(ctx));
-    let ret_op = ReturnOp::new(ctx, arg1);
+    let ret_op = ReturnOp::new(ctx, vec![arg1]);
     ret_op.get_operation().insert_at_back(dual_arg_block, ctx);
     arg1.replace_some_uses_with(ctx, |_, _| true, &arg2);
 
@@ -230,10 +230,10 @@ fn test_replace_within_same_def_site() {
               ^entry_block2v1():
                 c0_v2 = test.constant builtin.integer <0: si64> !0;
                 v0, v1 = test.dual_def () [] []: <() -> (builtin.integer si64, builtin.integer si64)>;
-                test.return v1
+                builtin.return v1
 
               ^block3v1(v3: builtin.integer si64, v4: builtin.integer si64):
-                test.return v4
+                builtin.return v4
             }
         }
 
@@ -669,7 +669,7 @@ fn test_result_index_tracking_with_uses() -> Result<()> {
     let r1 = dual_op.deref(ctx).get_result(1);
 
     // Build a user op that holds r0 as its first operand, r1 as its second.
-    let user_op = ReturnOp::new(ctx, r0).get_operation();
+    let user_op = ReturnOp::new(ctx, vec![r0]).get_operation();
     Operation::push_operand(user_op, ctx, r1);
 
     // Sanity: operands are r0 and r1; their result indices are 0 and 1.
@@ -734,7 +734,7 @@ fn test_block_arg_index_tracking_with_uses() -> Result<()> {
     let a1 = block.deref(ctx).get_argument(1);
 
     // Build a user op that holds a0 as its first operand, a1 as its second.
-    let user_op = ReturnOp::new(ctx, a0).get_operation();
+    let user_op = ReturnOp::new(ctx, vec![a0]).get_operation();
     Operation::push_operand(user_op, ctx, a1);
 
     // Sanity: operands are a0 and a1; their argument indices are 0 and 1.
@@ -798,11 +798,11 @@ fn test_successor_push_pop_insert_remove() -> Result<()> {
     let succ2 = BasicBlock::new(ctx, None, vec![]);
     succ2.insert_after(ctx, succ1);
 
-    let succ0_ret = ReturnOp::new(ctx, const_op.get_result(ctx));
+    let succ0_ret = ReturnOp::new(ctx, vec![const_op.get_result(ctx)]);
     succ0_ret.get_operation().insert_at_back(succ0, ctx);
-    let succ1_ret = ReturnOp::new(ctx, const_op.get_result(ctx));
+    let succ1_ret = ReturnOp::new(ctx, vec![const_op.get_result(ctx)]);
     succ1_ret.get_operation().insert_at_back(succ1, ctx);
-    let succ2_ret = ReturnOp::new(ctx, const_op.get_result(ctx));
+    let succ2_ret = ReturnOp::new(ctx, vec![const_op.get_result(ctx)]);
     succ2_ret.get_operation().insert_at_back(succ2, ctx);
 
     let branch_like = Operation::new(
@@ -963,7 +963,7 @@ fn print_simple() -> Result<()> {
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }
 
@@ -984,7 +984,7 @@ fn parse_simple() -> Result<()> {
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> {
             ^entry_block_1_0():
                 c0_op_2_0_res0 = test.constant builtin.integer <0: si64>;
-                test.return c0_op_2_0_res0
+                builtin.return c0_op_2_0_res0
             ^exit(a : builtin.integer si32):
             }
         }"#;
@@ -1033,7 +1033,7 @@ fn parse_function_with_attrs() -> Result<()> {
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }
 
@@ -1061,7 +1061,7 @@ fn parse_function_with_attrs() -> Result<()> {
             {
               ^entry_block2v1_block3v1() !1:
                 c0_v1 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_v1 !3
+                builtin.return c0_v1 !3
             } !4
         } !5
 
@@ -1102,7 +1102,7 @@ fn parse_err_multiple_def() {
             ^entry_block_1_0():
                 c0_op_2_0_res0 = test.constant builtin.integer <0 : si64>;
                 c0_op_2_0_res0 = test.constant builtin.integer <0 : si64>;
-                test.return c0_op_2_0_res0
+                builtin.return c0_op_2_0_res0
             ^exit():
             }
         }"#;
@@ -1119,7 +1119,7 @@ fn parse_err_multiple_def() {
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> {
             ^entry_block_1_0():
                 c0_op_2_0_res0 = test.constant builtin.integer <0: si64>;
-                test.return c0_op_2_0_res0
+                builtin.return c0_op_2_0_res0
             ^entry_block_1_0():
             }
         }"#;
@@ -1139,7 +1139,7 @@ fn parse_err_unresolved_def() {
         ^block_0_0():
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> {
             ^entry_block_1_0():
-                test.return c0_op_2_0_res0
+                builtin.return c0_op_2_0_res0
             }
         }"#;
 
@@ -1159,7 +1159,7 @@ fn parse_err_block_label_colon() {
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> {
             ^entry_block_1_0():
                 c0_op_2_0_res0 = test.constant builtin.integer <0: si64>;
-                test.return c0_op_2_0_res0
+                builtin.return c0_op_2_0_res0
             ^exit()
             }
         }"#;
@@ -1221,7 +1221,7 @@ fn test_preorder_forward_walk() {
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }
 
@@ -1232,10 +1232,10 @@ fn test_preorder_forward_walk() {
         {
           ^entry_block2v1():
             c0_v0 = test.constant builtin.integer <0: si64> !0;
-            test.return c0_v0
+            builtin.return c0_v0
         }
         c0_v0 = test.constant builtin.integer <0: si64> !0
-        test.return c0_v0
+        builtin.return c0_v0
     "#]]
     .assert_eq(&ops);
 
@@ -1301,7 +1301,7 @@ fn walker_print() {
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }
 
@@ -1312,10 +1312,10 @@ fn walker_print() {
         {
           ^entry_block2v1():
             c0_v0 = test.constant builtin.integer <0: si64> !0;
-            test.return c0_v0
+            builtin.return c0_v0
         }
         c0_v0 = test.constant builtin.integer <0: si64> !0
-        test.return c0_v0
+        builtin.return c0_v0
     "#]]
     .assert_eq(&printed);
 }
@@ -1345,12 +1345,12 @@ fn test_postorder_forward_walk() {
     });
     expect![[r#"
         c0_v0 = test.constant builtin.integer <0: si64> !0
-        test.return c0_v0
+        builtin.return c0_v0
         builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
         {
           ^entry_block2v1():
             c0_v0 = test.constant builtin.integer <0: si64> !0;
-            test.return c0_v0
+            builtin.return c0_v0
         }
         builtin.module @bar 
         {
@@ -1359,7 +1359,7 @@ fn test_postorder_forward_walk() {
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }
 
@@ -1440,7 +1440,7 @@ fn test_verify_multiple_terminator() -> Result<()> {
 
     verify_op(&module_op, ctx)?;
 
-    let ret2_op = ReturnOp::new(ctx, const_op.get_result(ctx));
+    let ret2_op = ReturnOp::new(ctx, vec![const_op.get_result(ctx)]);
     ret2_op
         .get_operation()
         .insert_before(ctx, ret_op.get_operation());
@@ -1489,11 +1489,11 @@ fn test_verify_operation_fails_on_undominated_op_result_use() {
 
     let def_op = ConstantOp::new(ctx, 0);
     def_op.get_operation().insert_at_back(b1, ctx);
-    ReturnOp::new(ctx, def_op.get_result(ctx))
+    ReturnOp::new(ctx, vec![def_op.get_result(ctx)])
         .get_operation()
         .insert_at_back(b1, ctx);
 
-    ReturnOp::new(ctx, def_op.get_result(ctx))
+    ReturnOp::new(ctx, vec![def_op.get_result(ctx)])
         .get_operation()
         .insert_at_back(b2, ctx);
 
@@ -1532,10 +1532,10 @@ fn test_verify_operation_fails_on_undominated_block_argument_use() {
 
     let b1_arg0 = b1.deref(ctx).get_argument(0);
 
-    ReturnOp::new(ctx, b1_arg0)
+    ReturnOp::new(ctx, vec![b1_arg0])
         .get_operation()
         .insert_at_back(b1, ctx);
-    ReturnOp::new(ctx, b1_arg0)
+    ReturnOp::new(ctx, vec![b1_arg0])
         .get_operation()
         .insert_at_back(b2, ctx);
 
@@ -1568,7 +1568,7 @@ fn block_inline_attrs_print() -> Result<()> {
             {
               ^entry_block2v1() [block_test_attr: builtin.string "test_value"]:
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }"#]]
     .assert_eq(&printed);
@@ -1584,7 +1584,7 @@ fn block_inline_attrs_roundtrip() -> Result<()> {
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> {
             ^entry_block_1_0() [block_attr: builtin.string "hello"]:
                 c0_op_2_0_res0 = test.constant builtin.integer <0: si64>;
-                test.return c0_op_2_0_res0
+                builtin.return c0_op_2_0_res0
             }
         }"#;
 
@@ -1647,7 +1647,7 @@ fn block_multiple_inline_attrs() -> Result<()> {
             {
               ^entry_block2v1() [attr1: builtin.string "value1", attr2: builtin.string "value2"]:
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
             }
         }"#]]
     .assert_eq(&printed);
@@ -1664,7 +1664,7 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> {
             ^entry_block_1_0() [block_attr: builtin.string "hello"]:
                 c0_op_2_0_res0 = test.constant builtin.integer <0: si64>;
-                test.return c0_op_2_0_res0
+                builtin.return c0_op_2_0_res0
             }
         }"#;
 
@@ -1694,7 +1694,7 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
             {
               ^entry_block_1_0_block1v1() [block_attr: builtin.string "hello"] !1:
                 c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_op_2_0_res0_v0 !3
+                builtin.return c0_op_2_0_res0_v0 !3
             } !4
         } !5
 
@@ -1731,7 +1731,7 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
             {
               ^entry_block_1_0_block1v1_block1v1() [block_attr: builtin.string "hello"] !1:
                 c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;
-                test.return c0_op_2_0_res0_v0 !3
+                builtin.return c0_op_2_0_res0_v0 !3
             } !4
         } !5
 

--- a/tests/rewriter.rs
+++ b/tests/rewriter.rs
@@ -214,7 +214,7 @@ fn replace_c0_with_c1() -> Result<()> {
             {
               ^entry_block2v1():
                 v2 = test.constant builtin.integer <2: si64>;
-                test.return v2
+                builtin.return v2
             }
         }"#]]
     .assert_eq(&printed);
@@ -359,7 +359,7 @@ fn scoped_rewriter_test() -> Result<()> {
             {
               ^entry_block2v1():
                 v2 = test.load v1 ;
-                test.return v2
+                builtin.return v2
             }
         }"#]].assert_eq(&printed);
 
@@ -471,7 +471,7 @@ fn split_block_after_const_zero() -> Result<()> {
                 .replace_all_uses_with(ctx, &const1_result);
 
             // Add a return at the end of old block to return the const0_op's result
-            let ret = ReturnOp::new(ctx, const0_op.get_result(ctx)).get_operation();
+            let ret = ReturnOp::new(ctx, vec![const0_op.get_result(ctx)]).get_operation();
             {
                 ScopedRewriter::new(rewriter, OpInsertionPoint::AtBlockEnd(block))
                     .insert_operation(ctx, ret);
@@ -502,11 +502,11 @@ fn split_block_after_const_zero() -> Result<()> {
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
 
               ^entry_split_block3v1():
                 v1 = test.constant builtin.integer <1: si64>;
-                test.return v1
+                builtin.return v1
             }
         }"#]]
     .assert_eq(&printed);
@@ -577,11 +577,11 @@ fn inline_region_on_const_zero() -> Result<()> {
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
-                test.return c0_v0
+                builtin.return c0_v0
 
               ^entry_block4v1():
                 c0_v1 = test.constant builtin.integer <0: si64> !1;
-                test.return c0_v1
+                builtin.return c0_v1
             }
         }"#]]
     .assert_eq(&printed);


### PR DESCRIPTION
Extend the builtin dialect with the following ops : 

UnrealizedConversionCastOp: same semantic as MLIR, a transient op/utility useful for transient states in type system conversions 

ReturnOp: Promoting the return op from test/common into builtin dialect.   Single change is to support variadic operands for returnOp, (to be coeherent with the FunctionType as it can represent variadic results )

Introducing HasTerminatorInterface<T> ,  potentially useful op_interface , which imposes a particular terminator to be used. Interplays nicely with Ops with GraphRegions, where there is no Terminator imposed by default, but a terminator would be useful to have coeherence in SSA chains  . 
Implementation however is not restricting to GraphRegions.  