### PR TITLE
Further optimize combinator codegen

### DIFF
--- a/src/irfmt/parsers.rs
+++ b/src/irfmt/parsers.rs
@@ -16,7 +16,7 @@ use crate::{
     identifier::Identifier,
     location::{Located, Location},
     operation::Operation,
-    parsable::{IntoParseResult, Parsable, ParseResult, StateStream},
+    parsable::{IntoParseResult, Parsable, ParseResult, StateStream, parser_combinator},
     result::Result,
     r#type::TypeHandle,
     value::Value,
@@ -85,11 +85,10 @@ where
 pub fn int_parser<'a, IntT>()
 -> Box<dyn Parser<StateStream<'a>, Output = IntT, PartialState = ()> + 'a>
 where
-    IntT: FromStr,
+    IntT: FromStr + 'a,
     IntT::Err: core::error::Error + Send + Sync + 'static,
 {
-    combine::parser(move |parsable_state: &mut StateStream<'a>| int_parse(parsable_state, ()))
-        .boxed()
+    parser_combinator(int_parse, ())
 }
 
 /// A trait for parsing an integer from a string with a given radix.
@@ -129,10 +128,9 @@ where
 pub fn hex_int_parser<'a, IntT>()
 -> Box<dyn Parser<StateStream<'a>, Output = IntT, PartialState = ()> + 'a>
 where
-    IntT: FromStrRadix,
+    IntT: FromStrRadix + 'a,
 {
-    combine::parser(move |parsable_state: &mut StateStream<'a>| hex_int_parse(parsable_state, ()))
-        .boxed()
+    parser_combinator(hex_int_parse, ())
 }
 
 /// Parse a quoted string, which is a double-quoted string that may contain escaped characters.
@@ -180,10 +178,7 @@ pub fn quoted_string_parse<'a>(
 /// A parser combinator to parse a quoted string, which is a double-quoted string that may contain escaped characters.
 pub fn quoted_string_parser<'a>()
 -> Box<dyn Parser<StateStream<'a>, Output = String, PartialState = ()> + 'a> {
-    combine::parser(move |parsable_state: &mut StateStream<'a>| {
-        quoted_string_parse(parsable_state, ())
-    })
-    .boxed()
+    parser_combinator(quoted_string_parse, ())
 }
 
 /// A parser to parse [AttrId](crate::attribute::AttrId) followed by the attribute's contents.
@@ -246,8 +241,7 @@ pub fn ssa_opd_parse<'a>(state_stream: &mut StateStream<'a>, _arg: ()) -> ParseR
 /// a [forward reference](crate::builtin::ops::ForwardRefOp) is returned.
 pub fn ssa_opd_parser<'a>()
 -> Box<dyn Parser<StateStream<'a>, Output = Value, PartialState = ()> + 'a> {
-    combine::parser(move |parsable_state: &mut StateStream<'a>| ssa_opd_parse(parsable_state, ()))
-        .boxed()
+    parser_combinator(ssa_opd_parse, ())
 }
 
 /// Parse a block label into a [`Ptr<BasicBlock>`]. Typically called to parse
@@ -272,16 +266,7 @@ pub fn block_opd_parse<'a>(
 /// the block operands of an [Operation]. If the block doesn't exist, it's created,
 pub fn block_opd_parser<'a>()
 -> Box<dyn Parser<StateStream<'a>, Output = Ptr<BasicBlock>, PartialState = ()> + 'a> {
-    combine::parser(move |parsable_state: &mut StateStream<'a>| block_opd_parse(parsable_state, ()))
-        .boxed()
-}
-
-#[inline(never)]
-pub fn parsable_parser<'a, Arg: Clone + 'static, Output: 'a>(
-    parse: fn(&mut StateStream<'a>, Arg) -> ParseResult<'a, Output>,
-    args: Arg,
-) -> Box<dyn Parser<StateStream<'a>, Output = Output, PartialState = ()> + 'a> {
-    combine::parser(move |state_stream| parse(state_stream, args.clone())).boxed()
+    parser_combinator(block_opd_parse, ())
 }
 
 /// After an [Operation] is fully parsed, for each result,

--- a/src/irfmt/parsers.rs
+++ b/src/irfmt/parsers.rs
@@ -276,6 +276,14 @@ pub fn block_opd_parser<'a>()
         .boxed()
 }
 
+#[inline(never)]
+pub fn parsable_parser<'a, Arg: Clone + 'static, Output: 'a>(
+    parse: fn(&mut StateStream<'a>, Arg) -> ParseResult<'a, Output>,
+    args: Arg,
+) -> Box<dyn Parser<StateStream<'a>, Output = Output, PartialState = ()> + 'a> {
+    combine::parser(move |state_stream| parse(state_stream, args.clone())).boxed()
+}
+
 /// After an [Operation] is fully parsed, for each result,
 /// set its name and register it as an SSA definition.
 pub fn process_parsed_ssa_defs(

--- a/src/op.rs
+++ b/src/op.rs
@@ -418,8 +418,12 @@ pub fn canonical_syntax_parse<'a, T: Op>(
     state_stream: &mut StateStream<'a>,
     results: Vec<(Identifier, Location)>,
 ) -> ParseResult<'a, OpObj> {
-    canonical_syntax_parse_impl(state_stream, results, T::get_concrete_op_info())
-        .map(|(op, c)| (T::wrap_operation(op), c))
+    canonical_syntax_parse_impl(
+        state_stream,
+        results,
+        T::get_concrete_op_info,
+        T::wrap_operation,
+    )
 }
 
 /// We keep the non-generic impl of [canonical_syntax_parse] separate to reduce code bloat
@@ -427,8 +431,9 @@ pub fn canonical_syntax_parse<'a, T: Op>(
 fn canonical_syntax_parse_impl<'a>(
     state_stream: &mut StateStream<'a>,
     results: Vec<(Identifier, Location)>,
-    concrete_op: ConcreteOpInfo,
-) -> ParseResult<'a, Ptr<Operation>> {
+    concrete_op: fn() -> ConcreteOpInfo,
+    wrap_op: fn(Ptr<Operation>) -> OpObj,
+) -> ParseResult<'a, OpObj> {
     // Results and opid have already been parsed. Continue after that.
     let mut without_regions = delimited_list_parser('(', ')', ',', ssa_opd_parser())
         .and(spaces().with(delimited_list_parser('[', ']', ',', block_opd_parser())))
