### PR TITLE
Provide `typesig` directive for `format_op`

### DIFF
--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -607,18 +607,9 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
             }
             Ok(quote! {
                 let op = self.get_operation().deref(ctx);
-                let operand_types = ::pliron::irfmt::printers::iter_with_sep(
-                    op.operands().map(|opd| ::pliron::r#type::Typed::get_type(&opd, ctx)),
-                    ::pliron::printable::ListSeparator::CharSpace(','),
-                );
-                let result_types = ::pliron::irfmt::printers::iter_with_sep(
-                    op.result_types(),
-                    ::pliron::printable::ListSeparator::CharSpace(','),
-                );
-                let typesig = ::pliron::irfmt::printers::functional_type(
-                    operand_types,
-                    result_types,
-                );
+                let arguments = op.operand_types(ctx).collect();
+                let results = op.result_types().collect();
+                let typesig = ::pliron::r#type::TypeSig { arguments, results };
                 ::pliron::printable::Printable::fmt(&typesig, ctx, state, fmt)?;
             })
         } else if d.name == "attr_dict" {
@@ -1541,27 +1532,10 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             }
             state.result_types = ElementSpec::All(result_types_var_name.clone());
             Ok(quote! {
-                let _operand_types = ::pliron::irfmt::parsers::delimited_list_parser(
-                    '(',
-                    ')',
-                    ',',
-                    ::pliron::irfmt::parsers::type_parser(),
-                )
-                .parse_stream(state_stream)
-                .into_result()?
-                .0;
-                ::pliron::irfmt::parsers::spaced(::pliron::combine::parser::char::string("->"))
-                    .parse_stream(state_stream)
-                    .into_result()?;
-                let #result_types_var_name = ::pliron::irfmt::parsers::delimited_list_parser(
-                    '(',
-                    ')',
-                    ',',
-                    ::pliron::irfmt::parsers::type_parser(),
-                )
-                .parse_stream(state_stream)
-                .into_result()?
-                .0;
+                let type_sig =
+                    ::pliron::r#type::TypeSig::parser(())
+                    .parse_stream(state_stream).into_result()?.0;
+                let #result_types_var_name = type_sig.results;
             })
         } else if d.name == "successors" {
             let Some(Elem::Directive(sep)) = &d.args.first() else {

--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -598,6 +598,29 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
                 let types = ::pliron::irfmt::printers::iter_with_sep(types, #sep);
                 ::pliron::printable::Printable::fmt(&types, ctx, state, fmt)?;
             })
+        } else if d.name == "typesig" {
+            if !d.args.is_empty() {
+                return Err(syn::Error::new_spanned(
+                    input.ident.clone(),
+                    "The `typesig` directive takes no arguments".to_string(),
+                ));
+            }
+            Ok(quote! {
+                let op = self.get_operation().deref(ctx);
+                let operand_types = ::pliron::irfmt::printers::iter_with_sep(
+                    op.operands().map(|opd| ::pliron::r#type::Typed::get_type(&opd, ctx)),
+                    ::pliron::printable::ListSeparator::CharSpace(','),
+                );
+                let result_types = ::pliron::irfmt::printers::iter_with_sep(
+                    op.result_types(),
+                    ::pliron::printable::ListSeparator::CharSpace(','),
+                );
+                let typesig = ::pliron::irfmt::printers::functional_type(
+                    operand_types,
+                    result_types,
+                );
+                ::pliron::printable::Printable::fmt(&typesig, ctx, state, fmt)?;
+            })
         } else if d.name == "attr_dict" {
             Ok(quote! {
                 let self_op = self.get_operation().deref(ctx);
@@ -1500,6 +1523,45 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
                     .parse_stream(state_stream)
                     .into_result()?
                     .0;
+            })
+        } else if d.name == "typesig" {
+            if !d.args.is_empty() {
+                return Err(syn::Error::new_spanned(
+                    input.ident.clone(),
+                    "The `typesig` directive takes no arguments".to_string(),
+                ));
+            }
+            let result_types_var_name = format_ident!("result_types");
+            if matches!(&state.result_types, ElementSpec::Individual(result_types) if !result_types.is_empty())
+            {
+                return Err(syn::Error::new_spanned(
+                    input.ident.clone(),
+                    "Cannot mix typesig directive with numbered result types".to_string(),
+                ));
+            }
+            state.result_types = ElementSpec::All(result_types_var_name.clone());
+            Ok(quote! {
+                let _operand_types = ::pliron::irfmt::parsers::delimited_list_parser(
+                    '(',
+                    ')',
+                    ',',
+                    ::pliron::irfmt::parsers::type_parser(),
+                )
+                .parse_stream(state_stream)
+                .into_result()?
+                .0;
+                ::pliron::irfmt::parsers::spaced(::pliron::combine::parser::char::string("->"))
+                    .parse_stream(state_stream)
+                    .into_result()?;
+                let #result_types_var_name = ::pliron::irfmt::parsers::delimited_list_parser(
+                    '(',
+                    ')',
+                    ',',
+                    ::pliron::irfmt::parsers::type_parser(),
+                )
+                .parse_stream(state_stream)
+                .into_result()?
+                .0;
             })
         } else if d.name == "successors" {
             let Some(Elem::Directive(sep)) = &d.args.first() else {

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -481,7 +481,8 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///   6. The "succ" directive specifies an operation's successor. It takes one argument,
 ///      which is an unnamed variable `$i` with `i` specifying `successor[i]`.
 ///   7. The "operands" directive specifies all the operands of an operation. It takes one argument
-///      which is a directive specifying the separator between operands.
+///      which is a directive specifying the separator between operands. This cannot be combined
+///      with using unnamed variables `$i` to refer to operands.
 ///      The following directives are supported:
 ///        1. `NewLine`: takes no argument, and specifies a newline to be used as list separator.
 ///        2. ``CharNewline(`c`)``: takes a single character argument that will be followed by a newline.
@@ -500,7 +501,11 @@ pub fn format(args: TokenStream, input: TokenStream) -> TokenStream {
 ///  11. The "types" directive specifies all the result types of an operation. It takes one argument
 ///      which is a directive specifying the separator between result types. The separator directive is
 ///      same as that for "operands" above. This cannot be combined with the "type" directive.
-///  12. The <a name="opt_attr"></a> "opt_attr" directive specifies an optional attribute on an `Op`.
+///  12. The "typesig" directive prints the full type signature of an operation as
+///      `(operand_types) -> (result_types)`. It takes no arguments. When parsing, the operand
+///      types are consumed and ignored; only the result types are used to build the operation.
+///      This cannot be combined with the "type" or "types" directives.
+///  13. The <a name="opt_attr"></a> "opt_attr" directive specifies an optional attribute on an `Op`.
 ///      It takes two or more arguments, which are same as those of the [attr](#attr) directive.
 ///      This cannot be combined with the [attr_dict](#attr_dict) directive.
 ///

--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -82,7 +82,7 @@ fn one_result_zero_operands() {
         .expect("OneResultZeroOperands parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
@@ -126,7 +126,7 @@ fn one_result_zero_operands_canonical() {
         .expect("OneResultZeroOperandsCanonical parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands_canonical () [] []: <() -> (builtin.integer si64)> !1;
@@ -171,7 +171,7 @@ fn one_result_one_operand() {
         .expect("OneResultOneOperand parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
@@ -217,7 +217,7 @@ fn two_result_two_operands() {
         .expect("TwoResultTwoOperands parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
@@ -263,7 +263,7 @@ fn two_results_one_operand() {
         .expect("TwoResultsOneOperand parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
@@ -310,7 +310,7 @@ fn one_result_one_operand_typesig() {
         .expect("OneResultOneOperandTypeSig parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
@@ -357,7 +357,7 @@ fn attr_op() {
         .expect("AttrOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
@@ -403,7 +403,7 @@ fn attr_op2() {
         .expect("AttrOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.attr_op2 "Hello World" :builtin.integer si64 !1;
@@ -436,7 +436,7 @@ fn attr_op2() {
         .expect("AttrOp parser failed with optional attribute");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block2v1() !0:
             res0_v1 = test.attr_op2 "Hello World" <42: si64>:builtin.integer si64 !1;
@@ -482,7 +482,7 @@ fn attr_op2_labeled() {
         .expect("AttrOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.attr_op2_labeled name : "Hello World" :builtin.integer si64 !1;
@@ -515,7 +515,7 @@ fn attr_op2_labeled() {
         .expect("AttrOp parser failed with optional attribute");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block2v1() !0:
             res0_v1 = test.attr_op2_labeled name : "Hello World" value : <42: si64>:builtin.integer si64 !1;
@@ -561,7 +561,7 @@ fn attr_op2_labeled_delimited() {
         .expect("AttrOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.attr_op2_labeled_delimited <name : "Hello World"> :builtin.integer si64 !1;
@@ -594,7 +594,7 @@ fn attr_op2_labeled_delimited() {
         .expect("AttrOp parser failed with optional attribute");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block2v1() !0:
             res0_v1 = test.attr_op2_labeled_delimited <name : "Hello World"> <<value : <42: si64>>>:builtin.integer si64 !1;
@@ -640,7 +640,7 @@ fn attr_op2_delimited() {
         .expect("AttrOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.attr_op2_delimited <"Hello World"> :builtin.integer si64 !1;
@@ -673,7 +673,7 @@ fn attr_op2_delimited() {
         .expect("AttrOp parser failed with optional attribute");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block2v1() !0:
             res0_v1 = test.attr_op2_delimited <"Hello World"> [[<42: si64>]]:builtin.integer si64 !1;
@@ -716,7 +716,7 @@ fn attr_op3() {
         .expect("AttrOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.attr_op3 builtin.integer <0: si64>:builtin.integer si64 !1;
@@ -765,7 +765,7 @@ fn if_op() {
         .expect("IfOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block2v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
@@ -828,7 +828,7 @@ fn if_else_op() {
         .expect("IfOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block3v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
@@ -892,7 +892,7 @@ fn br_op() {
         .expect("BrOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block2v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
@@ -945,7 +945,7 @@ fn multiple_successors_op() {
         .expect("MultipleSuccessorsOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block3v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
@@ -1010,7 +1010,7 @@ fn multiple_regions_op() {
         .expect("MultipleRegionsOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block3v1() !0:
             res_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
@@ -1075,7 +1075,7 @@ fn attr_dict_op() {
         .expect("AttrDictOp parser failed");
 
     expect![[r#"
-        builtin.func @testfunc: builtin.function <()->()> 
+        builtin.func @testfunc: builtin.function <() -> ()> 
         {
           ^entry_block1v1() !0:
             res0_v0 = test.attr_op <3: si64>:builtin.integer si64 !1;

--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -283,6 +283,53 @@ fn two_results_one_operand() {
     assert!(verify_operation(res, ctx).is_ok());
 }
 
+#[format_op("$0 ` : ` typesig")]
+#[def_op("test.one_result_one_operand_typesig")]
+#[derive_op_interface_impl(NOpdsInterface<1>, NResultsInterface<1>, OneResultInterface)]
+#[verify_succ]
+struct OneResultOneOperandTypeSigOp {}
+
+#[test]
+fn one_result_one_operand_typesig() {
+    let ctx = &mut Context::new();
+
+    let printed = "builtin.func @testfunc: builtin.function <() -> ()> {
+          ^entry():
+            res0 = test.one_result_zero_operands : builtin.integer si64;
+            res1 = test.one_result_one_operand_typesig res0 : (builtin.integer si64) -> (builtin.integer si64);
+            test.return res1
+        }";
+
+    let state_stream = state_stream_from_iterator(
+        printed.chars(),
+        parsable::State::new(ctx, location::Source::InMemory),
+    );
+
+    let (res, _) = Operation::top_level_parser()
+        .parse(state_stream)
+        .expect("OneResultOneOperandTypeSig parser failed");
+
+    expect![[r#"
+        builtin.func @testfunc: builtin.function <()->()> 
+        {
+          ^entry_block1v1() !0:
+            res0_v0 = test.one_result_zero_operands : builtin.integer si64 !1;
+            res1_v1 = test.one_result_one_operand_typesig res0_v0 : (builtin.integer si64) -> (builtin.integer si64) !2;
+            test.return res1_v1 !3
+        } !4
+
+        outlined_attributes:
+        !0 = @[<in-memory>: line: 2, column: 11], []
+        !1 = @[<in-memory>: line: 3, column: 13], [builtin_debug_info = builtin.debug_info [res0]]
+        !2 = @[<in-memory>: line: 4, column: 13], [builtin_debug_info = builtin.debug_info [res1]]
+        !3 = @[<in-memory>: line: 5, column: 13], []
+        !4 = @[<in-memory>: line: 1, column: 1], []
+    "#]]
+    .assert_eq(&res.disp(ctx).to_string());
+
+    assert!(verify_operation(res, ctx).is_ok());
+}
+
 use pliron::builtin::attributes::IntegerAttr;
 
 #[format_op("attr($attr, $IntegerAttr) `:` type($0)")]

--- a/src/builtin/types.rs
+++ b/src/builtin/types.rs
@@ -12,7 +12,7 @@ use crate::{
     irfmt::parsers::int_parser,
     parsable::{Parsable, ParseResult, StateStream},
     printable::{self, Printable},
-    r#type::{Type, TypeHandle, TypedHandle},
+    r#type::{Type, TypeHandle, TypeSig, TypedHandle},
     utils::apfloat::{self, GetSemantics, Semantics},
 };
 
@@ -112,28 +112,27 @@ impl Printable for IntegerType {
 ///
 /// See MLIR's [FunctionType](https://mlir.llvm.org/docs/Dialects/Builtin/#functiontype).
 ///
-#[pliron_type(
-    name = "builtin.function",
-    format = "`<` `(` vec($inputs, CharSpace(`,`)) `)` `->` `(`vec($results, CharSpace(`,`)) `)` `>`",
-    generate_get = true,
-    verifier = "succ"
-)]
+#[pliron_type(name = "builtin.function", format = "`<` $0 `>`", verifier = "succ")]
 #[derive(Hash, PartialEq, Eq, Debug)]
-pub struct FunctionType {
-    /// Function arguments / inputs.
-    inputs: Vec<TypeHandle>,
-    /// Function results / outputs.
-    results: Vec<TypeHandle>,
-}
+pub struct FunctionType(TypeSig);
 
 impl FunctionType {
+    /// Get a Function type.
+    pub fn get(
+        ctx: &Context,
+        arguments: Vec<TypeHandle>,
+        results: Vec<TypeHandle>,
+    ) -> TypedHandle<Self> {
+        FunctionType::register_instance(FunctionType(TypeSig { arguments, results }), ctx)
+    }
+
     /// Get, if it already exists, a Function type.
     pub fn get_existing(
         ctx: &Context,
-        inputs: Vec<TypeHandle>,
+        arguments: Vec<TypeHandle>,
         results: Vec<TypeHandle>,
     ) -> Option<TypedHandle<Self>> {
-        Type::get_instance(FunctionType { inputs, results }, ctx)
+        Type::get_instance(FunctionType(TypeSig { arguments, results }), ctx)
     }
 }
 
@@ -141,12 +140,12 @@ impl FunctionType {
 impl FunctionTypeInterface for FunctionType {
     /// Get a reference to the function input / argument types.
     fn arg_types(&self) -> Vec<TypeHandle> {
-        self.inputs.clone()
+        self.0.arguments.clone()
     }
 
     /// Get a reference to the function result / output types.
     fn res_types(&self) -> Vec<TypeHandle> {
-        self.results.clone()
+        self.0.results.clone()
     }
 }
 

--- a/src/irfmt/printers/mod.rs
+++ b/src/irfmt/printers/mod.rs
@@ -72,20 +72,3 @@ pub fn enclosed<P: Printable>(left: &'static str, right: &'static str, p: P) -> 
         },
     )
 }
-
-/// Print a function type with inputs and results like `(i32, i32) -> (i64)`
-pub fn functional_type<'a>(
-    inputs: impl Printable + 'a,
-    results: impl Printable + 'a,
-) -> impl Printable + 'a {
-    PrinterFn(
-        move |ctx: &Context, state: &State, f: &mut fmt::Formatter<'_>| {
-            write!(
-                f,
-                "({}) -> ({})",
-                inputs.print(ctx, state),
-                results.print(ctx, state)
-            )
-        },
-    )
-}

--- a/src/irfmt/printers/mod.rs
+++ b/src/irfmt/printers/mod.rs
@@ -73,7 +73,7 @@ pub fn enclosed<P: Printable>(left: &'static str, right: &'static str, p: P) -> 
     )
 }
 
-/// Print a function type with inputs and results like `<(i32, i32) -> (i64)>`
+/// Print a function type with inputs and results like `(i32, i32) -> (i64)`
 pub fn functional_type<'a>(
     inputs: impl Printable + 'a,
     results: impl Printable + 'a,
@@ -82,7 +82,7 @@ pub fn functional_type<'a>(
         move |ctx: &Context, state: &State, f: &mut fmt::Formatter<'_>| {
             write!(
                 f,
-                "<({}) -> ({})>",
+                "({}) -> ({})",
                 inputs.print(ctx, state),
                 results.print(ctx, state)
             )

--- a/src/op.rs
+++ b/src/op.rs
@@ -47,7 +47,6 @@ use thiserror::Error;
 
 use crate::{
     attribute::AttributeDict,
-    builtin::{type_interfaces::FunctionTypeInterface, types::FunctionType},
     combine::{
         Parser,
         parser::{self, char::spaces},
@@ -63,7 +62,7 @@ use crate::{
             block_opd_parser, delimited_list_parser, location, process_parsed_ssa_defs, spaced,
             ssa_opd_parser, zero_or_more_parser,
         },
-        printers::{functional_type, iter_with_sep},
+        printers::iter_with_sep,
     },
     location::{Located, Location},
     operation::{Operation, verify_operation},
@@ -72,7 +71,7 @@ use crate::{
     region::Region,
     result::Result,
     std_deps::{hash::FxHashMap, sync::LazyLock},
-    r#type::Typed,
+    r#type::{TypeSig, Typed},
 };
 
 #[derive(Clone, Hash, PartialEq, Eq)]
@@ -379,10 +378,10 @@ pub fn canonical_syntax_print(
             .map(|succ| "^".to_string() + &succ.unique_name(ctx)),
         sep,
     );
-    let op_type = functional_type(
-        iter_with_sep(op.operands().map(|opd| opd.get_type(ctx)), sep),
-        iter_with_sep(op.results().map(|res| res.get_type(ctx)), sep),
-    );
+    let op_type = TypeSig {
+        arguments: op.operands().map(|opd| opd.get_type(ctx)).collect(),
+        results: op.results().map(|res| res.get_type(ctx)).collect(),
+    };
     let regions = iter_with_sep(op.regions(), printable::ListSeparator::Newline);
 
     if op.get_num_results() != 0 {
@@ -425,7 +424,12 @@ pub fn canonical_syntax_parse<'a, T: Op>(
         .and(spaces().with(delimited_list_parser('[', ']', ',', block_opd_parser())))
         .and(spaces().with(AttributeDict::parser(())))
         .skip(spaced(token(':')))
-        .and((location(), FunctionType::parser(())))
+        .and((
+            location(),
+            token('<')
+                .with(TypeSig::parser(()))
+                .skip(spaced(token('>'))),
+        ))
         .then(
             move |(((operands, successors), attr_dict), (fty_loc, fty))| {
                 let results = results.clone();
@@ -433,22 +437,20 @@ pub fn canonical_syntax_parse<'a, T: Op>(
                 combine::parser(move |parsable_state: &mut StateStream<'a>| {
                     let results = results.clone();
                     let ctx = &mut parsable_state.state.ctx;
-                    let results_types = fty.deref(ctx).res_types().to_vec();
-                    let operands_types = fty.deref(ctx).arg_types().to_vec();
-                    if results_types.len() != results.len() {
+                    if fty.results.len() != results.len() {
                         input_err!(
                             fty_loc.clone(),
                             CanonicalSyntaxParseError::ResultsMismatch {
-                                num_res_ty: results_types.len(),
+                                num_res_ty: fty.results.len(),
                                 num_res: results.len()
                             }
                         )?
                     }
-                    if operands.len() != operands_types.len() {
+                    if operands.len() != fty.arguments.len() {
                         input_err!(
                             fty_loc.clone(),
                             CanonicalSyntaxParseError::OperandsMismatch {
-                                num_opd_ty: operands_types.len(),
+                                num_opd_ty: fty.arguments.len(),
                                 num_opd: operands.len()
                             }
                         )?
@@ -456,7 +458,7 @@ pub fn canonical_syntax_parse<'a, T: Op>(
                     let opr = Operation::new(
                         ctx,
                         T::get_concrete_op_info(),
-                        results_types,
+                        fty.results.clone(),
                         operands.clone(),
                         successors.clone(),
                         0,

--- a/src/op.rs
+++ b/src/op.rs
@@ -392,7 +392,7 @@ pub fn canonical_syntax_print(
 
     write!(
         f,
-        "{} ({}) [{}] {}: {}",
+        "{} ({}) [{}] {}: <{}>",
         opid.disp(ctx),
         operands.disp(ctx),
         successors.disp(ctx),

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -304,6 +304,14 @@ impl Operation {
         self.results.iter().map(|res| res.ty)
     }
 
+    /// Get an iterator over the operand types of this operation.
+    pub fn operand_types<'a>(
+        &'a self,
+        ctx: &'a Context,
+    ) -> impl Iterator<Item = TypeHandle> + Clone {
+        self.operands().map(|opd| opd.get_type(ctx))
+    }
+
     /// Get number of operands.
     pub fn get_num_operands(&self) -> usize {
         self.operands.len()

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -14,6 +14,7 @@
 //!    constrain where a pass is allowed to run.
 //! 5. [`Analysis`] and [`AnalysisManager`]: Provides analyses caching with
 //!    preservation and invalidation support.
+//! 6. [`PMConfig`] provides configuration that can be set via the [AnalysisManager].
 //!
 //! # Usage
 //!

--- a/src/type.rs
+++ b/src/type.rs
@@ -65,6 +65,7 @@ use core::{
     ops::Deref,
 };
 use downcast_rs::{Downcast, impl_downcast};
+use pliron_derive::format;
 use thiserror::Error;
 
 /// Basic functionality that every type in the IR must implement.
@@ -633,3 +634,11 @@ pub use statics::*;
 pub static TYPE_INTERFACE_VERIFIERS_MAP: LazyLock<
     FxHashMap<core::any::TypeId, Vec<TypeInterfaceVerifier>>,
 > = LazyLock::new(|| collect_deduped_interface_verifiers(get_type_interface_verifiers()));
+
+/// A convenient struct to hold a type signature, i.e., a list of input types and a list of result types.
+
+#[format("`(` vec($arguments, CharSpace(`,`)) `)` ` -> ` `(`vec($results, CharSpace(`,`)) `)`")]
+pub struct TypeSig {
+    pub arguments: Vec<TypeHandle>,
+    pub results: Vec<TypeHandle>,
+}

--- a/src/type.rs
+++ b/src/type.rs
@@ -635,8 +635,9 @@ pub static TYPE_INTERFACE_VERIFIERS_MAP: LazyLock<
     FxHashMap<core::any::TypeId, Vec<TypeInterfaceVerifier>>,
 > = LazyLock::new(|| collect_deduped_interface_verifiers(get_type_interface_verifiers()));
 
-/// A convenient struct to hold a type signature, i.e., a list of input types and a list of result types.
+/// A convenient struct to hold a type signature.
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[format("`(` vec($arguments, CharSpace(`,`)) `)` ` -> ` `(`vec($results, CharSpace(`,`)) `)`")]
 pub struct TypeSig {
     pub arguments: Vec<TypeHandle>,

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -982,7 +982,7 @@ fn test_outline_printonce_attr() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v2 = test.constant builtin.integer <0: si64> !0;
@@ -1024,7 +1024,7 @@ fn test_outline_printonce_attr() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1_block4v1() !0:
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1_block3v1() !1:
                 c0_v3 = test.constant builtin.integer <0: si64> !2;
@@ -1118,7 +1118,7 @@ fn test_outline_attr_on_block() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1() !0:
                 c0_v0 = test.constant builtin.integer <0: si64> !1;
@@ -1151,7 +1151,7 @@ fn test_outline_attr_on_block() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1_block4v1() !0:
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1_block3v1() !1:
                 c0_v1 = test.constant builtin.integer <0: si64> !2;

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -118,7 +118,7 @@ fn replace_c0_with_c1_operand() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -141,7 +141,7 @@ fn replace_c0_with_c1_operand() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c1_v1 = test.constant builtin.integer <1: si64> !0;
@@ -196,7 +196,7 @@ fn test_replace_within_same_def_site() {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v2 = test.constant builtin.integer <0: si64> !0;
@@ -225,7 +225,7 @@ fn test_replace_within_same_def_site() {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v2 = test.constant builtin.integer <0: si64> !0;
@@ -959,7 +959,7 @@ fn print_simple() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1028,7 +1028,7 @@ fn parse_function_with_attrs() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
               [test_on_func_value: builtin.string "func_attr_value"]
             {
               ^entry_block2v1():
@@ -1056,7 +1056,7 @@ fn parse_function_with_attrs() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1_block4v1() !0:
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
               [test_on_func_value: builtin.string "func_attr_value"]
             {
               ^entry_block2v1_block3v1() !1:
@@ -1217,7 +1217,7 @@ fn test_preorder_forward_walk() {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1228,7 +1228,7 @@ fn test_preorder_forward_walk() {
         outlined_attributes:
         !0 = [builtin_debug_info = builtin.debug_info [c0]]
 
-        builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+        builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
         {
           ^entry_block2v1():
             c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1297,7 +1297,7 @@ fn walker_print() {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1308,7 +1308,7 @@ fn walker_print() {
         outlined_attributes:
         !0 = [builtin_debug_info = builtin.debug_info [c0]]
 
-        builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+        builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
         {
           ^entry_block2v1():
             c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1346,7 +1346,7 @@ fn test_postorder_forward_walk() {
     expect![[r#"
         c0_v0 = test.constant builtin.integer <0: si64> !0
         test.return c0_v0
-        builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+        builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
         {
           ^entry_block2v1():
             c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1355,7 +1355,7 @@ fn test_postorder_forward_walk() {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1564,7 +1564,7 @@ fn block_inline_attrs_print() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1() [block_test_attr: builtin.string "test_value"]:
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1643,7 +1643,7 @@ fn block_multiple_inline_attrs() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1() [attr1: builtin.string "value1", attr2: builtin.string "value2"]:
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -1690,7 +1690,7 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
         builtin.module @bar 
         {
           ^block_0_0_block2v1() !0:
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block_1_0_block1v1() [block_attr: builtin.string "hello"] !1:
                 c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;
@@ -1727,7 +1727,7 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
         builtin.module @bar 
         {
           ^block_0_0_block2v1_block2v1() !0:
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block_1_0_block1v1_block1v1() [block_attr: builtin.string "hello"] !1:
                 c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;

--- a/tests/rewriter.rs
+++ b/tests/rewriter.rs
@@ -593,7 +593,7 @@ fn inline_region_on_const_zero() -> Result<()> {
           ^block3v1():
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
-      
+              
             }
         }"#]]
     .assert_eq(&printed);

--- a/tests/rewriter.rs
+++ b/tests/rewriter.rs
@@ -210,7 +210,7 @@ fn replace_c0_with_c1() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 v2 = test.constant builtin.integer <2: si64>;
@@ -355,7 +355,7 @@ fn scoped_rewriter_test() -> Result<()> {
         {
           ^block1v1():
             v1 = test.global () [] [test_global_op_const_val: builtin.integer <0: si64>, sym_name: builtin.identifier global_0]: <() -> (test.ptr )>;
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 v2 = test.load v1 ;
@@ -498,7 +498,7 @@ fn split_block_after_const_zero() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -573,7 +573,7 @@ fn inline_region_on_const_zero() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():
                 c0_v0 = test.constant builtin.integer <0: si64> !0;
@@ -591,9 +591,9 @@ fn inline_region_on_const_zero() -> Result<()> {
         builtin.module @bar 
         {
           ^block3v1():
-            builtin.func @foo: builtin.function <()->(builtin.integer si64)> 
+            builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
-              
+      
             }
         }"#]]
     .assert_eq(&printed);


### PR DESCRIPTION
Based on #149 and discussions that came out of it.

Co-authored-by: Genna Wingert <1058083+wingertge@users.noreply.github.com>