### PR TITLE
feat: Allow printing input types via a nested `operands` directive

### DIFF
--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -434,7 +434,7 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
         } else if d.name == "type" {
             let err = Err(syn::Error::new_spanned(
                     input.ident.clone(),
-                    "The `type` directive takes a single unnamed variable argument to specify the result index, or the `operands` directive".to_string(),
+                    "The `type` directive takes a single unnamed variable argument to specify the result index".to_string(),
                 ));
             if d.args.len() != 1 {
                 return err;
@@ -450,7 +450,7 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
         } else if d.name == "opdtype" {
             let err = Err(syn::Error::new_spanned(
                     input.ident.clone(),
-                    "The `opdtype` directive takes a single unnamed variable argument to specify the result index, or the `operands` directive".to_string(),
+                    "The `opdtype` directive takes a single unnamed variable argument to specify the result index".to_string(),
                 ));
             if d.args.len() != 1 {
                 return err;

--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -450,7 +450,7 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
         } else if d.name == "opdtype" {
             let err = Err(syn::Error::new_spanned(
                     input.ident.clone(),
-                    "The `opdtype` directive takes a single unnamed variable argument to specify the result index".to_string(),
+                    "The `opdtype` directive takes a single unnamed variable argument to specify the operand index".to_string(),
                 ));
             if d.args.len() != 1 {
                 return err;
@@ -1411,9 +1411,10 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             }
         } else if d.name == "opdtype" {
             let err = Err(syn::Error::new_spanned(
-                    input.ident.clone(),
-                    "The `type` directive takes a single unnamed variable argument to specify the result index".to_string(),
-                ));
+                input.ident.clone(),
+                "The `opdtype` directive takes a single unnamed variable argument to specify the operand index"
+                    .to_string(),
+            ));
             if d.args.len() != 1 {
                 return err;
             }

--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -439,23 +439,26 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
             if d.args.len() != 1 {
                 return err;
             }
-            if let Elem::Directive(Directive { name, args, .. }) = &d.args[0]
-                && name == "operands"
-            {
-                let Elem::Directive(sep) = &args[0] else {
-                    return err;
-                };
-                let sep = directive_to_list_separator(sep, true, input.ident.span())?;
-                Ok(quote! {
-                    let op = self.get_operation().deref(ctx);
-                    let operand_types = op.operands().map(|opd| ::pliron::r#type::Typed::get_type(&opd, ctx));
-                    let operand_types = ::pliron::irfmt::printers::iter_with_sep(operand_types, #sep);
-                    ::pliron::printable::Printable::fmt(&operand_types, ctx, state, fmt)?;
-                })
-            } else if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
+            if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
                 Ok(quote! {
                     let res = self.get_operation().deref(ctx).get_type(#index);
                     ::pliron::printable::Printable::fmt(&res, ctx, state, fmt)?;
+                })
+            } else {
+                err
+            }
+        } else if d.name == "opdtype" {
+            let err = Err(syn::Error::new_spanned(
+                    input.ident.clone(),
+                    "The `opdtype` directive takes a single unnamed variable argument to specify the result index, or the `operands` directive".to_string(),
+                ));
+            if d.args.len() != 1 {
+                return err;
+            }
+            if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
+                Ok(quote! {
+                    let opd = ::pliron::r#type::Typed::get_type(&self.get_operation().deref(ctx).get_operand(#index), ctx);
+                    ::pliron::printable::Printable::fmt(&opd, ctx, state, fmt)?;
                 })
             } else {
                 err
@@ -610,6 +613,26 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
                 let types = op.result_types();
                 let types = ::pliron::irfmt::printers::iter_with_sep(types, #sep);
                 ::pliron::printable::Printable::fmt(&types, ctx, state, fmt)?;
+            })
+        } else if d.name == "opdtypes" {
+            let err = Err(syn::Error::new_spanned(
+                input.ident.clone(),
+                "The `opdtypes` directive takes a single argument to specify the separator.
+                    Refer to the documentation for details"
+                    .to_string(),
+            ));
+            if d.args.len() != 1 {
+                return err;
+            }
+            let Elem::Directive(sep) = &d.args[0] else {
+                return err;
+            };
+            let sep = directive_to_list_separator(sep, true, input.ident.span())?;
+            Ok(quote! {
+                let op = self.get_operation().deref(ctx);
+                let operand_types = op.operands().map(|opd| ::pliron::r#type::Typed::get_type(&opd, ctx));
+                let operand_types = ::pliron::irfmt::printers::iter_with_sep(operand_types, #sep);
+                ::pliron::printable::Printable::fmt(&operand_types, ctx, state, fmt)?;
             })
         } else if d.name == "typesig" {
             if !d.args.is_empty() {
@@ -1065,6 +1088,7 @@ struct OpParserState {
     regions_temp_parent_op: Option<syn::Ident>,
     operands: ElementSpec<usize>,
     successors: ElementSpec<usize>,
+    operand_types: ElementSpec<usize>,
     result_types: ElementSpec<usize>,
     // The second element specifies attribtues that are specified as optional.
     attributes: (ElementSpec<String>, FxHashSet<String>),
@@ -1365,19 +1389,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             if d.args.len() != 1 {
                 return err;
             }
-            if let Elem::Directive(dir) = &d.args[0]
-                && dir.name == "operands"
-            {
-                let Elem::Directive(sep) = &dir.args[0] else {
-                    return err;
-                };
-                let sep = directive_to_list_separator(sep, false, input.ident.span())?;
-                Ok(quote! {
-                    ::pliron::irfmt::parsers::list_parser(#sep, ::pliron::irfmt::parsers::type_parser())
-                        .parse_stream(state_stream)
-                        .into_result()?;
-                })
-            } else if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
+            if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
                 let res_type = format_ident!("res_{}", index);
                 match state.result_types {
                     ElementSpec::Individual(ref mut result_types) => {
@@ -1393,6 +1405,34 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
                 }
                 Ok(quote! {
                     let #res_type = ::pliron::irfmt::parsers::type_parser().parse_stream(state_stream).into_result()?.0;
+                })
+            } else {
+                err
+            }
+        } else if d.name == "opdtype" {
+            let err = Err(syn::Error::new_spanned(
+                    input.ident.clone(),
+                    "The `type` directive takes a single unnamed variable argument to specify the result index".to_string(),
+                ));
+            if d.args.len() != 1 {
+                return err;
+            }
+            if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
+                let opd_type = format_ident!("opd_{}", index);
+                match state.operand_types {
+                    ElementSpec::Individual(ref mut operand_types) => {
+                        operand_types.insert(*index, opd_type.clone());
+                    }
+                    ElementSpec::All(_) => {
+                        return Err(syn::Error::new_spanned(
+                            input.ident.clone(),
+                            "Cannot mix operand types directive with numbered operand types"
+                                .to_string(),
+                        ));
+                    }
+                }
+                Ok(quote! {
+                    ::pliron::irfmt::parsers::type_parser().parse_stream(state_stream).into_result()?.0;
                 })
             } else {
                 err
@@ -1636,6 +1676,28 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
                     .parse_stream(state_stream)
                     .into_result()?
                     .0;
+            })
+        } else if d.name == "opdtypes" {
+            let Some(Elem::Directive(sep)) = &d.args.first() else {
+                return Err(syn::Error::new_spanned(
+                    input.ident.clone(),
+                    "The `opdtypes` directive takes a single argument to specify the separator.
+                    Refer to the documentation for details"
+                        .to_string(),
+                ));
+            };
+            let sep = directive_to_list_separator(sep, false, input.ident.span())?;
+            if matches!(&state.operand_types, ElementSpec::Individual(operand_types) if !operand_types.is_empty())
+            {
+                return Err(syn::Error::new_spanned(
+                    input.ident.clone(),
+                    "Cannot mix operand types directive with numbered operand types".to_string(),
+                ));
+            }
+            Ok(quote! {
+                ::pliron::irfmt::parsers::list_parser(#sep, ::pliron::irfmt::parsers::type_parser())
+                    .parse_stream(state_stream)
+                    .into_result()?;
             })
         } else if d.name == "attr_dict" {
             let attr_sets_name = format_ident!("attr_sets");

--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -434,12 +434,25 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
         } else if d.name == "type" {
             let err = Err(syn::Error::new_spanned(
                     input.ident.clone(),
-                    "The `type` directive takes a single unnamed variable argument to specify the result index".to_string(),
+                    "The `type` directive takes a single unnamed variable argument to specify the result index, or the `operands` directive".to_string(),
                 ));
             if d.args.len() != 1 {
                 return err;
             }
-            if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
+            if let Elem::Directive(Directive { name, args, .. }) = &d.args[0]
+                && name == "operands"
+            {
+                let Elem::Directive(sep) = &args[0] else {
+                    return err;
+                };
+                let sep = directive_to_list_separator(sep, true, input.ident.span())?;
+                Ok(quote! {
+                    let op = self.get_operation().deref(ctx);
+                    let operand_types = op.operands().map(|opd| ::pliron::r#type::Typed::get_type(&opd, ctx));
+                    let operand_types = ::pliron::irfmt::printers::iter_with_sep(operand_types, #sep);
+                    ::pliron::printable::Printable::fmt(&operand_types, ctx, state, fmt)?;
+                })
+            } else if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
                 Ok(quote! {
                     let res = self.get_operation().deref(ctx).get_type(#index);
                     ::pliron::printable::Printable::fmt(&res, ctx, state, fmt)?;
@@ -1352,7 +1365,19 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             if d.args.len() != 1 {
                 return err;
             }
-            if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
+            if let Elem::Directive(dir) = &d.args[0]
+                && dir.name == "operands"
+            {
+                let Elem::Directive(sep) = &dir.args[0] else {
+                    return err;
+                };
+                let sep = directive_to_list_separator(sep, false, input.ident.span())?;
+                Ok(quote! {
+                    ::pliron::irfmt::parsers::list_parser(#sep, ::pliron::irfmt::parsers::type_parser())
+                        .parse_stream(state_stream)
+                        .into_result()?;
+                })
+            } else if let Elem::UnnamedVar(UnnamedVar { index, .. }) = &d.args[0] {
                 let res_type = format_ident!("res_{}", index);
                 match state.result_types {
                     ElementSpec::Individual(ref mut result_types) => {

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -455,14 +455,10 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   3. The "type" directive specifies that a type must be parsed. It takes one argument,
 ///      which is an unnamed variable `$i` with `i` specifying `result[i]`. This cannot be
 ///      combined with the "types" directive.
-///   4. The "opdtype" directive specifies that an operand type should be printed. It takes one
-///      argument, which is an unnamed variable `$i` with `i` specifying `operands[i]`. This cannot
-///      be combined with the "opdtypes" directive. Note: Parsed operand types are currently ignored
-///      and not validated against the actual input operands.
-///   5. The "region" directive specifies that a region must be parsed. It takes one argument,
+///   4. The "region" directive specifies that a region must be parsed. It takes one argument,
 ///      which is an unnamed variable `$i` with `i` specifying `region[i]`. This cannot be
 ///      combined with the "regions" directive.
-///   6. The <a name="attr"></a> "attr" directive can be used to specify attribute on an `Op` when
+///   5. The <a name="attr"></a> "attr" directive can be used to specify attribute on an `Op` when
 ///      the attribute's rust type is fixed at compile time. It takes two mandatory and two optional
 ///      arguments.
 ///
@@ -482,7 +478,7 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///      here (because the type is statically known, allowing us to be able to parse it),
 ///      thus allowing it to be more succinct. This cannot be combined with the [attr_dict](#attr_dict)
 ///      directive.
-///   7. The "succ" directive specifies an operation's successor. It takes one argument,
+///   6. The "succ" directive specifies an operation's successor. It takes one argument,
 ///      which is an unnamed variable `$i` with `i` specifying `successor[i]`.
 ///   7. The "operands" directive specifies all the operands of an operation. It takes one argument
 ///      which is a directive specifying the separator between operands. This cannot be combined
@@ -492,24 +488,33 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///        2. ``CharNewline(`c`)``: takes a single character argument that will be followed by a newline.
 ///        3. ``Char(`c`)``: takes a single character argument that will be used as separator.
 ///        4. ``CharSpace(`c`)``: takes a single character argument that will be followed by a space.
-///   9. The "successors" directive specifies all the successors of an operation. It takes one argument
+///   8. The "successors" directive specifies all the successors of an operation. It takes one argument
 ///      which is a directive specifying the separator between successors. The separator directive is
 ///      same as that for "operands" above. This cannot be combined with the "succ" directive.
-///  10. The "regions" directive specifies all the regions of an operation. It takes one argument
+///   9. The "regions" directive specifies all the regions of an operation. It takes one argument
 ///      which is a directive specifying the separator between regions. The separator directive is same
 ///      as that for "operands" above. This cannot be combined with the "region" directive.
-///  11. The <a name="attr_dict"></a> "attr_dict" directive specifies an
+///  10. The <a name="attr_dict"></a> "attr_dict" directive specifies an
 ///      [AttributeDict](../pliron/attribute/struct.AttributeDict.html).
 ///      It cannot be combined with any of [attr](#attr), [opt_attr](#opt_attr) directives or
 ///      a named variable (`$name`).
-///  12. The "types" directive specifies all the result types of an operation. It takes one argument
+///  11. The "types" directive specifies all the result types of an operation. It takes one argument
 ///      which is a directive specifying the separator between result types. The separator directive is
 ///      same as that for "operands" above. This cannot be combined with the "type" directive.
 ///  12. The "typesig" directive prints the full type signature of an operation as
 ///      `(operand_types) -> (result_types)`. It takes no arguments. When parsing, the operand
 ///      types are consumed and ignored; only the result types are used to build the operation.
 ///      This cannot be combined with the "type" or "types" directives.
-///  13. The <a name="opt_attr"></a> "opt_attr" directive specifies an optional attribute on an `Op`.
+///  13. The "opdtype" directive specifies that an operand type should be printed. It takes one
+///      argument, which is an unnamed variable `$i` with `i` specifying `operands[i]`. This cannot
+///      be combined with the "opdtypes" directive. Note: Parsed operand types are currently ignored
+///      and not validated against the actual input operands.
+///  14. The "opdtypes" directive specifies all the operand types of an operation. It takes one
+///      argument which is a directive specifying the separator between operand types. The separator
+///      directive is same as that for "operands" above. This cannot be combined with the "opdtype"
+///      directive. Note: Parsed operand types are currently ignored and not validated against the
+///      actual input operands.
+///  15. The <a name="opt_attr"></a> "opt_attr" directive specifies an optional attribute on an `Op`.
 ///      It takes two or more arguments, which are same as those of the [attr](#attr) directive.
 ///      This cannot be combined with the [attr_dict](#attr_dict) directive.
 ///

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -504,16 +504,16 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///  12. The "typesig" directive prints the full type signature of an operation as
 ///      `(operand_types) -> (result_types)`. It takes no arguments. When parsing, the operand
 ///      types are consumed and ignored; only the result types are used to build the operation.
-///      This cannot be combined with the "type" or "types" directives.
+///      This cannot be combined with any of "type", "types", "opdtype" or "opdtypes" directives.
 ///  13. The "opdtype" directive specifies that an operand type should be printed. It takes one
 ///      argument, which is an unnamed variable `$i` with `i` specifying `operands[i]`. This cannot
-///      be combined with the "opdtypes" directive. Note: Parsed operand types are currently ignored
-///      and not validated against the actual input operands.
+///      be combined with the "opdtypes" or "typesig" directives. **Note**: Parsed operand types
+///      are ignored, and not validated against actual operand types.
 ///  14. The "opdtypes" directive specifies all the operand types of an operation. It takes one
 ///      argument which is a directive specifying the separator between operand types. The separator
 ///      directive is same as that for "operands" above. This cannot be combined with the "opdtype"
-///      directive. Note: Parsed operand types are currently ignored and not validated against the
-///      actual input operands.
+///      or "typesig" directives. **Note**: Parsed operand types are ignored and not validated against
+///      actual operand types.
 ///  15. The <a name="opt_attr"></a> "opt_attr" directive specifies an optional attribute on an `Op`.
 ///      It takes two or more arguments, which are same as those of the [attr](#attr) directive.
 ///      This cannot be combined with the [attr_dict](#attr_dict) directive.

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -455,10 +455,14 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   3. The "type" directive specifies that a type must be parsed. It takes one argument,
 ///      which is an unnamed variable `$i` with `i` specifying `result[i]`. This cannot be
 ///      combined with the "types" directive.
-///   4. The "region" directive specifies that a region must be parsed. It takes one argument,
+///   4. The "opdtype" directive specifies that an operand type should be printed. It takes one
+///      argument, which is an unnamed variable `$i` with `i` specifying `operands[i]`. This cannot
+///      be combined with the "opdtypes" directive. Note: Parsed operand types are currently ignored
+///      and not validated against the actual input operands.
+///   5. The "region" directive specifies that a region must be parsed. It takes one argument,
 ///      which is an unnamed variable `$i` with `i` specifying `region[i]`. This cannot be
 ///      combined with the "regions" directive.
-///   5. The <a name="attr"></a> "attr" directive can be used to specify attribute on an `Op` when
+///   6. The <a name="attr"></a> "attr" directive can be used to specify attribute on an `Op` when
 ///      the attribute's rust type is fixed at compile time. It takes two mandatory and two optional
 ///      arguments.
 ///
@@ -478,7 +482,7 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///      here (because the type is statically known, allowing us to be able to parse it),
 ///      thus allowing it to be more succinct. This cannot be combined with the [attr_dict](#attr_dict)
 ///      directive.
-///   6. The "succ" directive specifies an operation's successor. It takes one argument,
+///   7. The "succ" directive specifies an operation's successor. It takes one argument,
 ///      which is an unnamed variable `$i` with `i` specifying `successor[i]`.
 ///   7. The "operands" directive specifies all the operands of an operation. It takes one argument
 ///      which is a directive specifying the separator between operands. This cannot be combined
@@ -488,17 +492,17 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///        2. ``CharNewline(`c`)``: takes a single character argument that will be followed by a newline.
 ///        3. ``Char(`c`)``: takes a single character argument that will be used as separator.
 ///        4. ``CharSpace(`c`)``: takes a single character argument that will be followed by a space.
-///   8. The "successors" directive specifies all the successors of an operation. It takes one argument
+///   9. The "successors" directive specifies all the successors of an operation. It takes one argument
 ///      which is a directive specifying the separator between successors. The separator directive is
 ///      same as that for "operands" above. This cannot be combined with the "succ" directive.
-///   9. The "regions" directive specifies all the regions of an operation. It takes one argument
+///  10. The "regions" directive specifies all the regions of an operation. It takes one argument
 ///      which is a directive specifying the separator between regions. The separator directive is same
 ///      as that for "operands" above. This cannot be combined with the "region" directive.
-///  10. The <a name="attr_dict"></a> "attr_dict" directive specifies an
+///  11. The <a name="attr_dict"></a> "attr_dict" directive specifies an
 ///      [AttributeDict](../pliron/attribute/struct.AttributeDict.html).
 ///      It cannot be combined with any of [attr](#attr), [opt_attr](#opt_attr) directives or
 ///      a named variable (`$name`).
-///  11. The "types" directive specifies all the result types of an operation. It takes one argument
+///  12. The "types" directive specifies all the result types of an operation. It takes one argument
 ///      which is a directive specifying the separator between result types. The separator directive is
 ///      same as that for "operands" above. This cannot be combined with the "type" directive.
 ///  12. The "typesig" directive prints the full type signature of an operation as

--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -309,7 +309,7 @@ fn opdtypes() {
         .expect("OneResultTwoOperands parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
@@ -402,7 +402,7 @@ fn opdtype() {
         .expect("OneResultTwoOperands parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;

--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -283,6 +283,52 @@ fn two_results_one_operand() {
     assert!(verify_operation(res, ctx).is_ok());
 }
 
+#[format_op("$0 `, ` $1 `: (` type(operands(CharSpace(`,`))) `) -> (` types(CharSpace(`,`)) `)`")]
+#[def_op("test.one_result_two_operands")]
+#[verify_succ]
+struct OneResultTwoOperandsOp {}
+
+#[test]
+fn functional_style_types() {
+    let ctx = &mut Context::new();
+
+    let printed = "builtin.func @testfunc: builtin.function <() -> ()> {
+          ^entry():
+            res0 = test.one_result_zero_operands : builtin.integer si64;
+            res1 = test.one_result_two_operands res0, res0 : (builtin.integer si64, builtin.integer si64) -> (builtin.integer si64);
+            test.return res1
+        }";
+
+    let state_stream = state_stream_from_iterator(
+        printed.chars(),
+        parsable::State::new(ctx, location::Source::InMemory),
+    );
+
+    let (res, _) = Operation::top_level_parser()
+        .parse(state_stream)
+        .expect("OneResultTwoOperands parser failed");
+
+    expect![[r#"
+        builtin.func @testfunc: builtin.function <()->()> 
+        {
+          ^entry_block1v1() !0:
+            res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
+            res1_v1 = test.one_result_two_operands res0_v0, res0_v0: (builtin.integer si64, builtin.integer si64) -> (builtin.integer si64) !2;
+            test.return res1_v1 !3
+        } !4
+
+        outlined_attributes:
+        !0 = @[<in-memory>: line: 2, column: 11], []
+        !1 = @[<in-memory>: line: 3, column: 13], [builtin_debug_info = builtin.debug_info [res0]]
+        !2 = @[<in-memory>: line: 4, column: 13], [builtin_debug_info = builtin.debug_info [res1]]
+        !3 = @[<in-memory>: line: 5, column: 13], []
+        !4 = @[<in-memory>: line: 1, column: 1], []
+    "#]]
+    .assert_eq(&res.disp(ctx).to_string());
+
+    assert!(verify_operation(res, ctx).is_ok());
+}
+
 #[format_op("$0 ` : ` typesig")]
 #[def_op("test.one_result_one_operand_typesig")]
 #[derive_op_interface_impl(NOpdsInterface<1>, NResultsInterface<1>, OneResultInterface)]

--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -283,13 +283,13 @@ fn two_results_one_operand() {
     assert!(verify_operation(res, ctx).is_ok());
 }
 
-#[format_op("$0 `, ` $1 `: (` type(operands(CharSpace(`,`))) `) -> (` types(CharSpace(`,`)) `)`")]
+#[format_op("$0 `, ` $1 `: (` opdtypes(CharSpace(`,`)) `) -> (` types(CharSpace(`,`)) `)`")]
 #[def_op("test.one_result_two_operands")]
 #[verify_succ]
 struct OneResultTwoOperandsOp {}
 
 #[test]
-fn functional_style_types() {
+fn opdtypes() {
     let ctx = &mut Context::new();
 
     let printed = "builtin.func @testfunc: builtin.function <() -> ()> {
@@ -368,6 +368,52 @@ fn one_result_one_operand_typesig() {
         !0 = @[<in-memory>: line: 2, column: 11], []
         !1 = @[<in-memory>: line: 3, column: 13], [builtin_debug_info = builtin.debug_info [res0]]
         !2 = @[<in-memory>: line: 4, column: 13], [builtin_debug_info = builtin.debug_info [res1]]
+        !3 = @[<in-memory>: line: 5, column: 13], []
+        !4 = @[<in-memory>: line: 1, column: 1], []
+    "#]]
+    .assert_eq(&res.disp(ctx).to_string());
+
+    assert!(verify_operation(res, ctx).is_ok());
+}
+
+#[format_op("$0 ` : (` opdtype($0) `)`")]
+#[def_op("test.zero_results_one_operand")]
+#[verify_succ]
+struct ZeroResultsOneOperandOp {}
+
+#[test]
+fn opdtype() {
+    let ctx = &mut Context::new();
+
+    let printed = "builtin.func @testfunc: builtin.function <() -> ()> {
+          ^entry():
+            res0 = test.one_result_zero_operands : builtin.integer si64;
+            test.zero_results_one_operand res0 : (builtin.integer si64);
+            test.return res0
+        }";
+
+    let state_stream = state_stream_from_iterator(
+        printed.chars(),
+        parsable::State::new(ctx, location::Source::InMemory),
+    );
+
+    let (res, _) = Operation::top_level_parser()
+        .parse(state_stream)
+        .expect("OneResultTwoOperands parser failed");
+
+    expect![[r#"
+        builtin.func @testfunc: builtin.function <()->()> 
+        {
+          ^entry_block1v1() !0:
+            res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
+            test.zero_results_one_operand res0_v0 : (builtin.integer si64) !2;
+            test.return res0_v0 !3
+        } !4
+
+        outlined_attributes:
+        !0 = @[<in-memory>: line: 2, column: 11], []
+        !1 = @[<in-memory>: line: 3, column: 13], [builtin_debug_info = builtin.debug_info [res0]]
+        !2 = @[<in-memory>: line: 4, column: 13], []
         !3 = @[<in-memory>: line: 5, column: 13], []
         !4 = @[<in-memory>: line: 1, column: 1], []
     "#]]


### PR DESCRIPTION
Allows nesting `operands` inside of `type` as a way to get input types. It's a bit hacky but it's the best I could manage with the way parsing is implemented right now. I didn't want to add yet another directive, and this should be familiar to anyone who knows the MLIR syntax.

I'm open to syntax changes, but there does need to be a way to print input types. Not just for the functional style type signature (which I personally prefer), but it's also pretty important for converting ops (i.e. LLVM conversion prints the type as `$input_ty to $result_ty`).