@@ -467,7 +472,7 @@ fn canonical_syntax_parse_impl<'a>(
                     }
                     let opr = Operation::new(
                         ctx,
-                        concrete_op,
+                        concrete_op(),
                         fty.results.clone(),
                         operands.clone(),
                         successors.clone(),
@@ -484,7 +489,7 @@ fn canonical_syntax_parse_impl<'a>(
     zero_or_more_parser(Region::parser(op))
         .parse_stream(state_stream)
         .into_result()?;
-    Ok(op).into_parse_result()
+    Ok(wrap_op(op)).into_parse_result()
 }
 
 /// Parser for an [Op] in canonical syntax.

--- a/src/parsable.rs
+++ b/src/parsable.rs
@@ -24,7 +24,7 @@ use crate::{
     context::{Context, Ptr},
     identifier::Identifier,
     input_err,
-    irfmt::parsers::{hex_int_parser, int_parser, parsable_parser, quoted_string_parser},
+    irfmt::parsers::{hex_int_parser, int_parser, quoted_string_parser},
     location::{self, Located, Location, Source},
     op::op_impls,
     operation::Operation,
@@ -158,8 +158,17 @@ pub trait Parsable {
     where
         Self::Parsed: 'a,
     {
-        parsable_parser(Self::parse, arg)
+        parser_combinator(Self::parse, arg)
     }
+}
+
+/// Build a parser combinator from a [Parsable::parse] function and its argument.
+#[inline(never)]
+pub fn parser_combinator<'a, Arg: Clone + 'static, Output: 'a>(
+    parse: fn(&mut StateStream<'a>, Arg) -> ParseResult<'a, Output>,
+    args: Arg,
+) -> Box<dyn Parser<StateStream<'a>, Output = Output, PartialState = ()> + 'a> {
+    combine::parser(move |state_stream| parse(state_stream, args.clone())).boxed()
 }
 
 /// Build a [StateStream] from an iterator, for use with [Parsable].

--- a/src/parsable.rs
+++ b/src/parsable.rs
@@ -24,7 +24,7 @@ use crate::{
     context::{Context, Ptr},
     identifier::Identifier,
     input_err,
-    irfmt::parsers::{hex_int_parser, int_parser, quoted_string_parser},
+    irfmt::parsers::{hex_int_parser, int_parser, parsable_parser, quoted_string_parser},
     location::{self, Located, Location, Source},
     op::op_impls,
     operation::Operation,
@@ -154,11 +154,11 @@ pub trait Parsable {
     /// Get a parser combinator that can work on [StateStream] as its input.
     fn parser<'a>(
         arg: Self::Arg,
-    ) -> Box<dyn Parser<StateStream<'a>, Output = Self::Parsed, PartialState = ()> + 'a> {
-        combine::parser(move |parsable_state: &mut StateStream<'a>| {
-            Self::parse(parsable_state, arg.clone())
-        })
-        .boxed()
+    ) -> Box<dyn Parser<StateStream<'a>, Output = Self::Parsed, PartialState = ()> + 'a>
+    where
+        Self::Parsed: 'a,
+    {
+        parsable_parser(Self::parse, arg)
     }
 }
 


### PR DESCRIPTION
Moves some more combinator code to use function pointers, to move as much code as possible out of the monomorphized portion and into the generic implementation.

While `parser_combinator` is monomorphized for every `(Arg, Output)` pair, all ops share the same `Vec<(Identifier, Location)>` arg and `OpObj` output. When the parser is crated inside the default trait method, it's monomorphized for every implementor and creates unique closure types for every op, even when the closure has identical contents and type. The standalone function takes a function pointer instead, which does not trigger monomorphization for each implementor.

Less impactful than the last PR, but still adds up to ~7% less overall codegen in `pliron-spirv`. Combinator-related code is now nearly gone, with remaining code being actual implementations (and `cast_to_trait` but that's a different issue). So I think this is as far as the combinator-related changes can be pushed.

Here's the breakdown:
`parsable_parser`: ~8k lines saved (because most parsers were already unused and stripped by rustc)
Moving the `map` into `canonical_syntax_parse_impl`: ~24k lines saved
Moving the call to `concrete_op_info` into `canonical_syntax_parse_impl`: ~12k lines saved

Note on parser signature:
The `where Self::Parsed: 'a` bound should've been required the whole time because function pointers are only valid for the minimum of all lifetimes they contain, but it wasn't properly enforced because the compiler allows some things locally that aren't valid in a function signature. This shouldn't be a breaking change anywhere.