### PR TITLE
Reduce combinator codegen by using `parse` directly where possible

### DIFF
--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -726,8 +726,7 @@ trait ParsableBuilder<State: Default> {
             let variant_name_parsed = quote! {
                 let variant_name_parsed =
                     ::pliron::alloc::string::ToString::to_string(
-                        &::pliron::identifier::Identifier::parser(()).
-                            parse_stream(state_stream).into_result()?.0
+                        &::pliron::identifier::Identifier::parse(state_stream, ())?.0
                     );
             };
 
@@ -847,7 +846,7 @@ trait ParsableBuilder<State: Default> {
         };
         let name = format_ident!("{}", name);
         Ok(quote! {
-            let #name = <#ty>::parser(()).parse_stream(state_stream).into_result()?.0;
+            let #name = <#ty>::parse(state_stream, ())?.0;
         })
     }
 
@@ -871,7 +870,7 @@ trait ParsableBuilder<State: Default> {
         })?;
         let name = format_ident!("field_at_{}", index);
         Ok(quote! {
-            let #name = <#ty>::parser(()).parse_stream(state_stream).into_result()?.0;
+            let #name = <#ty>::parse(state_stream, ())?.0;
         })
     }
 
@@ -1066,7 +1065,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             use ::pliron::op::Op;
             use ::pliron::operation::Operation;
             use ::pliron::irfmt::parsers::
-                {process_parsed_ssa_defs, ssa_opd_parser, block_opd_parser, attr_parser};
+                {process_parsed_ssa_defs, ssa_opd_parser, block_opd_parser};
         };
 
         // Is region parsing specified as part of the syntax?
@@ -1301,10 +1300,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
         }
 
         Ok(quote! {
-            let #attr_name_ident = attr_parser()
-                .parse_stream(state_stream)
-                .into_result()?
-                .0;
+            let #attr_name_ident = ::pliron::irfmt::parsers::attr_parse(state_stream)?.0;
         })
     }
 
@@ -1326,7 +1322,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             }
         }
         Ok(quote! {
-            let #opd_name = ssa_opd_parser().parse_stream(state_stream).into_result()?.0;
+            let #opd_name = ::pliron::irfmt::parsers::ssa_opd_parse(state_stream, ())?.0;
         })
     }
 
@@ -1338,11 +1334,10 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
         if d.name == "canonical" {
             state.is_canonical = true;
             Ok(quote! {
-                ::pliron::op::canonical_syntax_parser::<Self>(
+                ::pliron::op::canonical_syntax_parse::<Self>(
+                    state_stream,
                     arg,
                 )
-                .parse_stream(state_stream)
-                .into()
             })
         } else if d.name == "type" {
             let err = Err(syn::Error::new_spanned(
@@ -1367,7 +1362,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
                     }
                 }
                 Ok(quote! {
-                    let #res_type = ::pliron::irfmt::parsers::type_parser().parse_stream(state_stream).into_result()?.0;
+                    let #res_type = ::pliron::irfmt::parsers::type_parse(state_stream)?.0;
                 })
             } else {
                 err
@@ -1482,7 +1477,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
                 }
             }
             Ok(quote! {
-                let #succ_name = block_opd_parser().parse_stream(state_stream).into_result()?.0;
+                let #succ_name = ::pliron::irfmt::parsers::block_opd_parse(state_stream, ())?.0;
             })
         } else if d.name == "regions" {
             let Some(Elem::Directive(sep)) = &d.args.first() else {
@@ -1533,8 +1528,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             state.result_types = ElementSpec::All(result_types_var_name.clone());
             Ok(quote! {
                 let type_sig =
-                    ::pliron::r#type::TypeSig::parser(())
-                    .parse_stream(state_stream).into_result()?.0;
+                    ::pliron::r#type::TypeSig::parse(state_stream, ())?.0;
                 let #result_types_var_name = type_sig.results;
             })
         } else if d.name == "successors" {
@@ -1624,7 +1618,7 @@ impl ParsableBuilder<OpParserState> for DeriveOpParsable {
             state.attributes.0 = ElementSpec::All(attr_sets_name.clone());
             Ok(quote! {
                 let #attr_sets_name =
-                    ::pliron::attribute::AttributeDict::parser(()).parse_stream(state_stream).into_result()?.0;
+                    ::pliron::attribute::AttributeDict::parse(state_stream, ())?.0;
             })
         } else {
             unimplemented!("Unknown directive {}", d.name)

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -209,13 +209,9 @@ pub trait Attribute: Printable + Verify + Downcast + Sync + Send + DynClone + De
     where
         Self: Sized + Parsable<Arg = (), Parsed = A>,
     {
-        let attr_parser: AttrParserFn = Box::new(|&()| {
-            combine::parser(move |parsable_state: &mut StateStream<'_>| {
-                Self::parse(parsable_state, ())
-                    .map(|(attr, r)| -> (AttrObj, _) { (Box::new(attr), r) })
-            })
-            .boxed()
-        });
+        let attr_parser: AttrParserFn = |parsable_state, &()| {
+            Self::parse(parsable_state, ()).map(|(attr, r)| -> (AttrObj, _) { (Box::new(attr), r) })
+        };
         let attrid = Self::get_attr_id_static();
         Dialect::register(ctx, &attrid.dialect).add_attr(attrid.clone(), attr_parser);
     }
@@ -228,11 +224,7 @@ pub type AttrObj = Box<dyn Attribute>;
 
 /// A storable function pointer to parse a specific [Attribute].
 /// The [Attribute]'s [Dialect] maps an [AttrId] to such a parser.
-pub(crate) type AttrParserFn = Box<
-    for<'a> fn(
-        &'a (),
-    ) -> Box<dyn Parser<StateStream<'a>, Output = AttrObj, PartialState = ()> + 'a>,
->;
+pub(crate) type AttrParserFn = for<'a> fn(&mut StateStream<'a>, &'a ()) -> ParseResult<'a, AttrObj>;
 
 impl PartialEq for AttrObj {
     fn eq(&self, other: &Self) -> bool {
@@ -287,7 +279,7 @@ impl Parsable for AttrObj {
                         attr_id.disp(state.ctx)
                     )?
                 };
-                attr_parser(&()).parse_stream(parsable_state).into_result()
+                attr_parser(parsable_state, &())
             })
         });
 

