### PR TITLE
added ConstFoldInterface implementations for `fmul`, `fdiv`, and `frem`

### DIFF
--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -784,6 +784,57 @@ impl ConstFoldInterface for FSubOp {
 }
 
 #[op_interface_impl]
+impl ConstFoldInterface for FMulOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_bin_op(ops, self.fast_math_flags(ctx), |lhs, rhs| {
+            lhs.mul(rhs).value
+        })
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FDivOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_bin_op(ops, self.fast_math_flags(ctx), |lhs, rhs| {
+            lhs.div(rhs).value
+        })
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
+impl ConstFoldInterface for FRemOp {
+    fn check_fold(&self, ctx: &Context, ops: &[Option<AttrObj>]) -> Vec<Option<AttrObj>> {
+        check_fold_float_bin_op(ops, self.fast_math_flags(ctx), |lhs, rhs| {
+            lhs.rem(rhs).value
+        })
+    }
+    fn fold_in_place(
+        &self,
+        ctx: &mut Context,
+        ops: &[Option<AttrObj>],
+        rw: &mut dyn Rewriter,
+    ) -> IRStatus {
+        self.fold_with_materialization(ctx, ops, rw)
+    }
+}
+
+#[op_interface_impl]
 impl BranchOpFoldInterface for BrOp {
     fn check_fold(&self, ctx: &Context, _operands: &[Option<AttrObj>]) -> Vec<Ptr<BasicBlock>> {
         self.get_operation().deref(ctx).successors().collect()

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -1598,3 +1598,554 @@ fn fsub_nnan_does_not_fold_nan_result() -> Result<()> {
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// llvm.fmul
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fmul_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fmul <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 10> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn fmul_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fmul <> x, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fmul_folds_negative_operands_to_positive() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single -2.5> : builtin.fp32;
+        b = builtin.constant <builtin.single -4.0> : builtin.fp32;
+        c = llvm.fmul <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 10> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn fmul_folds_infinity_and_finite() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.0> : builtin.fp32;
+        c = llvm.fmul <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after
+            .matches("<builtin.single +Inf> : builtin.fp32")
+            .count(),
+        2
+    );
+    Ok(())
+}
+
+#[test]
+fn fmul_folds_zero_times_infinity_to_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fmul <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn fmul_folds_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.0> : builtin.fp32;
+        c = llvm.fmul <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        2
+    );
+    Ok(())
+}
+
+#[test]
+fn fmul_ninf_does_not_fold_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.0> : builtin.fp32;
+        c = llvm.fmul <NINF> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fmul_nnan_does_not_fold_nan_result() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fmul <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fmul_nnan_still_folds_finite() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fmul <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 10> : builtin.fp32"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.fdiv
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fdiv_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 10.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fdiv <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 2.5> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn fdiv_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fdiv <> x, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fdiv_folds_finite_by_zero_to_infinity() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        c = llvm.fdiv <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after
+            .matches("<builtin.single +Inf> : builtin.fp32")
+            .count(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn fdiv_folds_zero_by_zero_to_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        c = llvm.fdiv <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn fdiv_folds_infinity_by_infinity_to_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fdiv <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn fdiv_folds_finite_by_infinity_to_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.fdiv <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 0> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn fdiv_folds_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.0> : builtin.fp32;
+        c = llvm.fdiv <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        2
+    );
+    Ok(())
+}
+
+#[test]
+fn fdiv_ninf_does_not_fold_division_by_zero() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        c = llvm.fdiv <NINF> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fdiv_nnan_does_not_fold_nan_result() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        c = llvm.fdiv <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn fdiv_nnan_still_folds_finite() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 10.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.fdiv <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 2.5> : builtin.fp32"));
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// llvm.frem
+// ---------------------------------------------------------------------------
+
+#[test]
+fn frem_folds_two_constants() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 10.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.frem <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 2> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn frem_does_not_fold_with_non_constant_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 (builtin.fp32) variadic = false> [] {
+        ^entry(x: builtin.fp32):
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.frem <> x, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+/// `frem` truncates toward zero, so the result takes the sign of the dividend
+/// rather than rounding to nearest as IEEE `remainder` would.
+#[test]
+fn frem_result_takes_sign_of_dividend() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single -10.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.frem <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single -2> : builtin.fp32"));
+    Ok(())
+}
+
+/// IEEE `remainder(3.0, 2.0)` would be -1.0; `frem`/`fmod` must give 1.0.
+#[test]
+fn frem_truncates_rather_than_rounding_to_nearest() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 3.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.0> : builtin.fp32;
+        c = llvm.frem <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 1> : builtin.fp32"));
+    Ok(())
+}
+
+#[test]
+fn frem_folds_by_zero_to_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        c = llvm.frem <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        1
+    );
+    Ok(())
+}
+
+#[test]
+fn frem_folds_infinity_dividend_to_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.0> : builtin.fp32;
+        c = llvm.frem <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        1
+    );
+    Ok(())
+}
+
+/// A finite dividend with an infinite divisor returns the dividend unchanged.
+#[test]
+fn frem_folds_infinity_divisor_to_dividend() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.frem <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single 2.5> : builtin.fp32").count(),
+        2
+    );
+    Ok(())
+}
+
+#[test]
+fn frem_folds_nan() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single NaN> : builtin.fp32;
+        b = builtin.constant <builtin.single 2.0> : builtin.fp32;
+        c = llvm.frem <> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert_eq!(
+        after.matches("<builtin.single NaN> : builtin.fp32").count(),
+        2
+    );
+    Ok(())
+}
+
+#[test]
+fn frem_nnan_does_not_fold_nan_result() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 1.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 0.0> : builtin.fp32;
+        c = llvm.frem <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn frem_ninf_does_not_fold_infinite_operand() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 2.5> : builtin.fp32;
+        b = builtin.constant <builtin.single +Inf> : builtin.fp32;
+        c = llvm.frem <NINF> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, _after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Unchanged);
+    Ok(())
+}
+
+#[test]
+fn frem_nnan_still_folds_finite() -> Result<()> {
+    let input = r#"
+      llvm.func @f: llvm.func <builtin.fp32 () variadic = false> [] {
+        ^entry():
+        a = builtin.constant <builtin.single 10.0> : builtin.fp32;
+        b = builtin.constant <builtin.single 4.0> : builtin.fp32;
+        c = llvm.frem <NNAN> a, b : builtin.fp32;
+        llvm.return c
+      }
+    "#;
+    let (status, _before, after) = run_sccp_on_text(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(after.contains("<builtin.single 2> : builtin.fp32"));
+    Ok(())
+}


### PR DESCRIPTION
This PR works on https://github.com/pliron-org/pliron/issues/118 but does not close the issue. It implements ConstFoldInterface for `fmul`, `fdiv`, and `frem`. The implementations are straightforward, as they only produce poison when using the `nnan` and `nninf` flags, which are already handled by `check_fold_float_bin_op`.