### PR TITLE
perf: Improve codegen for `cast_to_trait`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -328,10 +328,9 @@ pub mod statics {
 
     #[::pliron::linkme::distributed_slice]
     #[linkme(crate = ::pliron::linkme)]
-    pub static CONTEXT_REGISTRATIONS: [LazyLock<ContextRegistration>];
+    pub static CONTEXT_REGISTRATIONS: [ContextRegistration];
 
-    pub fn get_context_registrations()
-    -> impl Iterator<Item = &'static LazyLock<ContextRegistration>> {
+    pub fn get_context_registrations() -> impl Iterator<Item = &'static ContextRegistration> {
         CONTEXT_REGISTRATIONS.iter()
     }
 }
@@ -347,12 +346,10 @@ pub mod statics {
         ::pliron::inventory::iter::<InventoryWrapper<LazyLock<DictKeyId>>>().map(|llw| llw.0)
     }
 
-    ::pliron::inventory::collect!(InventoryWrapper<LazyLock<ContextRegistration>>);
+    ::pliron::inventory::collect!(InventoryWrapper<ContextRegistration>);
 
-    pub fn get_context_registrations()
-    -> impl Iterator<Item = &'static LazyLock<ContextRegistration>> {
-        ::pliron::inventory::iter::<InventoryWrapper<LazyLock<ContextRegistration>>>()
-            .map(|llw| llw.0)
+    pub fn get_context_registrations() -> impl Iterator<Item = &'static ContextRegistration> {
+        ::pliron::inventory::iter::<InventoryWrapper<ContextRegistration>>().map(|llw| llw.0)
     }
 }
 
@@ -486,7 +483,7 @@ macro_rules! dict_key {
 /// context_registration!(my_registration_fn);
 /// fn my_registration_fn(_: &mut pliron::context::Context) {}
 /// ```
-/// Here, `my_registration_fn` is a function or closure matching [ContextRegistration].
+/// Here, `my_registration_fn` is a function matching [ContextRegistration].
 #[macro_export]
 macro_rules! context_registration {
     (   $(#[$outer:meta])*
@@ -496,8 +493,7 @@ macro_rules! context_registration {
             $(#[$outer])*
             #[cfg_attr(not(target_family = "wasm"),
                 ::pliron::linkme::distributed_slice(::pliron::context::CONTEXT_REGISTRATIONS), linkme(crate = ::pliron::linkme))]
-            static CONTEXT_REGISTRATION: $crate::std_deps::sync::LazyLock<::pliron::context::ContextRegistration> =
-                $crate::std_deps::sync::LazyLock::new(|| $registration);
+            static CONTEXT_REGISTRATION: ::pliron::context::ContextRegistration = $registration;
 
             #[cfg(target_family = "wasm")]
             ::pliron::inventory::submit! {


### PR DESCRIPTION
`cast_to_trait` currently uses checked conversion, which inserts multiple switch statements and generates a very large amount of code (~45 lines of LLVM). Since this code is generated for every single trait implementation it drastically increases code footprint.

There are actually several invariants that allow this code to be reduced:
 * The cast function can only be retrieved by providing the correct `TypeId` in the first place, and is downcast via a checked cast so the return type is additionally verified. This means `Any::is::<T>` cannot ever fail and can be removed.
 * Since we know the type is correct, the alignment is guaranteed since Rust doesn't allow misaligned references, and the source of the reference is a properly aligned `Box`. So we can skip the pointer alignment checks Rust would normally insert by transmuting to a reference.
 
 This new implementation generates only 4 lines of LLVM and reduces the overall code footprint in `pliron-spirv` by 20% even at just 1-3 interface implementations per op. The impact would be larger the more interfaces each op implements.
 
 I'd like to avoid the hacky transmute, but I've unfortunately confirmed that Rust is not smart enough to elide the alignment checks even though the pointer was just created from an aligned reference. So the transmute is necessary for good codegen. The pointer cast itself is identical to the nightly-only `Any::downcast_unchecked_ref`, so should be totally fine. I've also tested `unwrap_unchecked`, but it generates significantly worse code (see also [this comment on the tracking issue for `downcast_unchecked`](https://github.com/rust-lang/rust/issues/90850#issuecomment-1312812680)).