--- a/src/irfmt/parsers.rs
+++ b/src/irfmt/parsers.rs
@@ -59,6 +59,11 @@ pub fn location<'a>() -> Box<dyn Parser<StateStream<'a>, Output = Location, Part
 }
 
 /// A parser combinator to parse [TypeId](crate::type::TypeId) followed by the type's contents.
+pub fn type_parse<'a>(state_stream: &mut StateStream<'a>) -> ParseResult<'a, TypeHandle> {
+    TypeHandle::parse(state_stream, ())
+}
+
+/// A parser combinator to parse [TypeId](crate::type::TypeId) followed by the type's contents.
 pub fn type_parser<'a>()
 -> Box<dyn Parser<StateStream<'a>, Output = TypeHandle, PartialState = ()> + 'a> {
     TypeHandle::parser(())
@@ -179,6 +184,11 @@ pub fn quoted_string_parser<'a>()
         quoted_string_parse(parsable_state, ())
     })
     .boxed()
+}
+
+/// A parser combinator to parse [AttrId](crate::attribute::AttrId) followed by the attribute's contents.
+pub fn attr_parse<'a>(state_stream: &mut StateStream<'a>) -> ParseResult<'a, AttrObj> {
+    AttrObj::parse(state_stream, ())
 }
 
 /// A parser combinator to parse [AttrId](crate::attribute::AttrId) followed by the attribute's contents.

--- a/src/irfmt/parsers.rs
+++ b/src/irfmt/parsers.rs
@@ -58,7 +58,7 @@ pub fn location<'a>() -> Box<dyn Parser<StateStream<'a>, Output = Location, Part
     .boxed()
 }
 
-/// A parser combinator to parse [TypeId](crate::type::TypeId) followed by the type's contents.
+/// A parser to parse [TypeId](crate::type::TypeId) followed by the type's contents.
 pub fn type_parse<'a>(state_stream: &mut StateStream<'a>) -> ParseResult<'a, TypeHandle> {
     TypeHandle::parse(state_stream, ())
 }
@@ -186,7 +186,7 @@ pub fn quoted_string_parser<'a>()
     .boxed()
 }
 
-/// A parser combinator to parse [AttrId](crate::attribute::AttrId) followed by the attribute's contents.
+/// A parser to parse [AttrId](crate::attribute::AttrId) followed by the attribute's contents.
 pub fn attr_parse<'a>(state_stream: &mut StateStream<'a>) -> ParseResult<'a, AttrObj> {
     AttrObj::parse(state_stream, ())
 }

--- a/src/op.rs
+++ b/src/op.rs
@@ -206,7 +206,7 @@ pub trait Op: Downcast + Verify + Printable + DynClone {
     where
         Self: Sized + Parsable<Arg = Vec<(Identifier, Location)>, Parsed = OpBox>,
     {
-        let op_parser: OpParserFn = Box::new(|&(), args| Self::parser(args));
+        let op_parser: OpParserFn = Self::parse;
         let opid = Self::get_opid_static();
         Dialect::register(ctx, &opid.dialect).add_op(opid.clone(), op_parser);
     }
@@ -221,12 +221,8 @@ dyn_clone::clone_trait_object!(Op);
 
 /// A storable function pointer to parse a specific [Op].
 /// The [Op]'s [Dialect] maps an [OpId] to such a parser.
-pub(crate) type OpParserFn = Box<
-    for<'a> fn(
-        &'a (),
-        Vec<(Identifier, Location)>,
-    ) -> Box<dyn Parser<StateStream<'a>, Output = OpObj, PartialState = ()> + 'a>,
->;
+pub(crate) type OpParserFn =
+    for<'a> fn(&mut StateStream<'a>, Vec<(Identifier, Location)>) -> ParseResult<'a, OpObj>;
 
 /// [Op] objects are boxed and stored in the IR.
 pub type OpObj = OpBox;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -879,10 +879,8 @@ impl Parsable for Operation {
                     let Some(opid_parser) = dialect.ops.get(&opid) else {
                         input_err!(loc.clone(), "Unregistered Op {}", opid.disp(state.ctx))?
                     };
-                    let op = opid_parser(&(), results.clone())
-                        .parse_stream(parsable_state)
-                        .map(|op| op.get_operation())
-                        .into();
+                    let op = opid_parser(parsable_state, results.clone())
+                        .map(|(op, c)| (op.get_operation(), c));
 
                     if let Ok((op, _)) = op {
                         // Set the location of the operation to be from where we just parsed it.

--- a/src/type.rs
+++ b/src/type.rs
@@ -162,13 +162,10 @@ pub trait Type: Printable + Verify + Downcast + Sync + Send + Debug {
     where
         Self: Sized + Parsable<Arg = (), Parsed = TypedHandle<Self>>,
     {
-        let ptr_parser: TypeParserFn = Box::new(|&()| {
-            combine::parser(move |parsable_state: &mut StateStream<'_>| {
-                Self::parse(parsable_state, ())
-                    .map(|(typtr, r)| -> (TypeHandle, _) { (typtr.to_handle(), r) })
-            })
-            .boxed()
-        });
+        let ptr_parser: TypeParserFn = |parsable_state, &()| {
+            Self::parse(parsable_state, ())
+                .map(|(typtr, r)| -> (TypeHandle, _) { (typtr.to_handle(), r) })
+        };
         let typeid = Self::get_type_id_static();
         Dialect::register(ctx, &typeid.dialect.clone()).add_type(typeid, ptr_parser);
     }
@@ -177,12 +174,8 @@ impl_downcast!(Type);
 
 /// A storable function pointer to parse a specific [Type].
 /// The [Type]'s [Dialect] maps a [TypeId] to such a parser.
-pub(crate) type TypeParserFn = Box<
-    for<'a> fn(
-        &'a (),
-    )
-        -> Box<dyn Parser<StateStream<'a>, Output = TypeHandle, PartialState = ()> + 'a>,
->;
+pub(crate) type TypeParserFn =
+    for<'a> fn(&mut StateStream<'a>, &'a ()) -> ParseResult<'a, TypeHandle>;
 
 /// Trait for IR entities that have a direct type.
 pub trait Typed {
@@ -388,7 +381,7 @@ impl Parsable for TypeHandle {
                 let Some(type_parser) = dialect.types.get(&type_id) else {
                     input_err!(loc.clone(), "Unregistered type {}", type_id.disp(state.ctx))?
                 };
-                type_parser(&()).parse_stream(parsable_state).into()
+                type_parser(parsable_state, &())
             })
         });
 


### PR DESCRIPTION
Replaces immediately consumed `parser` calls with `parse` to avoid the overhead of `FnParser` and result conversion.

This is directly visible in code size, reducing `pliron-spirv`'s LLVM footprint from a base ~1.5mil by ~100k lines from the changes to the `register` methods, and ~300k from switching over the canonical parser to `parse`. It should also improve performance by eliminating round trips on the result type, though that's harder to measure.