### PR TITLE
Add `lua` to the llvm-opt testsuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,15 @@ LLVM-IR bitcode.
 ### Using the Library
 Add a dependence on the [crate](https://crates.io/crates/pliron) in your Rust project.
 
-Note: `pliron` is under active development. Every effort is made to ensure that the code is well tested
-and of production quality. The LLVM dialect, although not complete, can be useful practically. It can,
-for example, [compile bzip2](https://github.com/pliron-org/pliron/wiki/Compiling-bzip2-through-pliron's-LLVM-dialect).
+#### Current Status:
+`pliron` is under active development. Every effort is made to ensure that the
+code is well tested and of production quality.
+
+The LLVM dialect, although not complete, can be useful practically. It can,
+for example, [compile bzip2](https://github.com/pliron-org/pliron/wiki/Compiling-bzip2-through-pliron's-LLVM-dialect)
+and [lua](https://github.com/lua/lua) and run their test suites. These two are
+already part of our [llvm-opt testsuite](pliron-llvm/llvm-opt/tests/testsuite/README.md).
+
 We also plan to start work on supporting a cranelift dialect/backend soon.
 
 ### Documentation & Resources

--- a/pliron-llvm/llvm-opt/tests/testsuite/README
+++ b/pliron-llvm/llvm-opt/tests/testsuite/README
@@ -1,21 +1,21 @@
-Real-world wrapper tests live in this directory.
+# Real-world wrapper tests
 
-Each script must:
-- run in an isolated temporary directory,
-- build a real C program using llvm-opt-wrapper.sh as CC,
-- validate an expected success marker,
-- return non-zero on failure.
+Each script:
+- runs in an isolated temporary directory,
+- builds a real C program using llvm-opt-wrapper.sh as CC,
+- validates an expected success marker,
+- returns non-zero on failure.
 
-Currently available tests:
+## Currently available tests:
 - bzip2.sh: clones bzip2, checks out bzip2-1.0.8, runs make with wrapper,
   and verifies upstream self-tests succeeded.
 - lua.sh: clones lua, checks out v5.5.0, runs make with wrapper,
   and verifies the upstream test suite succeeded.
 
-Runner:
-- ../testsuite.sh discovers and executes all *.sh scripts in this directory.
+## Runner
+- `../testsuite.sh` discovers and executes all *.sh scripts in this directory.
 
-Environment variables:
+## Environment variables:
 - LLVM_OPT_WRAPPER: path to llvm-opt-wrapper.sh
   default: pliron-llvm/llvm-opt/llvm-opt-wrapper.sh
 - LLVM_OPT: path to llvm-opt binary

--- a/pliron-llvm/llvm-opt/tests/testsuite/README
+++ b/pliron-llvm/llvm-opt/tests/testsuite/README
@@ -9,6 +9,8 @@ Each script must:
 Currently available tests:
 - bzip2.sh: clones bzip2, checks out bzip2-1.0.8, runs make with wrapper,
   and verifies upstream self-tests succeeded.
+- lua.sh: clones lua, checks out v5.5.0, runs make with wrapper,
+  and verifies the upstream test suite succeeded.
 
 Runner:
 - ../testsuite.sh discovers and executes all *.sh scripts in this directory.

--- a/pliron-llvm/llvm-opt/tests/testsuite/bzip2.sh
+++ b/pliron-llvm/llvm-opt/tests/testsuite/bzip2.sh
@@ -24,25 +24,25 @@ WRAPPER="${LLVM_OPT_WRAPPER:-$ROOT_DIR/llvm-opt-wrapper.sh}"
 LLVM_OPT_BIN="${LLVM_OPT:-$ROOT_DIR/../../target/debug/llvm-opt}"
 
 if [[ ! -x "$WRAPPER" ]]; then
-	echo "[bzip2] wrapper not found or not executable: $WRAPPER" >&2
-	echo "[bzip2] set LLVM_OPT_WRAPPER=/path/to/llvm-opt-wrapper.sh" >&2
-	exit 1
+  echo "[bzip2] wrapper not found or not executable: $WRAPPER" >&2
+  echo "[bzip2] set LLVM_OPT_WRAPPER=/path/to/llvm-opt-wrapper.sh" >&2
+  exit 1
 fi
 
 if [[ ! -x "$LLVM_OPT_BIN" ]]; then
-	echo "[bzip2] llvm-opt binary not found or not executable: $LLVM_OPT_BIN" >&2
-	echo "[bzip2] set LLVM_OPT=/path/to/llvm-opt" >&2
-	exit 1
+  echo "[bzip2] llvm-opt binary not found or not executable: $LLVM_OPT_BIN" >&2
+  echo "[bzip2] set LLVM_OPT=/path/to/llvm-opt" >&2
+  exit 1
 fi
 
 if ! command -v git >/dev/null 2>&1; then
-	echo "[bzip2] git is required" >&2
-	exit 1
+  echo "[bzip2] git is required" >&2
+  exit 1
 fi
 
 if ! command -v make >/dev/null 2>&1; then
-	echo "[bzip2] make is required" >&2
-	exit 1
+  echo "[bzip2] make is required" >&2
+  exit 1
 fi
 
 workdir="$(mktemp -d "${TMPDIR:-/tmp}/llvm-opt-tests-bzip2.XXXXXX")"
@@ -60,21 +60,21 @@ echo "[bzip2] building with wrapper"
 
 build_log="$workdir/bzip2-make.log"
 if ! make \
-	CC="$WRAPPER" \
-	LLVM_OPT="$LLVM_OPT_BIN" \
-	-j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" \
-	2>&1 | tee "$build_log"; then
-	echo "[bzip2] build failed; tail of log:" >&2
-	tail -n 80 "$build_log" >&2 || true
-	exit 1
+  CC="$WRAPPER" \
+  LLVM_OPT="$LLVM_OPT_BIN" \
+  -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" \
+  2>&1 | tee "$build_log"; then
+  echo "[bzip2] build failed; tail of log:" >&2
+  tail -n 80 "$build_log" >&2 || true
+  exit 1
 fi
 
 # The upstream Makefile runs compression self-tests and prints this on success.
 if ! grep -F "you're in business" "$build_log" >/dev/null 2>&1; then
-	echo "[bzip2] self-test success marker not found in build output" >&2
-	echo "[bzip2] expected phrase: you're in business" >&2
-	tail -n 120 "$build_log" >&2 || true
-	exit 1
+  echo "[bzip2] self-test success marker not found in build output" >&2
+  echo "[bzip2] expected phrase: you're in business" >&2
+  tail -n 120 "$build_log" >&2 || true
+  exit 1
 fi
 
 echo "[bzip2] PASS"

--- a/pliron-llvm/llvm-opt/tests/testsuite/lua.sh
+++ b/pliron-llvm/llvm-opt/tests/testsuite/lua.sh
@@ -24,25 +24,25 @@ WRAPPER="${LLVM_OPT_WRAPPER:-$ROOT_DIR/llvm-opt-wrapper.sh}"
 LLVM_OPT_BIN="${LLVM_OPT:-$ROOT_DIR/../../target/debug/llvm-opt}"
 
 if [[ ! -x "$WRAPPER" ]]; then
-	echo "[lua] wrapper not found or not executable: $WRAPPER" >&2
-	echo "[lua] set LLVM_OPT_WRAPPER=/path/to/llvm-opt-wrapper.sh" >&2
-	exit 1
+  echo "[lua] wrapper not found or not executable: $WRAPPER" >&2
+  echo "[lua] set LLVM_OPT_WRAPPER=/path/to/llvm-opt-wrapper.sh" >&2
+  exit 1
 fi
 
 if [[ ! -x "$LLVM_OPT_BIN" ]]; then
-	echo "[lua] llvm-opt binary not found or not executable: $LLVM_OPT_BIN" >&2
-	echo "[lua] set LLVM_OPT=/path/to/llvm-opt" >&2
-	exit 1
+  echo "[lua] llvm-opt binary not found or not executable: $LLVM_OPT_BIN" >&2
+  echo "[lua] set LLVM_OPT=/path/to/llvm-opt" >&2
+  exit 1
 fi
 
 if ! command -v git >/dev/null 2>&1; then
-	echo "[lua] git is required" >&2
-	exit 1
+  echo "[lua] git is required" >&2
+  exit 1
 fi
 
 if ! command -v make >/dev/null 2>&1; then
-	echo "[lua] make is required" >&2
-	exit 1
+  echo "[lua] make is required" >&2
+  exit 1
 fi
 
 workdir="$(mktemp -d "${TMPDIR:-/tmp}/llvm-opt-tests-lua.XXXXXX")"
@@ -60,30 +60,30 @@ echo "[lua] building with wrapper"
 
 build_log="$workdir/lua-make.log"
 if ! make \
-	CC="$WRAPPER" \
-	LLVM_OPT="$LLVM_OPT_BIN" \
-	-j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" \
-	2>&1 | tee "$build_log"; then
-	echo "[lua] build failed; tail of log:" >&2
-	tail -n 80 "$build_log" >&2 || true
-	exit 1
+  CC="$WRAPPER" \
+  LLVM_OPT="$LLVM_OPT_BIN" \
+  -j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" \
+  2>&1 | tee "$build_log"; then
+  echo "[lua] build failed; tail of log:" >&2
+  tail -n 80 "$build_log" >&2 || true
+  exit 1
 fi
 
 echo "[lua] running upstream test suite"
 
 test_log="$workdir/lua-test.log"
 if ! (cd testes && "$workdir/lua/lua" -e "_U=true" all.lua) >"$test_log" 2>&1; then
-	echo "[lua] test suite run failed; tail of log:" >&2
-	tail -n 80 "$test_log" >&2 || true
-	exit 1
+  echo "[lua] test suite run failed; tail of log:" >&2
+  tail -n 80 "$test_log" >&2 || true
+  exit 1
 fi
 
 # The upstream test suite prints this on success.
 if ! grep -F "final OK !!!" "$test_log" >/dev/null 2>&1; then
-	echo "[lua] self-test success marker not found in test output" >&2
-	echo "[lua] expected phrase: final OK !!!" >&2
-	tail -n 120 "$test_log" >&2 || true
-	exit 1
+  echo "[lua] self-test success marker not found in test output" >&2
+  echo "[lua] expected phrase: final OK !!!" >&2
+  tail -n 120 "$test_log" >&2 || true
+  exit 1
 fi
 
 echo "[lua] PASS"

--- a/pliron-llvm/llvm-opt/tests/testsuite/lua.sh
+++ b/pliron-llvm/llvm-opt/tests/testsuite/lua.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Standalone usage:
+#   bash tests/testsuite/lua.sh
+#
+# Run from anywhere with explicit tool paths:
+#   LLVM_OPT_WRAPPER=/path/to/llvm-opt-wrapper.sh \
+#   LLVM_OPT=/path/to/llvm-opt \
+#   bash tests/testsuite/lua.sh
+#
+# What this script does:
+# - creates an isolated temporary directory,
+# - clones lua from GitHub,
+# - checks out tag v5.5.0,
+# - builds with CC set to llvm-opt-wrapper,
+# - runs the upstream Lua test suite and verifies its success marker.
+#
+# Requirements: git, make, a working clang toolchain, llvm-opt-wrapper.sh, llvm-opt.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WRAPPER="${LLVM_OPT_WRAPPER:-$ROOT_DIR/llvm-opt-wrapper.sh}"
+LLVM_OPT_BIN="${LLVM_OPT:-$ROOT_DIR/../../target/debug/llvm-opt}"
+
+if [[ ! -x "$WRAPPER" ]]; then
+	echo "[lua] wrapper not found or not executable: $WRAPPER" >&2
+	echo "[lua] set LLVM_OPT_WRAPPER=/path/to/llvm-opt-wrapper.sh" >&2
+	exit 1
+fi
+
+if [[ ! -x "$LLVM_OPT_BIN" ]]; then
+	echo "[lua] llvm-opt binary not found or not executable: $LLVM_OPT_BIN" >&2
+	echo "[lua] set LLVM_OPT=/path/to/llvm-opt" >&2
+	exit 1
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+	echo "[lua] git is required" >&2
+	exit 1
+fi
+
+if ! command -v make >/dev/null 2>&1; then
+	echo "[lua] make is required" >&2
+	exit 1
+fi
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/llvm-opt-tests-lua.XXXXXX")"
+trap 'rm -rf "$workdir"' EXIT
+
+echo "[lua] using temporary directory: $workdir"
+echo "[lua] cloning lua"
+
+git clone https://github.com/lua/lua.git "$workdir/lua" >/dev/null 2>&1
+cd "$workdir/lua"
+
+git checkout v5.5.0 >/dev/null 2>&1
+
+echo "[lua] building with wrapper"
+
+build_log="$workdir/lua-make.log"
+if ! make \
+	CC="$WRAPPER" \
+	LLVM_OPT="$LLVM_OPT_BIN" \
+	-j"$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)" \
+	2>&1 | tee "$build_log"; then
+	echo "[lua] build failed; tail of log:" >&2
+	tail -n 80 "$build_log" >&2 || true
+	exit 1
+fi
+
+echo "[lua] running upstream test suite"
+
+test_log="$workdir/lua-test.log"
+if ! (cd testes && "$workdir/lua/lua" -e "_U=true" all.lua) >"$test_log" 2>&1; then
+	echo "[lua] test suite run failed; tail of log:" >&2
+	tail -n 80 "$test_log" >&2 || true
+	exit 1
+fi
+
+# The upstream test suite prints this on success.
+if ! grep -F "final OK !!!" "$test_log" >/dev/null 2>&1; then
+	echo "[lua] self-test success marker not found in test output" >&2
+	echo "[lua] expected phrase: final OK !!!" >&2
+	tail -n 120 "$test_log" >&2 || true
+	exit 1
+fi
+
+echo "[lua] PASS"

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -77,11 +77,11 @@ use crate::{
         AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BlockAddressOp, BlockTagOp, BrOp,
         CallIntrinsicOp, CallOp, CondBrOp, ConstantOp, ExtractElementOp, ExtractValueOp, FAddOp,
         FCmpOp, FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp,
-        FenceOp, FreezeOp, FuncOp, GepIndex, GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp,
-        InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp,
-        PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp,
-        StoreOp, SubOp, SwitchCase, SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp,
-        UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
+        FenceOp, FreezeOp, FuncOp, GepIndex, GetElementPtrOp, GlobalOp, ICmpOp, IndirectBrOp,
+        InlineAsmOp, InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp,
+        PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp,
+        ShuffleVectorOp, StoreOp, SubOp, SwitchCase, SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp,
+        UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
     },
     types::{
         ArrayType, FuncType, PointerType, StructErr, StructType, VectorType, VectorTypeKind,
@@ -320,6 +320,12 @@ fn successors(block: LLVMBasicBlock) -> Vec<LLVMBasicBlock> {
                 )));
             }
             succs
+        }
+        LLVMOpcode::LLVMIndirectBr => {
+            // Operand 0 is the address; the rest are the possible destinations.
+            (1..llvm_get_num_operands(term))
+                .map(|i| llvm_value_as_basic_block(llvm_get_operand(term, i)))
+                .collect()
         }
         LLVMOpcode::LLVMRet | LLVMOpcode::LLVMUnreachable => {
             // No successors.
@@ -1207,7 +1213,22 @@ fn convert_instruction(
                     .get_operation(),
             )
         }
-        LLVMOpcode::LLVMIndirectBr => todo!(),
+        LLVMOpcode::LLVMIndirectBr => {
+            let addr = get_operand(opds, 0)?;
+            let src_block = llvm_get_instruction_parent(inst).unwrap();
+            let dests = succs
+                .iter()
+                .enumerate()
+                .map(|(i, dest)| {
+                    // Operand 0 is the address, so destinations start at operand 1.
+                    let llvm_dest =
+                        llvm_value_as_basic_block(llvm_get_operand(inst, (i + 1) as u32));
+                    let dest_opds = convert_branch_args(ctx, cctx, src_block, llvm_dest)?;
+                    Ok((*dest, dest_opds))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(IndirectBrOp::new(ctx, addr, dests).get_operation())
+        }
         LLVMOpcode::LLVMInsertElement => {
             let vector = get_operand(opds, 0)?;
             let element = get_operand(opds, 1)?;

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -50,8 +50,9 @@ use crate::{
         llvm_const_int_get_zext_value, llvm_const_real_get_double, llvm_count_struct_element_types,
         llvm_get_aggregate_element, llvm_get_alignment, llvm_get_allocated_type,
         llvm_get_array_length2, llvm_get_atomic_rmw_bin_op, llvm_get_atomic_sync_scope_id,
-        llvm_get_basic_block_name, llvm_get_basic_block_terminator, llvm_get_called_function_type,
-        llvm_get_called_value, llvm_get_cmpxchg_failure_ordering,
+        llvm_get_basic_block_name, llvm_get_basic_block_terminator,
+        llvm_get_block_address_basic_block, llvm_get_block_address_function,
+        llvm_get_called_function_type, llvm_get_called_value, llvm_get_cmpxchg_failure_ordering,
         llvm_get_cmpxchg_success_ordering, llvm_get_const_opcode, llvm_get_element_type,
         llvm_get_fast_math_flags, llvm_get_fcmp_predicate, llvm_get_gep_source_element_type,
         llvm_get_icmp_predicate, llvm_get_indices, llvm_get_initializer,
@@ -73,13 +74,14 @@ use crate::{
     },
     ops::{
         AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,
-        AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BrOp, CallIntrinsicOp, CallOp,
-        CondBrOp, ConstantOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp,
-        FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FenceOp, FreezeOp, FuncOp,
-        GepIndex, GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp, InsertElementOp, InsertValueOp,
-        IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp,
-        SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchCase, SwitchOp,
-        TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
+        AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BlockAddressOp, BlockTagOp, BrOp,
+        CallIntrinsicOp, CallOp, CondBrOp, ConstantOp, ExtractElementOp, ExtractValueOp, FAddOp,
+        FCmpOp, FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp,
+        FenceOp, FreezeOp, FuncOp, GepIndex, GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp,
+        InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp,
+        PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp,
+        StoreOp, SubOp, SwitchCase, SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp,
+        UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
     },
     types::{
         ArrayType, FuncType, PointerType, StructErr, StructType, VectorType, VectorTypeKind,
@@ -264,6 +266,11 @@ struct ConversionContext {
     block_map: FxHashMap<LLVMBasicBlock, Ptr<BasicBlock>>,
     /// Cache already converted types.
     type_cache: FxHashMap<LLVMType, TypeHandle>,
+    /// Tag addressed to a (function, block) pair.
+    block_tag_map: FxHashMap<(LLVMValue, LLVMBasicBlock), u64>,
+    /// Next block tag id to assign.
+    /// This is unique across all functions in the module for simplicity.
+    block_tag_counter: u64,
     /// Insertion point for constants in the entry block.
     constants_inserter: Option<IRInserter<DummyListener>>,
     /// Identifier legaliser
@@ -276,8 +283,9 @@ impl ConversionContext {
     /// Identifier::Legaliser remains unmodified.
     fn reset_for_region(&mut self, entry_block: Ptr<BasicBlock>) {
         self.constants_inserter = Some(IRInserter::new_at_block_start(entry_block));
+        // The same LLVM constant values map to different pliron Values in different regions.
+        // So we clear the value map for each region.
         self.value_map.clear();
-        self.block_map.clear();
     }
 }
 
@@ -709,6 +717,28 @@ fn process_constant(ctx: &mut Context, cctx: &mut ConversionContext, val: LLVMVa
             cctx.value_map
                 .insert(val, const_vector.deref(ctx).get_result(0));
         }
+        LLVMValueKind::LLVMBlockAddressValueKind => {
+            let function = llvm_get_block_address_function(val);
+            let block = llvm_get_block_address_basic_block(val);
+            let fn_name = llvm_get_value_name(function).unwrap_or_default();
+            let fn_name = cctx.id_legaliser.legalise(&fn_name);
+            let tag = *cctx
+                .block_tag_map
+                .entry((function, block))
+                .or_insert_with(|| {
+                    let tag = cctx.block_tag_counter;
+                    cctx.block_tag_counter += 1;
+                    tag
+                });
+            let block_addr_op = BlockAddressOp::new(
+                ctx,
+                fn_name,
+                tag,
+                llvm_get_pointer_address_space(llvm_type_of(val)),
+            );
+            insert_const_inst(ctx, cctx, block_addr_op.get_operation());
+            cctx.value_map.insert(val, block_addr_op.get_result(ctx));
+        }
         LLVMValueKind::LLVMArgumentValueKind => todo!(),
         LLVMValueKind::LLVMBasicBlockValueKind => todo!(),
         LLVMValueKind::LLVMMemoryUseValueKind => todo!(),
@@ -716,7 +746,6 @@ fn process_constant(ctx: &mut Context, cctx: &mut ConversionContext, val: LLVMVa
         LLVMValueKind::LLVMMemoryPhiValueKind => todo!(),
         LLVMValueKind::LLVMGlobalAliasValueKind => todo!(),
         LLVMValueKind::LLVMGlobalIFuncValueKind => todo!(),
-        LLVMValueKind::LLVMBlockAddressValueKind => todo!(),
         LLVMValueKind::LLVMConstantTokenNoneValueKind => todo!(),
         LLVMValueKind::LLVMMetadataAsValueValueKind => todo!(),
         LLVMValueKind::LLVMInlineAsmValueKind => todo!(),
@@ -1594,6 +1623,7 @@ pub fn convert_module(ctx: &mut Context, module: &LLVMModule) -> Result<ModuleOp
     }
 
     // Convert functions.
+    let mut func_map = FxHashMap::default();
     for fun in function_iter(module) {
         let llvm_name = llvm_get_value_name(fun).expect("Expected function to have a name");
         if llvm_lookup_intrinsic_id(&llvm_name).is_some() {
@@ -1602,6 +1632,22 @@ pub fn convert_module(ctx: &mut Context, module: &LLVMModule) -> Result<ModuleOp
         }
         let m_fun = convert_function(ctx, cctx, fun)?;
         m.append_operation(ctx, m_fun.get_operation(), 0);
+        func_map.insert(fun, m_fun);
     }
+
+    // We need to insert [BlockTagOp]s for blocks with their address taken.
+    for ((func, block), tag) in &cctx.block_tag_map {
+        if llvm_is_declaration(*func) {
+            // Skip blocks in function declarations.
+            continue;
+        }
+        let m_block = cctx
+            .block_map
+            .get(block)
+            .expect("We should have converted this block");
+        let tag_op = BlockTagOp::new(ctx, *tag);
+        tag_op.get_operation().insert_at_front(*m_block, ctx);
+    }
+
     Ok(m)
 }

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -14,41 +14,42 @@ use llvm_sys::{
     analysis::LLVMVerifyModule,
     bit_writer::LLVMWriteBitcodeToFile,
     core::{
-        LLVMAddCase, LLVMAddFunction, LLVMAddGlobal, LLVMAddGlobalInAddressSpace, LLVMAddIncoming,
-        LLVMAppendBasicBlockInContext, LLVMArrayType2, LLVMBasicBlockAsValue, LLVMBlockAddress,
-        LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast, LLVMBuildAnd, LLVMBuildArrayAlloca,
-        LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCall2, LLVMBuildCondBr, LLVMBuildExtractElement,
-        LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
-        LLVMBuildFNeg, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc,
-        LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFreeze, LLVMBuildGEP2, LLVMBuildICmp,
-        LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntToPtr, LLVMBuildLShr,
-        LLVMBuildLoad2, LLVMBuildMul, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPtrToInt, LLVMBuildRet,
-        LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSIToFP, LLVMBuildSRem,
-        LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildSub,
-        LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem,
-        LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt,
-        LLVMCanValueUseFastMathFlags, LLVMClearInsertionPosition, LLVMConstInt,
-        LLVMConstIntGetZExtValue, LLVMConstNull, LLVMConstReal, LLVMConstRealGetDouble,
-        LLVMConstVector, LLVMContextCreate, LLVMContextDispose, LLVMCountIncoming,
-        LLVMCountParamTypes, LLVMCountParams, LLVMCountStructElementTypes,
-        LLVMCreateBuilderInContext, LLVMCreateMemoryBufferWithContentsOfFile,
-        LLVMCreateMemoryBufferWithMemoryRangeCopy, LLVMDeleteFunction, LLVMDisposeMemoryBuffer,
-        LLVMDisposeMessage, LLVMDisposeModule, LLVMDoubleTypeInContext, LLVMDumpModule,
-        LLVMDumpType, LLVMDumpValue, LLVMFloatTypeInContext, LLVMFunctionType,
-        LLVMGetAggregateElement, LLVMGetAlignment, LLVMGetAllocatedType, LLVMGetArrayLength2,
-        LLVMGetBasicBlockName, LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator,
-        LLVMGetBlockAddressBasicBlock, LLVMGetBlockAddressFunction, LLVMGetCalledFunctionType,
-        LLVMGetCalledValue, LLVMGetConstOpcode, LLVMGetElementType, LLVMGetFCmpPredicate,
-        LLVMGetFastMathFlags, LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal,
-        LLVMGetFirstInstruction, LLVMGetFirstParam, LLVMGetGEPSourceElementType,
-        LLVMGetICmpPredicate, LLVMGetIncomingBlock, LLVMGetIncomingValue, LLVMGetIndices,
-        LLVMGetInitializer, LLVMGetInsertBlock, LLVMGetInstructionOpcode, LLVMGetInstructionParent,
-        LLVMGetIntTypeWidth, LLVMGetIntrinsicDeclaration, LLVMGetLastFunction, LLVMGetLastGlobal,
-        LLVMGetLinkage, LLVMGetMaskValue, LLVMGetModuleIdentifier, LLVMGetNNeg, LLVMGetNSW,
-        LLVMGetNUW, LLVMGetNamedFunction, LLVMGetNamedGlobal, LLVMGetNextBasicBlock,
-        LLVMGetNextFunction, LLVMGetNextGlobal, LLVMGetNextInstruction, LLVMGetNextParam,
-        LLVMGetNumArgOperands, LLVMGetNumIndices, LLVMGetNumMaskElements, LLVMGetNumOperands,
-        LLVMGetOperand, LLVMGetParam, LLVMGetParamTypes, LLVMGetPointerAddressSpace, LLVMGetPoison,
+        LLVMAddCase, LLVMAddDestination, LLVMAddFunction, LLVMAddGlobal,
+        LLVMAddGlobalInAddressSpace, LLVMAddIncoming, LLVMAppendBasicBlockInContext,
+        LLVMArrayType2, LLVMBasicBlockAsValue, LLVMBlockAddress, LLVMBuildAShr, LLVMBuildAdd,
+        LLVMBuildAddrSpaceCast, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildBitCast, LLVMBuildBr,
+        LLVMBuildCall2, LLVMBuildCondBr, LLVMBuildExtractElement, LLVMBuildExtractValue,
+        LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul, LLVMBuildFNeg, LLVMBuildFPExt,
+        LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc, LLVMBuildFRem, LLVMBuildFSub,
+        LLVMBuildFreeze, LLVMBuildGEP2, LLVMBuildICmp, LLVMBuildIndirectBr, LLVMBuildInsertElement,
+        LLVMBuildInsertValue, LLVMBuildIntToPtr, LLVMBuildLShr, LLVMBuildLoad2, LLVMBuildMul,
+        LLVMBuildOr, LLVMBuildPhi, LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid,
+        LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect,
+        LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildSub, LLVMBuildSwitch,
+        LLVMBuildTrunc, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable,
+        LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt, LLVMCanValueUseFastMathFlags,
+        LLVMClearInsertionPosition, LLVMConstInt, LLVMConstIntGetZExtValue, LLVMConstNull,
+        LLVMConstReal, LLVMConstRealGetDouble, LLVMConstVector, LLVMContextCreate,
+        LLVMContextDispose, LLVMCountIncoming, LLVMCountParamTypes, LLVMCountParams,
+        LLVMCountStructElementTypes, LLVMCreateBuilderInContext,
+        LLVMCreateMemoryBufferWithContentsOfFile, LLVMCreateMemoryBufferWithMemoryRangeCopy,
+        LLVMDeleteFunction, LLVMDisposeMemoryBuffer, LLVMDisposeMessage, LLVMDisposeModule,
+        LLVMDoubleTypeInContext, LLVMDumpModule, LLVMDumpType, LLVMDumpValue,
+        LLVMFloatTypeInContext, LLVMFunctionType, LLVMGetAggregateElement, LLVMGetAlignment,
+        LLVMGetAllocatedType, LLVMGetArrayLength2, LLVMGetBasicBlockName, LLVMGetBasicBlockParent,
+        LLVMGetBasicBlockTerminator, LLVMGetBlockAddressBasicBlock, LLVMGetBlockAddressFunction,
+        LLVMGetCalledFunctionType, LLVMGetCalledValue, LLVMGetConstOpcode, LLVMGetElementType,
+        LLVMGetFCmpPredicate, LLVMGetFastMathFlags, LLVMGetFirstBasicBlock, LLVMGetFirstFunction,
+        LLVMGetFirstGlobal, LLVMGetFirstInstruction, LLVMGetFirstParam,
+        LLVMGetGEPSourceElementType, LLVMGetICmpPredicate, LLVMGetIncomingBlock,
+        LLVMGetIncomingValue, LLVMGetIndices, LLVMGetInitializer, LLVMGetInsertBlock,
+        LLVMGetInstructionOpcode, LLVMGetInstructionParent, LLVMGetIntTypeWidth,
+        LLVMGetIntrinsicDeclaration, LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetLinkage,
+        LLVMGetMaskValue, LLVMGetModuleIdentifier, LLVMGetNNeg, LLVMGetNSW, LLVMGetNUW,
+        LLVMGetNamedFunction, LLVMGetNamedGlobal, LLVMGetNextBasicBlock, LLVMGetNextFunction,
+        LLVMGetNextGlobal, LLVMGetNextInstruction, LLVMGetNextParam, LLVMGetNumArgOperands,
+        LLVMGetNumIndices, LLVMGetNumMaskElements, LLVMGetNumOperands, LLVMGetOperand,
+        LLVMGetParam, LLVMGetParamTypes, LLVMGetPointerAddressSpace, LLVMGetPoison,
         LLVMGetPreviousBasicBlock, LLVMGetPreviousFunction, LLVMGetPreviousGlobal,
         LLVMGetPreviousInstruction, LLVMGetPreviousParam, LLVMGetReturnType,
         LLVMGetStructElementTypes, LLVMGetStructName, LLVMGetSwitchCaseValue, LLVMGetTypeKind,
@@ -341,10 +342,10 @@ pub mod llvm_is_a {
         LLVMIsAAllocaInst, LLVMIsAArgument, LLVMIsABlockAddress, LLVMIsACallInst, LLVMIsAConstant,
         LLVMIsAConstantExpr, LLVMIsAConstantFP, LLVMIsAConstantInt, LLVMIsAExtractElementInst,
         LLVMIsAExtractValueInst, LLVMIsAFCmpInst, LLVMIsAFPToUIInst, LLVMIsAGetElementPtrInst,
-        LLVMIsAGlobalValue, LLVMIsAGlobalVariable, LLVMIsAICmpInst, LLVMIsAInsertElementInst,
-        LLVMIsAInsertValueInst, LLVMIsAInstruction, LLVMIsAInvokeInst, LLVMIsALoadInst,
-        LLVMIsAPHINode, LLVMIsAShuffleVectorInst, LLVMIsAStoreInst, LLVMIsASwitchInst,
-        LLVMIsAUIToFPInst, LLVMIsAZExtInst,
+        LLVMIsAGlobalValue, LLVMIsAGlobalVariable, LLVMIsAICmpInst, LLVMIsAIndirectBrInst,
+        LLVMIsAInsertElementInst, LLVMIsAInsertValueInst, LLVMIsAInstruction, LLVMIsAInvokeInst,
+        LLVMIsALoadInst, LLVMIsAPHINode, LLVMIsAShuffleVectorInst, LLVMIsAStoreInst,
+        LLVMIsASwitchInst, LLVMIsAUIToFPInst, LLVMIsAZExtInst,
     };
 
     use super::*;
@@ -422,6 +423,11 @@ pub mod llvm_is_a {
     /// LLVMIsASwitchInst
     pub fn switch_inst(val: LLVMValue) -> bool {
         unsafe { !LLVMIsASwitchInst(val.into()).is_null() }
+    }
+
+    /// LLVMIsAIndirectBrInst
+    pub fn indirect_br_inst(val: LLVMValue) -> bool {
+        unsafe { !LLVMIsAIndirectBrInst(val.into()).is_null() }
     }
 
     /// LLVMIsAArgument
@@ -2305,6 +2311,20 @@ pub fn llvm_add_case(switch_inst: LLVMValue, on_val: LLVMValue, dest_block: LLVM
     assert!(llvm_is_a::switch_inst(switch_inst));
     unsafe {
         LLVMAddCase(switch_inst.into(), on_val.into(), dest_block.into());
+    }
+}
+
+/// LLVMBuildIndirectBr
+pub fn llvm_build_indirect_br(builder: &LLVMBuilder, addr: LLVMValue, num_dests: u32) -> LLVMValue {
+    assert!(llvm_get_insert_block(builder).is_some());
+    unsafe { LLVMBuildIndirectBr(builder.inner_ref(), addr.into(), num_dests).into() }
+}
+
+/// LLVMAddDestination
+pub fn llvm_add_destination(indirect_br_inst: LLVMValue, dest_block: LLVMBasicBlock) {
+    assert!(llvm_is_a::indirect_br_inst(indirect_br_inst));
+    unsafe {
+        LLVMAddDestination(indirect_br_inst.into(), dest_block.into());
     }
 }
 

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -15,9 +15,9 @@ use llvm_sys::{
     bit_writer::LLVMWriteBitcodeToFile,
     core::{
         LLVMAddCase, LLVMAddFunction, LLVMAddGlobal, LLVMAddGlobalInAddressSpace, LLVMAddIncoming,
-        LLVMAppendBasicBlockInContext, LLVMArrayType2, LLVMBasicBlockAsValue, LLVMBuildAShr,
-        LLVMBuildAdd, LLVMBuildAddrSpaceCast, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildBitCast,
-        LLVMBuildBr, LLVMBuildCall2, LLVMBuildCondBr, LLVMBuildExtractElement,
+        LLVMAppendBasicBlockInContext, LLVMArrayType2, LLVMBasicBlockAsValue, LLVMBlockAddress,
+        LLVMBuildAShr, LLVMBuildAdd, LLVMBuildAddrSpaceCast, LLVMBuildAnd, LLVMBuildArrayAlloca,
+        LLVMBuildBitCast, LLVMBuildBr, LLVMBuildCall2, LLVMBuildCondBr, LLVMBuildExtractElement,
         LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
         LLVMBuildFNeg, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc,
         LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFreeze, LLVMBuildGEP2, LLVMBuildICmp,
@@ -37,32 +37,32 @@ use llvm_sys::{
         LLVMDumpType, LLVMDumpValue, LLVMFloatTypeInContext, LLVMFunctionType,
         LLVMGetAggregateElement, LLVMGetAlignment, LLVMGetAllocatedType, LLVMGetArrayLength2,
         LLVMGetBasicBlockName, LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator,
-        LLVMGetCalledFunctionType, LLVMGetCalledValue, LLVMGetConstOpcode, LLVMGetElementType,
-        LLVMGetFCmpPredicate, LLVMGetFastMathFlags, LLVMGetFirstBasicBlock, LLVMGetFirstFunction,
-        LLVMGetFirstGlobal, LLVMGetFirstInstruction, LLVMGetFirstParam,
-        LLVMGetGEPSourceElementType, LLVMGetICmpPredicate, LLVMGetIncomingBlock,
-        LLVMGetIncomingValue, LLVMGetIndices, LLVMGetInitializer, LLVMGetInsertBlock,
-        LLVMGetInstructionOpcode, LLVMGetInstructionParent, LLVMGetIntTypeWidth,
-        LLVMGetIntrinsicDeclaration, LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetLinkage,
-        LLVMGetMaskValue, LLVMGetModuleIdentifier, LLVMGetNNeg, LLVMGetNSW, LLVMGetNUW,
-        LLVMGetNamedFunction, LLVMGetNamedGlobal, LLVMGetNextBasicBlock, LLVMGetNextFunction,
-        LLVMGetNextGlobal, LLVMGetNextInstruction, LLVMGetNextParam, LLVMGetNumArgOperands,
-        LLVMGetNumIndices, LLVMGetNumMaskElements, LLVMGetNumOperands, LLVMGetOperand,
-        LLVMGetParam, LLVMGetParamTypes, LLVMGetPointerAddressSpace, LLVMGetPoison,
+        LLVMGetBlockAddressBasicBlock, LLVMGetBlockAddressFunction, LLVMGetCalledFunctionType,
+        LLVMGetCalledValue, LLVMGetConstOpcode, LLVMGetElementType, LLVMGetFCmpPredicate,
+        LLVMGetFastMathFlags, LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal,
+        LLVMGetFirstInstruction, LLVMGetFirstParam, LLVMGetGEPSourceElementType,
+        LLVMGetICmpPredicate, LLVMGetIncomingBlock, LLVMGetIncomingValue, LLVMGetIndices,
+        LLVMGetInitializer, LLVMGetInsertBlock, LLVMGetInstructionOpcode, LLVMGetInstructionParent,
+        LLVMGetIntTypeWidth, LLVMGetIntrinsicDeclaration, LLVMGetLastFunction, LLVMGetLastGlobal,
+        LLVMGetLinkage, LLVMGetMaskValue, LLVMGetModuleIdentifier, LLVMGetNNeg, LLVMGetNSW,
+        LLVMGetNUW, LLVMGetNamedFunction, LLVMGetNamedGlobal, LLVMGetNextBasicBlock,
+        LLVMGetNextFunction, LLVMGetNextGlobal, LLVMGetNextInstruction, LLVMGetNextParam,
+        LLVMGetNumArgOperands, LLVMGetNumIndices, LLVMGetNumMaskElements, LLVMGetNumOperands,
+        LLVMGetOperand, LLVMGetParam, LLVMGetParamTypes, LLVMGetPointerAddressSpace, LLVMGetPoison,
         LLVMGetPreviousBasicBlock, LLVMGetPreviousFunction, LLVMGetPreviousGlobal,
         LLVMGetPreviousInstruction, LLVMGetPreviousParam, LLVMGetReturnType,
         LLVMGetStructElementTypes, LLVMGetStructName, LLVMGetSwitchCaseValue, LLVMGetTypeKind,
         LLVMGetUndef, LLVMGetUndefMaskElem, LLVMGetValueKind, LLVMGetValueName2, LLVMGetVectorSize,
-        LLVMGlobalGetValueType, LLVMHalfTypeInContext, LLVMIntTypeInContext,
-        LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst, LLVMIsAUser,
-        LLVMIsDeclaration, LLVMIsFunctionVarArg, LLVMIsOpaqueStruct, LLVMLookupIntrinsicID,
-        LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext, LLVMPositionBuilderAtEnd,
-        LLVMPositionBuilderBefore, LLVMPrintModuleToFile, LLVMPrintModuleToString,
-        LLVMPrintTypeToString, LLVMPrintValueToString, LLVMScalableVectorType, LLVMSetAlignment,
-        LLVMSetFastMathFlags, LLVMSetInitializer, LLVMSetLinkage, LLVMSetNNeg,
-        LLVMStructCreateNamed, LLVMStructSetBody, LLVMStructTypeInContext, LLVMTypeIsSized,
-        LLVMTypeOf, LLVMValueAsBasicBlock, LLVMValueIsBasicBlock, LLVMVectorType,
-        LLVMVoidTypeInContext,
+        LLVMGlobalGetValueType, LLVMHalfTypeInContext, LLVMInstructionEraseFromParent,
+        LLVMIntTypeInContext, LLVMIntrinsicIsOverloaded, LLVMIsAFunction, LLVMIsATerminatorInst,
+        LLVMIsAUser, LLVMIsDeclaration, LLVMIsFunctionVarArg, LLVMIsOpaqueStruct,
+        LLVMLookupIntrinsicID, LLVMModuleCreateWithNameInContext, LLVMPointerTypeInContext,
+        LLVMPositionBuilderAtEnd, LLVMPositionBuilderBefore, LLVMPrintModuleToFile,
+        LLVMPrintModuleToString, LLVMPrintTypeToString, LLVMPrintValueToString,
+        LLVMReplaceAllUsesWith, LLVMScalableVectorType, LLVMSetAlignment, LLVMSetFastMathFlags,
+        LLVMSetInitializer, LLVMSetLinkage, LLVMSetNNeg, LLVMStructCreateNamed, LLVMStructSetBody,
+        LLVMStructTypeInContext, LLVMTypeIsSized, LLVMTypeOf, LLVMValueAsBasicBlock,
+        LLVMValueIsBasicBlock, LLVMVectorType, LLVMVoidTypeInContext,
     },
     error::{LLVMDisposeErrorMessage, LLVMErrorRef, LLVMGetErrorMessage},
     prelude::{
@@ -338,13 +338,13 @@ pub fn llvm_dump_module(module: &LLVMModule) {
 /// The family of LLVMIsA* functions for Value
 pub mod llvm_is_a {
     use llvm_sys::core::{
-        LLVMIsAAllocaInst, LLVMIsAArgument, LLVMIsACallInst, LLVMIsAConstant, LLVMIsAConstantExpr,
-        LLVMIsAConstantFP, LLVMIsAConstantInt, LLVMIsAExtractElementInst, LLVMIsAExtractValueInst,
-        LLVMIsAFCmpInst, LLVMIsAFPToUIInst, LLVMIsAGetElementPtrInst, LLVMIsAGlobalValue,
-        LLVMIsAGlobalVariable, LLVMIsAICmpInst, LLVMIsAInsertElementInst, LLVMIsAInsertValueInst,
-        LLVMIsAInstruction, LLVMIsAInvokeInst, LLVMIsALoadInst, LLVMIsAPHINode,
-        LLVMIsAShuffleVectorInst, LLVMIsAStoreInst, LLVMIsASwitchInst, LLVMIsAUIToFPInst,
-        LLVMIsAZExtInst,
+        LLVMIsAAllocaInst, LLVMIsAArgument, LLVMIsABlockAddress, LLVMIsACallInst, LLVMIsAConstant,
+        LLVMIsAConstantExpr, LLVMIsAConstantFP, LLVMIsAConstantInt, LLVMIsAExtractElementInst,
+        LLVMIsAExtractValueInst, LLVMIsAFCmpInst, LLVMIsAFPToUIInst, LLVMIsAGetElementPtrInst,
+        LLVMIsAGlobalValue, LLVMIsAGlobalVariable, LLVMIsAICmpInst, LLVMIsAInsertElementInst,
+        LLVMIsAInsertValueInst, LLVMIsAInstruction, LLVMIsAInvokeInst, LLVMIsALoadInst,
+        LLVMIsAPHINode, LLVMIsAShuffleVectorInst, LLVMIsAStoreInst, LLVMIsASwitchInst,
+        LLVMIsAUIToFPInst, LLVMIsAZExtInst,
     };
 
     use super::*;
@@ -488,6 +488,38 @@ pub mod llvm_is_a {
     pub fn store_inst(val: LLVMValue) -> bool {
         unsafe { !LLVMIsAStoreInst(val.into()).is_null() }
     }
+
+    /// LLVMIsABlockAddress
+    pub fn block_address(val: LLVMValue) -> bool {
+        unsafe { !LLVMIsABlockAddress(val.into()).is_null() }
+    }
+}
+
+/// The family of LLVMIs* functions for Value
+pub mod llvm_is {
+    use llvm_sys::core::{LLVMIsConstant, LLVMIsPoison, LLVMIsUndef};
+
+    use super::*;
+
+    /// LLVMIsConstant
+    pub fn constant(val: LLVMValue) -> bool {
+        unsafe { !LLVMIsConstant(val.into()).to_bool() }
+    }
+
+    /// LLVMIsUndef
+    pub fn undef(val: LLVMValue) -> bool {
+        unsafe { !LLVMIsUndef(val.into()).to_bool() }
+    }
+
+    /// LLVMIsPoison
+    pub fn poison(val: LLVMValue) -> bool {
+        unsafe { !LLVMIsPoison(val.into()).to_bool() }
+    }
+}
+
+/// LLVMReplaceAllUsesWith
+pub fn llvm_replace_all_uses_with(old_val: LLVMValue, new_val: LLVMValue) {
+    unsafe { LLVMReplaceAllUsesWith(old_val.into(), new_val.into()) }
 }
 
 /// LLVMTypeOf
@@ -711,6 +743,12 @@ pub fn llvm_get_instruction_parent(inst: LLVMValue) -> Option<LLVMBasicBlock> {
     }
 }
 
+/// LLVMInstructionEraseFromParent
+pub fn llvm_instruction_erase_from_parent(inst: LLVMValue) {
+    assert!(llvm_is_a::instruction(inst));
+    unsafe { LLVMInstructionEraseFromParent(inst.into()) }
+}
+
 /// LLVMGetNumOperands
 pub fn llvm_get_num_operands(val: LLVMValue) -> u32 {
     assert!(llvm_is_a::user(val));
@@ -730,6 +768,24 @@ pub fn llvm_get_aggregate_element(val: LLVMValue, index: u32) -> Option<LLVMValu
         let elem = LLVMGetAggregateElement(val.into(), index);
         (!elem.is_null()).then_some(elem.into())
     }
+}
+
+/// LLVMBlockAddress
+pub fn llvm_block_address(function: LLVMValue, block: LLVMBasicBlock) -> LLVMValue {
+    assert!(llvm_is_a::function(function));
+    unsafe { LLVMBlockAddress(function.into(), block.into()).into() }
+}
+
+/// LLVMGetBlockAddressFunction
+pub fn llvm_get_block_address_function(val: LLVMValue) -> LLVMValue {
+    assert!(llvm_is_a::block_address(val));
+    unsafe { LLVMGetBlockAddressFunction(val.into()).into() }
+}
+
+/// LLVMGetBlockAddressBasicBlock
+pub fn llvm_get_block_address_basic_block(val: LLVMValue) -> LLVMBasicBlock {
+    assert!(llvm_is_a::block_address(val));
+    unsafe { LLVMGetBlockAddressBasicBlock(val.into()).into() }
 }
 
 /// LLVMBasicBlockAsValue

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -19,27 +19,28 @@ use llvm_sys::{
         LLVMBuildAdd, LLVMBuildAddrSpaceCast, LLVMBuildAnd, LLVMBuildArrayAlloca, LLVMBuildBitCast,
         LLVMBuildBr, LLVMBuildCall2, LLVMBuildCondBr, LLVMBuildExtractElement,
         LLVMBuildExtractValue, LLVMBuildFAdd, LLVMBuildFCmp, LLVMBuildFDiv, LLVMBuildFMul,
-        LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc, LLVMBuildFRem,
-        LLVMBuildFSub, LLVMBuildFreeze, LLVMBuildGEP2, LLVMBuildICmp, LLVMBuildInsertElement,
-        LLVMBuildInsertValue, LLVMBuildIntToPtr, LLVMBuildLShr, LLVMBuildLoad2, LLVMBuildMul,
-        LLVMBuildOr, LLVMBuildPhi, LLVMBuildPtrToInt, LLVMBuildRet, LLVMBuildRetVoid,
-        LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSIToFP, LLVMBuildSRem, LLVMBuildSelect,
-        LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildSub, LLVMBuildSwitch,
-        LLVMBuildTrunc, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem, LLVMBuildUnreachable,
-        LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt, LLVMCanValueUseFastMathFlags,
-        LLVMClearInsertionPosition, LLVMConstInt, LLVMConstIntGetZExtValue, LLVMConstNull,
-        LLVMConstReal, LLVMConstRealGetDouble, LLVMConstVector, LLVMContextCreate,
-        LLVMContextDispose, LLVMCountIncoming, LLVMCountParamTypes, LLVMCountParams,
-        LLVMCountStructElementTypes, LLVMCreateBuilderInContext,
-        LLVMCreateMemoryBufferWithContentsOfFile, LLVMCreateMemoryBufferWithMemoryRangeCopy,
-        LLVMDeleteFunction, LLVMDisposeMemoryBuffer, LLVMDisposeMessage, LLVMDisposeModule,
-        LLVMDoubleTypeInContext, LLVMDumpModule, LLVMDumpType, LLVMDumpValue,
-        LLVMFloatTypeInContext, LLVMFunctionType, LLVMGetAggregateElement, LLVMGetAlignment,
-        LLVMGetAllocatedType, LLVMGetArrayLength2, LLVMGetBasicBlockName, LLVMGetBasicBlockParent,
-        LLVMGetBasicBlockTerminator, LLVMGetCalledFunctionType, LLVMGetCalledValue,
-        LLVMGetConstOpcode, LLVMGetElementType, LLVMGetFCmpPredicate, LLVMGetFastMathFlags,
-        LLVMGetFirstBasicBlock, LLVMGetFirstFunction, LLVMGetFirstGlobal, LLVMGetFirstInstruction,
-        LLVMGetFirstParam, LLVMGetGEPSourceElementType, LLVMGetICmpPredicate, LLVMGetIncomingBlock,
+        LLVMBuildFNeg, LLVMBuildFPExt, LLVMBuildFPToSI, LLVMBuildFPToUI, LLVMBuildFPTrunc,
+        LLVMBuildFRem, LLVMBuildFSub, LLVMBuildFreeze, LLVMBuildGEP2, LLVMBuildICmp,
+        LLVMBuildInsertElement, LLVMBuildInsertValue, LLVMBuildIntToPtr, LLVMBuildLShr,
+        LLVMBuildLoad2, LLVMBuildMul, LLVMBuildOr, LLVMBuildPhi, LLVMBuildPtrToInt, LLVMBuildRet,
+        LLVMBuildRetVoid, LLVMBuildSDiv, LLVMBuildSExt, LLVMBuildSIToFP, LLVMBuildSRem,
+        LLVMBuildSelect, LLVMBuildShl, LLVMBuildShuffleVector, LLVMBuildStore, LLVMBuildSub,
+        LLVMBuildSwitch, LLVMBuildTrunc, LLVMBuildUDiv, LLVMBuildUIToFP, LLVMBuildURem,
+        LLVMBuildUnreachable, LLVMBuildVAArg, LLVMBuildXor, LLVMBuildZExt,
+        LLVMCanValueUseFastMathFlags, LLVMClearInsertionPosition, LLVMConstInt,
+        LLVMConstIntGetZExtValue, LLVMConstNull, LLVMConstReal, LLVMConstRealGetDouble,
+        LLVMConstVector, LLVMContextCreate, LLVMContextDispose, LLVMCountIncoming,
+        LLVMCountParamTypes, LLVMCountParams, LLVMCountStructElementTypes,
+        LLVMCreateBuilderInContext, LLVMCreateMemoryBufferWithContentsOfFile,
+        LLVMCreateMemoryBufferWithMemoryRangeCopy, LLVMDeleteFunction, LLVMDisposeMemoryBuffer,
+        LLVMDisposeMessage, LLVMDisposeModule, LLVMDoubleTypeInContext, LLVMDumpModule,
+        LLVMDumpType, LLVMDumpValue, LLVMFloatTypeInContext, LLVMFunctionType,
+        LLVMGetAggregateElement, LLVMGetAlignment, LLVMGetAllocatedType, LLVMGetArrayLength2,
+        LLVMGetBasicBlockName, LLVMGetBasicBlockParent, LLVMGetBasicBlockTerminator,
+        LLVMGetCalledFunctionType, LLVMGetCalledValue, LLVMGetConstOpcode, LLVMGetElementType,
+        LLVMGetFCmpPredicate, LLVMGetFastMathFlags, LLVMGetFirstBasicBlock, LLVMGetFirstFunction,
+        LLVMGetFirstGlobal, LLVMGetFirstInstruction, LLVMGetFirstParam,
+        LLVMGetGEPSourceElementType, LLVMGetICmpPredicate, LLVMGetIncomingBlock,
         LLVMGetIncomingValue, LLVMGetIndices, LLVMGetInitializer, LLVMGetInsertBlock,
         LLVMGetInstructionOpcode, LLVMGetInstructionParent, LLVMGetIntTypeWidth,
         LLVMGetIntrinsicDeclaration, LLVMGetLastFunction, LLVMGetLastGlobal, LLVMGetLinkage,
@@ -2029,6 +2030,12 @@ pub fn llvm_build_frem(
         )
         .into()
     }
+}
+
+/// LLVMBuildFNeg
+pub fn llvm_build_fneg(builder: &LLVMBuilder, val: LLVMValue, name: &str) -> LLVMValue {
+    assert!(llvm_get_insert_block(builder).is_some());
+    unsafe { LLVMBuildFNeg(builder.inner_ref(), val.into(), to_c_str(name).as_ptr()).into() }
 }
 
 /// LLVMBuildFCmp

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -33,8 +33,8 @@ use llvm_sys::{
         LLVMContextDispose, LLVMCountIncoming, LLVMCountParamTypes, LLVMCountParams,
         LLVMCountStructElementTypes, LLVMCreateBuilderInContext,
         LLVMCreateMemoryBufferWithContentsOfFile, LLVMCreateMemoryBufferWithMemoryRangeCopy,
-        LLVMDeleteFunction, LLVMDisposeMemoryBuffer, LLVMDisposeMessage, LLVMDisposeModule,
-        LLVMDoubleTypeInContext, LLVMDumpModule, LLVMDumpType, LLVMDumpValue,
+        LLVMDeleteFunction, LLVMDeleteGlobal, LLVMDisposeMemoryBuffer, LLVMDisposeMessage,
+        LLVMDisposeModule, LLVMDoubleTypeInContext, LLVMDumpModule, LLVMDumpType, LLVMDumpValue,
         LLVMFloatTypeInContext, LLVMFunctionType, LLVMGetAggregateElement, LLVMGetAlignment,
         LLVMGetAllocatedType, LLVMGetArrayLength2, LLVMGetBasicBlockName, LLVMGetBasicBlockParent,
         LLVMGetBasicBlockTerminator, LLVMGetBlockAddressBasicBlock, LLVMGetBlockAddressFunction,
@@ -1279,6 +1279,12 @@ pub fn llvm_add_global_in_address_space(
         )
         .into()
     }
+}
+
+/// LLVMDeleteGlobal
+pub fn llvm_delete_global(global: LLVMValue) {
+    assert!(llvm_is_a::global_variable(global));
+    unsafe { LLVMDeleteGlobal(global.into()) }
 }
 
 /// LLVMGetInsertBlock

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -1200,6 +1200,225 @@ impl Verify for SwitchOp {
     }
 }
 
+/// One destination of an [IndirectBrOp].
+#[derive(Clone)]
+pub struct IndirectBrDest {
+    /// The destination block to jump to.
+    pub dest: Ptr<BasicBlock>,
+    /// The operands to pass to the destination block.
+    pub dest_opds: Vec<Value>,
+}
+
+impl Printable for IndirectBrDest {
+    fn fmt(
+        &self,
+        ctx: &Context,
+        _state: &pliron::printable::State,
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> core::fmt::Result {
+        write!(
+            f,
+            "^{}({})",
+            self.dest.deref(ctx).unique_name(ctx),
+            list_with_sep(
+                &self.dest_opds,
+                pliron::printable::ListSeparator::CharSpace(',')
+            )
+            .disp(ctx)
+        )
+    }
+}
+
+impl Parsable for IndirectBrDest {
+    type Arg = ();
+    type Parsed = Self;
+
+    fn parse<'a>(
+        state_stream: &mut StateStream<'a>,
+        _arg: Self::Arg,
+    ) -> ParseResult<'a, Self::Parsed> {
+        let mut parser = (
+            block_opd_parser(),
+            delimited_list_parser('(', ')', ',', ssa_opd_parser()),
+        );
+
+        let ((dest, dest_opds), _) = parser.parse_stream(state_stream).into_result()?;
+
+        Ok(IndirectBrDest { dest, dest_opds }).into_parse_result()
+    }
+}
+
+/// Equivalent to LLVM's IndirectBr opcode.
+///
+/// ### Operands
+/// | operand | description |
+/// |-----|-------|
+/// | `address` | [PointerType] |
+/// | `dest_opds` | variadic of any type, one segment per destination |
+///
+/// ### Successors:
+/// | Successor | description |
+/// |-----|-------|
+/// | `dests` | one or more successor(s) |
+#[pliron_op(
+    name = "llvm.indirectbr",
+    interfaces = [IsTerminatorInterface, NResultsInterface<0>],
+    operands = (address: PointerType, dest_opds),
+)]
+pub struct IndirectBrOp;
+
+impl Printable for IndirectBrOp {
+    fn fmt(
+        &self,
+        ctx: &Context,
+        state: &pliron::printable::State,
+        f: &mut core::fmt::Formatter<'_>,
+    ) -> core::fmt::Result {
+        let op = self.get_operation().deref(ctx);
+        let address = op.get_operand(0);
+        let dests = self.destinations(ctx);
+
+        write!(f, "{} {} [", Self::get_opid_static(), address.disp(ctx))?;
+        indented_block!(state, {
+            write!(f, "{}", indented_nl(state))?;
+            list_with_sep(&dests, pliron::printable::ListSeparator::CharNewline(','))
+                .fmt(ctx, state, f)?;
+        });
+        write!(f, "{}]", indented_nl(state))?;
+
+        Ok(())
+    }
+}
+
+impl Parsable for IndirectBrOp {
+    type Arg = Vec<(Identifier, Location)>;
+    type Parsed = OpObj;
+
+    fn parse<'a>(
+        state_stream: &mut StateStream<'a>,
+        arg: Self::Arg,
+    ) -> ParseResult<'a, Self::Parsed> {
+        if !arg.is_empty() {
+            input_err!(
+                state_stream.loc(),
+                op_interfaces::NResultsVerifyErr(0, arg.len())
+            )?
+        }
+
+        let dests = delimited_list_parser('[', ']', ',', IndirectBrDest::parser(()));
+
+        let final_parser = spaced(ssa_opd_parser()).and(dests);
+
+        final_parser
+            .then(move |(address, dests)| {
+                let results = arg.clone();
+                combine::parser(move |parsable_state: &mut StateStream<'a>| {
+                    let ctx = &mut parsable_state.state.ctx;
+                    let op = IndirectBrOp::new(
+                        ctx,
+                        address,
+                        dests
+                            .iter()
+                            .map(|d| (d.dest, d.dest_opds.clone()))
+                            .collect(),
+                    );
+
+                    process_parsed_ssa_defs(parsable_state, &results, op.get_operation())?;
+                    Ok(OpObj::new(op)).into_parse_result()
+                })
+            })
+            .parse_stream(state_stream)
+            .into()
+    }
+}
+
+impl IndirectBrOp {
+    /// Create a new [IndirectBrOp].
+    pub fn new(
+        ctx: &mut Context,
+        address: Value,
+        dests: Vec<(Ptr<BasicBlock>, Vec<Value>)>,
+    ) -> Self {
+        let mut operand_segments = vec![vec![address]];
+        operand_segments.extend(dests.iter().map(|(_, dest_opds)| dest_opds.clone()));
+        let (operands, segment_sizes) = Self::compute_segment_sizes(operand_segments);
+
+        let successors = dests.iter().map(|(dest, _)| *dest).collect();
+        let op = IndirectBrOp {
+            op: Operation::new(
+                ctx,
+                Self::get_concrete_op_info(),
+                vec![],
+                operands,
+                successors,
+                0,
+            ),
+        };
+
+        // Set the operand segment sizes attribute.
+        op.set_operand_segment_sizes(ctx, segment_sizes);
+        op
+    }
+
+    /// Get the destinations of this indirectbr operation, along with the operands
+    /// passed to each.
+    pub fn destinations(&self, ctx: &Context) -> Vec<IndirectBrDest> {
+        let op = self.get_operation().deref(ctx);
+        op.successors()
+            .enumerate()
+            .map(|(i, dest)| IndirectBrDest {
+                dest,
+                dest_opds: self.successor_operands(ctx, i),
+            })
+            .collect()
+    }
+}
+
+#[op_interface_impl]
+impl BranchOpInterface for IndirectBrOp {
+    fn successor_operands(&self, ctx: &Context, succ_idx: usize) -> Vec<Value> {
+        // Skip the first segment, which is the address.
+        self.get_segment(ctx, succ_idx + 1)
+    }
+
+    fn add_successor_operand(&self, ctx: &mut Context, succ_idx: usize, operand: Value) -> usize {
+        // The successor operands start at segment 1, since segment 0 is the address operand.
+        self.push_to_segment(ctx, succ_idx + 1, operand)
+    }
+
+    fn remove_successor_operand(
+        &self,
+        ctx: &mut Context,
+        succ_idx: usize,
+        opd_idx: usize,
+    ) -> Value {
+        // The successor operands start at segment 1, since segment 0 is the address operand.
+        self.remove_from_segment(ctx, succ_idx + 1, opd_idx)
+    }
+}
+
+#[op_interface_impl]
+impl OperandSegmentInterface for IndirectBrOp {}
+
+#[derive(Error, Debug)]
+pub enum IndirectBrOpVerifyErr {
+    #[error("IndirectBrOp must have at least one destination")]
+    NoDestinations,
+}
+
+impl Verify for IndirectBrOp {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        let loc = self.loc(ctx);
+        let op = &*self.get_operation().deref(ctx);
+
+        if op.get_num_successors() < 1 {
+            verify_err!(loc, IndirectBrOpVerifyErr::NoDestinations)?;
+        }
+
+        Ok(())
+    }
+}
+
 /// A way to express whether a GEP index is a constant or an SSA value
 #[derive(Clone)]
 pub enum GepIndex {

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -1,5 +1,7 @@
 //! [Op]s defined in the LLVM dialect
 
+use std::num::NonZero;
+
 use pliron::{
     arg_err_noloc,
     attribute::{AttrObj, AttributeDict, attr_cast, attr_impls},
@@ -20,6 +22,7 @@ use pliron::{
     },
     common_traits::{Named, Verify},
     context::{Context, Ptr},
+    graph::walkers::{self, IRNode, WALKCONFIG_PREORDER_FORWARD},
     identifier::Identifier,
     indented_block, input_err,
     irfmt::{
@@ -40,7 +43,7 @@ use pliron::{
     result::{Error, ErrorKind, Result},
     symbol_table::SymbolTableCollection,
     r#type::{TypeHandle, TypedHandle, type_cast, type_impls},
-    utils::{const_bound_n::I, vec_exns::VecExtns},
+    utils::{apint::APInt, const_bound_n::I, vec_exns::VecExtns},
     value::Value,
     verify_err, verify_error,
 };
@@ -2593,6 +2596,184 @@ impl SymbolUserOpInterface for AddressOfOp {
         let is_func = (&*symbol as &dyn Op).is::<FuncOp>();
         if !is_global && !is_func {
             return verify_err!(loc, SymbolUserOpVerifyErr::AddressOfInvalidReference);
+        }
+
+        Ok(())
+    }
+}
+
+/// Similar to MLIR's LLVM dialect `llvm.blocktag`.
+/// Marks a basic block with a tag so `llvm.blockaddress` can refer to it.
+/// A given function should have at most one llvm.blocktag operation with a given tag.
+#[pliron_op(
+    name = "llvm.blocktag",
+    format = "`<id = ` attr($llvm_block_tag_id, $IntegerAttr) `>`",
+    interfaces = [NResultsInterface<0>, NOpdsInterface<0>],
+    attributes = (llvm_block_tag_id: IntegerAttr),
+)]
+pub struct BlockTagOp;
+
+#[derive(Error, Debug)]
+enum BlockAddressTagVerifyErr {
+    #[error("Block address tag attribute missing")]
+    MissingTagAttribute,
+    #[error("Block address function name attribute missing")]
+    MissingFunctionNameAttribute,
+    #[error("Block address tag = {0} not found in function {1}")]
+    BlockAddressTagNotFound(u64, String),
+}
+
+impl Verify for BlockTagOp {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        if self.get_attr_llvm_block_tag_id(ctx).is_none() {
+            return verify_err!(self.loc(ctx), BlockAddressTagVerifyErr::MissingTagAttribute);
+        }
+        Ok(())
+    }
+}
+
+impl BlockTagOp {
+    pub fn new(ctx: &mut Context, tag: u64) -> Self {
+        let op = Operation::new(ctx, Self::get_concrete_op_info(), vec![], vec![], vec![], 0);
+        let op = Self { op };
+        let tag_ty = IntegerType::get(ctx, 64, Signedness::Signless);
+        op.set_attr_llvm_block_tag_id(
+            ctx,
+            IntegerAttr::new(tag_ty, APInt::from_u64(tag, NonZero::new(64).unwrap())),
+        );
+        op
+    }
+
+    pub fn get_tag_id(&self, ctx: &Context) -> u64 {
+        self.get_attr_llvm_block_tag_id(ctx)
+            .expect("BlockTagOp missing or has incorrect tag attribute type")
+            .value()
+            .to_u64()
+    }
+}
+
+/// Similar to MLIR's LLVM dialect `llvm.blockaddress`.
+/// Creates an SSA value containing the address of a tagged block in a function.
+#[pliron_op(
+    name = "llvm.blockaddress",
+    format = "`<function = @` attr($llvm_block_address_function, $IdentifierAttr) `, tag = ` attr($llvm_block_address_tag, $IntegerAttr) `> : ` type($0)",
+    interfaces = [OneResultInterface, NOpdsInterface<0>],
+    results = (_: PointerType),
+    attributes = (llvm_block_address_function: IdentifierAttr, llvm_block_address_tag: IntegerAttr),
+)]
+pub struct BlockAddressOp;
+
+impl Verify for BlockAddressOp {
+    fn verify(&self, ctx: &Context) -> Result<()> {
+        if self.get_attr_llvm_block_address_function(ctx).is_none() {
+            return verify_err!(
+                self.loc(ctx),
+                BlockAddressTagVerifyErr::MissingFunctionNameAttribute
+            );
+        }
+        if self.get_attr_llvm_block_address_tag(ctx).is_none() {
+            return verify_err!(self.loc(ctx), BlockAddressTagVerifyErr::MissingTagAttribute);
+        }
+        Ok(())
+    }
+}
+
+impl BlockAddressOp {
+    /// Create a new [BlockAddressOp] referring to a specific block (function_name, tag).
+    pub fn new(ctx: &mut Context, function_name: Identifier, tag: u64, address_space: u32) -> Self {
+        let result_type = PointerType::get(ctx, address_space).into();
+        let op = Operation::new(
+            ctx,
+            Self::get_concrete_op_info(),
+            vec![result_type],
+            vec![],
+            vec![],
+            0,
+        );
+        let op = Self { op };
+        let tag_ty = IntegerType::get(ctx, 64, Signedness::Signless);
+        op.set_attr_llvm_block_address_function(ctx, IdentifierAttr::new(function_name));
+        op.set_attr_llvm_block_address_tag(
+            ctx,
+            IntegerAttr::new(tag_ty, APInt::from_u64(tag, NonZero::new(64).unwrap())),
+        );
+        op
+    }
+
+    /// Get the function name of the block that this address refers to.
+    pub fn get_function_name(&self, ctx: &Context) -> Identifier {
+        self.get_attr_llvm_block_address_function(ctx)
+            .expect("BlockAddressOp missing or has incorrect function_name attribute type")
+            .clone()
+            .into()
+    }
+
+    /// Get the tag of the block that this address refers to.
+    pub fn get_tag_id(&self, ctx: &Context) -> u64 {
+        self.get_attr_llvm_block_address_tag(ctx)
+            .expect("BlockAddressOp missing or has incorrect tag attribute type")
+            .value()
+            .to_u64()
+    }
+
+    /// Get the [BlockTagOp] that this refers to.
+    /// For a well-formed program, this should always return `Some(BlockTagOp)`.
+    pub fn get_block_tag_op(
+        &self,
+        ctx: &Context,
+        symbol_tables: &mut SymbolTableCollection,
+    ) -> Option<BlockTagOp> {
+        let function_name = self.get_function_name(ctx);
+        let tag_id = self.get_tag_id(ctx);
+        let symbol = symbol_tables.lookup_symbol_in_nearest_table(
+            ctx,
+            self.get_operation(),
+            &function_name,
+        )?;
+
+        let func_op = symbol.as_any().downcast_ref::<FuncOp>()?;
+
+        // Search the function's blocks for a `BlockTagOp` with the same tag.
+        walkers::interruptible::immutable::walk_op(
+            ctx,
+            &mut tag_id.clone(),
+            &WALKCONFIG_PREORDER_FORWARD,
+            func_op.get_operation(),
+            |ctx, tag_id, irnode| {
+                let IRNode::Operation(op) = irnode else {
+                    return walkers::interruptible::walk_advance();
+                };
+                if let Some(block_tag_op) = Operation::get_op::<BlockTagOp>(op, ctx)
+                    && block_tag_op.get_tag_id(ctx) == *tag_id
+                {
+                    return walkers::interruptible::walk_break(block_tag_op);
+                }
+                walkers::interruptible::walk_advance()
+            },
+        )
+        .break_value()
+    }
+}
+
+#[op_interface_impl]
+impl SymbolUserOpInterface for BlockAddressOp {
+    fn used_symbols(&self, ctx: &Context) -> Vec<Identifier> {
+        vec![self.get_function_name(ctx)]
+    }
+
+    fn verify_symbol_uses(
+        &self,
+        ctx: &Context,
+        symbol_tables: &mut SymbolTableCollection,
+    ) -> Result<()> {
+        let loc = self.loc(ctx);
+        let function_name = self.get_function_name(ctx);
+        let tag = self.get_tag_id(ctx);
+        if self.get_block_tag_op(ctx, symbol_tables).is_none() {
+            return verify_err!(
+                loc,
+                BlockAddressTagVerifyErr::BlockAddressTagNotFound(tag, function_name.to_string())
+            );
         }
 
         Ok(())

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -64,17 +64,16 @@ use crate::{
         llvm_build_sub, llvm_build_switch, llvm_build_trunc, llvm_build_udiv, llvm_build_uitofp,
         llvm_build_unreachable, llvm_build_urem, llvm_build_va_arg, llvm_build_xor,
         llvm_build_zext, llvm_can_value_use_fast_math_flags, llvm_clear_insertion_position,
-        llvm_const_int, llvm_const_null, llvm_const_real, llvm_const_vector,
+        llvm_const_int, llvm_const_null, llvm_const_real, llvm_const_vector, llvm_delete_global,
         llvm_double_type_in_context, llvm_float_type_in_context, llvm_function_type,
-        llvm_get_inline_asm, llvm_get_named_function, llvm_get_param, llvm_get_poison,
-        llvm_get_sync_scope_id, llvm_get_undef, llvm_half_type_in_context,
-        llvm_instruction_erase_from_parent, llvm_int_type_in_context, llvm_is_a,
-        llvm_lookup_intrinsic_id, llvm_pointer_type_in_context, llvm_position_builder_at_end,
-        llvm_replace_all_uses_with, llvm_scalable_vector_type, llvm_set_alignment,
-        llvm_set_atomic_sync_scope_id, llvm_set_fast_math_flags, llvm_set_initializer,
-        llvm_set_linkage, llvm_set_nneg, llvm_set_ordering, llvm_struct_create_named,
-        llvm_struct_set_body, llvm_struct_type_in_context, llvm_type_of, llvm_vector_type,
-        llvm_void_type_in_context,
+        llvm_get_inline_asm, llvm_get_named_function, llvm_get_param,
+        llvm_get_pointer_address_space, llvm_get_poison, llvm_get_sync_scope_id, llvm_get_undef,
+        llvm_half_type_in_context, llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
+        llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
+        llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
+        llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
+        llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
+        llvm_struct_type_in_context, llvm_type_of, llvm_vector_type, llvm_void_type_in_context,
     },
     op_interfaces::{
         AlignableOpInterface, FastMathFlags, IsDeclaration, LlvmSymbolName, NNegFlag,
@@ -1241,24 +1240,7 @@ impl ToLLVMValue for BlockAddressOp {
         llvm_ctx: &LLVMContext,
         cctx: &mut ConversionContext,
     ) -> Result<LLVMValue> {
-        let tag = self.get_tag_id(ctx);
-        let func = self.get_function_name(ctx);
-
-        // We insert a placeholder instruction now and later replace it
-        // with the actual block address once we have converted all blocks.
-        // The placeholder cannot be any constant because those are unique'd and cannot
-        // be "replace all uses with"ed. So we use a load of a null pointer of the correct type.
-        let result_ty = convert_type(ctx, llvm_ctx, cctx, self.result_type(ctx))?;
-        let placeholder = llvm_build_load2(
-            &cctx.builder,
-            result_ty,
-            llvm_const_null(result_ty),
-            "blockaddress_placeholder",
-        );
-
-        cctx.pending_block_address_ops
-            .insert(placeholder, (func, tag));
-        Ok(placeholder)
+        <Self as ToLLVMConstValue>::convert(self, ctx, llvm_ctx, cctx)
     }
 }
 
@@ -2198,6 +2180,41 @@ impl ToLLVMConstValue for AddressOfOp {
 }
 
 #[op_interface_impl]
+impl ToLLVMConstValue for BlockAddressOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let tag = self.get_tag_id(ctx);
+        let func = self.get_function_name(ctx);
+
+        // The target block may not be converted yet (possibly not even its
+        // function), so emit a placeholder now and patch it in `convert_module`
+        // once the whole module is converted. The placeholder must be a real
+        // constant, not an instruction, so it can be used in other constant
+        // expressions (e.g. a global's initializer). A `GlobalVariable` fits:
+        // unlike other LLVM constants, which are unique'd, it has per-instance
+        // identity and so can be RAUW'd. Same trick used by MLIR's LLVM-IR
+        // translation and LLVM's own bitcode reader for forward-referenced
+        // block addresses.
+        let result_ty = convert_type(ctx, llvm_ctx, cctx, self.result_type(ctx))?;
+        let addr_space = llvm_get_pointer_address_space(result_ty);
+        let placeholder = llvm_add_global_in_address_space(
+            cctx.cur_llvm_module,
+            llvm_int_type_in_context(llvm_ctx, 8),
+            "blockaddress_placeholder",
+            addr_space,
+        );
+
+        cctx.pending_block_address_ops
+            .insert(placeholder, (func, tag));
+        Ok(placeholder)
+    }
+}
+
+#[op_interface_impl]
 impl ToLLVMConstValue for InsertValueOp {
     fn convert(
         &self,
@@ -2482,7 +2499,7 @@ pub fn convert_module(
             })?;
         let block_addr = llvm_block_address(*function_llvm, *block_llvm);
         llvm_replace_all_uses_with(*placeholder, block_addr);
-        llvm_instruction_erase_from_parent(*placeholder);
+        llvm_delete_global(*placeholder);
     }
 
     Ok(llvm_module)

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -26,7 +26,7 @@ use pliron::{
     graph::traversals::region::topological_order,
     identifier::Identifier,
     input_err, input_err_noloc, input_error, input_error_noloc,
-    linked_list::{ContainsLinkedList, LinkedList},
+    linked_list::ContainsLinkedList,
     location::Located,
     op::{Op, op_cast},
     operation::Operation,
@@ -47,33 +47,34 @@ use crate::{
     },
     llvm_sys::core::{
         LLVMBasicBlock, LLVMBuilder, LLVMContext, LLVMModule, LLVMType, LLVMValue,
-        instruction_iter, llvm_add_case, llvm_add_function, llvm_add_global_in_address_space,
-        llvm_add_incoming, llvm_append_basic_block_in_context, llvm_array_type2,
-        llvm_block_address, llvm_build_add, llvm_build_addrspacecast, llvm_build_and,
-        llvm_build_array_alloca, llvm_build_ashr, llvm_build_atomic_cmpxchg, llvm_build_atomic_rmw,
-        llvm_build_bitcast, llvm_build_br, llvm_build_call2, llvm_build_cond_br,
-        llvm_build_extract_element, llvm_build_extract_value, llvm_build_fadd, llvm_build_fcmp,
-        llvm_build_fdiv, llvm_build_fence, llvm_build_fmul, llvm_build_fneg, llvm_build_fpext,
-        llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc, llvm_build_freeze,
-        llvm_build_frem, llvm_build_fsub, llvm_build_gep2, llvm_build_icmp,
-        llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
-        llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or, llvm_build_phi,
-        llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void, llvm_build_sdiv,
-        llvm_build_select, llvm_build_sext, llvm_build_shl, llvm_build_shuffle_vector,
-        llvm_build_sitofp, llvm_build_srem, llvm_build_store, llvm_build_sub, llvm_build_switch,
-        llvm_build_trunc, llvm_build_udiv, llvm_build_uitofp, llvm_build_unreachable,
-        llvm_build_urem, llvm_build_va_arg, llvm_build_xor, llvm_build_zext,
-        llvm_can_value_use_fast_math_flags, llvm_clear_insertion_position, llvm_const_int,
-        llvm_const_null, llvm_const_real, llvm_const_vector, llvm_double_type_in_context,
-        llvm_float_type_in_context, llvm_function_type, llvm_get_inline_asm,
-        llvm_get_named_function, llvm_get_param, llvm_get_poison, llvm_get_sync_scope_id,
-        llvm_get_undef, llvm_half_type_in_context, llvm_instruction_erase_from_parent,
-        llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
-        llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
-        llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
-        llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
-        llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
-        llvm_struct_type_in_context, llvm_type_of, llvm_vector_type, llvm_void_type_in_context,
+        instruction_iter, llvm_add_case, llvm_add_destination, llvm_add_function,
+        llvm_add_global_in_address_space, llvm_add_incoming, llvm_append_basic_block_in_context,
+        llvm_array_type2, llvm_block_address, llvm_build_add, llvm_build_addrspacecast,
+        llvm_build_and, llvm_build_array_alloca, llvm_build_ashr, llvm_build_atomic_cmpxchg,
+        llvm_build_atomic_rmw, llvm_build_bitcast, llvm_build_br, llvm_build_call2,
+        llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value, llvm_build_fadd,
+        llvm_build_fcmp, llvm_build_fdiv, llvm_build_fence, llvm_build_fmul, llvm_build_fneg,
+        llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc,
+        llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2, llvm_build_icmp,
+        llvm_build_indirect_br, llvm_build_insert_element, llvm_build_insert_value,
+        llvm_build_int_to_ptr, llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or,
+        llvm_build_phi, llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void,
+        llvm_build_sdiv, llvm_build_select, llvm_build_sext, llvm_build_shl,
+        llvm_build_shuffle_vector, llvm_build_sitofp, llvm_build_srem, llvm_build_store,
+        llvm_build_sub, llvm_build_switch, llvm_build_trunc, llvm_build_udiv, llvm_build_uitofp,
+        llvm_build_unreachable, llvm_build_urem, llvm_build_va_arg, llvm_build_xor,
+        llvm_build_zext, llvm_can_value_use_fast_math_flags, llvm_clear_insertion_position,
+        llvm_const_int, llvm_const_null, llvm_const_real, llvm_const_vector,
+        llvm_double_type_in_context, llvm_float_type_in_context, llvm_function_type,
+        llvm_get_inline_asm, llvm_get_named_function, llvm_get_param, llvm_get_poison,
+        llvm_get_sync_scope_id, llvm_get_undef, llvm_half_type_in_context,
+        llvm_instruction_erase_from_parent, llvm_int_type_in_context, llvm_is_a,
+        llvm_lookup_intrinsic_id, llvm_pointer_type_in_context, llvm_position_builder_at_end,
+        llvm_replace_all_uses_with, llvm_scalable_vector_type, llvm_set_alignment,
+        llvm_set_atomic_sync_scope_id, llvm_set_fast_math_flags, llvm_set_initializer,
+        llvm_set_linkage, llvm_set_nneg, llvm_set_ordering, llvm_struct_create_named,
+        llvm_struct_set_body, llvm_struct_type_in_context, llvm_type_of, llvm_vector_type,
+        llvm_void_type_in_context,
     },
     op_interfaces::{
         AlignableOpInterface, FastMathFlags, IsDeclaration, LlvmSymbolName, NNegFlag,
@@ -84,11 +85,11 @@ use crate::{
         AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BlockAddressOp, BlockTagOp, BrOp,
         CallIntrinsicOp, CallOp, CondBrOp, ConstantOp, ExtractElementOp, ExtractValueOp, FAddOp,
         FCmpOp, FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp,
-        FenceOp, FreezeOp, FuncOp, GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp, InsertElementOp,
-        InsertValueOp, IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp,
-        SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp,
-        SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp,
-        ZExtOp, ZeroOp,
+        FenceOp, FreezeOp, FuncOp, GetElementPtrOp, GlobalOp, ICmpOp, IndirectBrOp, InlineAsmOp,
+        InsertElementOp, InsertValueOp, IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp,
+        PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp,
+        StoreOp, SubOp, SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, UnreachableOp,
+        VAArgOp, XorOp, ZExtOp, ZeroOp,
     },
     types::{ArrayType, FuncType, PointerType, StructType, VectorType, VoidType},
 };
@@ -649,7 +650,7 @@ impl ToLLVMValue for BrOp {
         link_succ_operands_with_phis(
             ctx,
             cctx,
-            op.get_container().expect("Unlinked operation"),
+            op.get_parent_block().expect("Unlinked operation"),
             succ_llvm,
             self.successor_operands(ctx, 0),
         )?;
@@ -678,14 +679,14 @@ impl ToLLVMValue for CondBrOp {
         link_succ_operands_with_phis(
             ctx,
             cctx,
-            op.get_container().expect("Unlinked operation"),
+            op.get_parent_block().expect("Unlinked operation"),
             true_succ_llvm,
             self.successor_operands(ctx, 0),
         )?;
         link_succ_operands_with_phis(
             ctx,
             cctx,
-            op.get_container().expect("Unlinked operation"),
+            op.get_parent_block().expect("Unlinked operation"),
             false_succ_llvm,
             self.successor_operands(ctx, 1),
         )?;
@@ -716,7 +717,7 @@ impl ToLLVMValue for SwitchOp {
         link_succ_operands_with_phis(
             ctx,
             cctx,
-            op.get_container().expect("Unlinked operation"),
+            op.get_parent_block().expect("Unlinked operation"),
             default_succ,
             self.default_dest_operands(ctx),
         )?;
@@ -725,7 +726,7 @@ impl ToLLVMValue for SwitchOp {
             link_succ_operands_with_phis(
                 ctx,
                 cctx,
-                op.get_container().expect("Unlinked operation"),
+                op.get_parent_block().expect("Unlinked operation"),
                 succ_llvm,
                 case.dest_opds,
             )?;
@@ -739,6 +740,35 @@ impl ToLLVMValue for SwitchOp {
         }
 
         Ok(switch_op)
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for IndirectBrOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        _llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let op = self.get_operation().deref(ctx);
+        let addr = convert_value_operand(cctx, ctx, &self.get_operand_address(ctx))?;
+        let dests = self.destinations(ctx);
+        let indirect_br_op = llvm_build_indirect_br(&cctx.builder, addr, dests.len() as u32);
+
+        for dest in dests {
+            let succ_llvm = convert_block_operand(cctx, ctx, dest.dest)?;
+            llvm_add_destination(indirect_br_op, succ_llvm);
+            link_succ_operands_with_phis(
+                ctx,
+                cctx,
+                op.get_parent_block().expect("Unlinked operation"),
+                succ_llvm,
+                dest.dest_opds,
+            )?;
+        }
+
+        Ok(indirect_br_op)
     }
 }
 

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -48,14 +48,15 @@ use crate::{
     llvm_sys::core::{
         LLVMBasicBlock, LLVMBuilder, LLVMContext, LLVMModule, LLVMType, LLVMValue,
         instruction_iter, llvm_add_case, llvm_add_function, llvm_add_global_in_address_space,
-        llvm_add_incoming, llvm_append_basic_block_in_context, llvm_array_type2, llvm_build_add,
-        llvm_build_addrspacecast, llvm_build_and, llvm_build_array_alloca, llvm_build_ashr,
-        llvm_build_atomic_cmpxchg, llvm_build_atomic_rmw, llvm_build_bitcast, llvm_build_br,
-        llvm_build_call2, llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value,
-        llvm_build_fadd, llvm_build_fcmp, llvm_build_fdiv, llvm_build_fence, llvm_build_fmul,
-        llvm_build_fneg, llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui,
-        llvm_build_fptrunc, llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2,
-        llvm_build_icmp, llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
+        llvm_add_incoming, llvm_append_basic_block_in_context, llvm_array_type2,
+        llvm_block_address, llvm_build_add, llvm_build_addrspacecast, llvm_build_and,
+        llvm_build_array_alloca, llvm_build_ashr, llvm_build_atomic_cmpxchg, llvm_build_atomic_rmw,
+        llvm_build_bitcast, llvm_build_br, llvm_build_call2, llvm_build_cond_br,
+        llvm_build_extract_element, llvm_build_extract_value, llvm_build_fadd, llvm_build_fcmp,
+        llvm_build_fdiv, llvm_build_fence, llvm_build_fmul, llvm_build_fneg, llvm_build_fpext,
+        llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc, llvm_build_freeze,
+        llvm_build_frem, llvm_build_fsub, llvm_build_gep2, llvm_build_icmp,
+        llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
         llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or, llvm_build_phi,
         llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void, llvm_build_sdiv,
         llvm_build_select, llvm_build_sext, llvm_build_shl, llvm_build_shuffle_vector,
@@ -66,8 +67,9 @@ use crate::{
         llvm_const_null, llvm_const_real, llvm_const_vector, llvm_double_type_in_context,
         llvm_float_type_in_context, llvm_function_type, llvm_get_inline_asm,
         llvm_get_named_function, llvm_get_param, llvm_get_poison, llvm_get_sync_scope_id,
-        llvm_get_undef, llvm_half_type_in_context, llvm_int_type_in_context, llvm_is_a,
-        llvm_lookup_intrinsic_id, llvm_pointer_type_in_context, llvm_position_builder_at_end,
+        llvm_get_undef, llvm_half_type_in_context, llvm_instruction_erase_from_parent,
+        llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
+        llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
         llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
         llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
         llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
@@ -79,13 +81,14 @@ use crate::{
     },
     ops::{
         AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,
-        AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BrOp, CallIntrinsicOp, CallOp,
-        CondBrOp, ConstantOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp,
-        FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FenceOp, FreezeOp, FuncOp,
-        GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp, InsertElementOp, InsertValueOp, IntToPtrOp,
-        LShrOp, LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp,
-        SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchOp, TruncOp, UDivOp,
-        UIToFPOp, URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp, ZExtOp, ZeroOp,
+        AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BlockAddressOp, BlockTagOp, BrOp,
+        CallIntrinsicOp, CallOp, CondBrOp, ConstantOp, ExtractElementOp, ExtractValueOp, FAddOp,
+        FCmpOp, FDivOp, FMulOp, FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp,
+        FenceOp, FreezeOp, FuncOp, GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp, InsertElementOp,
+        InsertValueOp, IntToPtrOp, LShrOp, LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp,
+        SDivOp, SExtOp, SIToFPOp, SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp,
+        SwitchOp, TruncOp, UDivOp, UIToFPOp, URemOp, UndefOp, UnreachableOp, VAArgOp, XorOp,
+        ZExtOp, ZeroOp,
     },
     types::{ArrayType, FuncType, PointerType, StructType, VectorType, VoidType},
 };
@@ -102,6 +105,11 @@ pub struct ConversionContext<'a> {
     function_map: FxHashMap<Identifier, LLVMValue>,
     // A map from pliron globals to LLVM globals.
     globals_map: FxHashMap<Identifier, LLVMValue>,
+    // A map from `(function symbol, block tag)` to the corresponding LLVM block.
+    block_tags: FxHashMap<(Identifier, u64), LLVMBasicBlock>,
+    // A map from every placeholder we insert to
+    // its corresponding `(function symbol, block tag)`
+    pending_block_address_ops: FxHashMap<LLVMValue, (Identifier, u64)>,
     // A map from pliron StructTypes to LLVM StructTypes.
     structs_map: FxHashMap<Identifier, LLVMType>,
     // Type cache to avoid redundant conversions.
@@ -120,6 +128,8 @@ impl<'a> ConversionContext<'a> {
             block_map: FxHashMap::default(),
             function_map: FxHashMap::default(),
             globals_map: FxHashMap::default(),
+            block_tags: FxHashMap::default(),
+            pending_block_address_ops: FxHashMap::default(),
             structs_map: FxHashMap::default(),
             type_cache: FxHashMap::default(),
             builder: LLVMBuilder::new(llvm_ctx),
@@ -156,6 +166,8 @@ pub enum ToLLVMErr {
     GlobalOpInitializerRegionBadReturn,
     #[error("Cannot evaluate value to a constant")]
     CannotEvaluateToConst,
+    #[error("BlockAddressOp refers to missing block tag {1} in function {0}")]
+    MissingBlockTag(String, u64),
 }
 
 pub fn convert_ipredicate(pred: ICmpPredicateAttr) -> LLVMIntPredicate {
@@ -1192,6 +1204,72 @@ impl ToLLVMValue for AddressOfOp {
 }
 
 #[op_interface_impl]
+impl ToLLVMValue for BlockAddressOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let tag = self.get_tag_id(ctx);
+        let func = self.get_function_name(ctx);
+
+        // We insert a placeholder instruction now and later replace it
+        // with the actual block address once we have converted all blocks.
+        // The placeholder cannot be any constant because those are unique'd and cannot
+        // be "replace all uses with"ed. So we use a load of a null pointer of the correct type.
+        let result_ty = convert_type(ctx, llvm_ctx, cctx, self.result_type(ctx))?;
+        let placeholder = llvm_build_load2(
+            &cctx.builder,
+            result_ty,
+            llvm_const_null(result_ty),
+            "blockaddress_placeholder",
+        );
+
+        cctx.pending_block_address_ops
+            .insert(placeholder, (func, tag));
+        Ok(placeholder)
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for BlockTagOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let cur_block = self
+            .get_operation()
+            .deref(ctx)
+            .get_parent_block()
+            .expect("BlockTagOp must be in a basic block");
+        let cur_func = cur_block
+            .deref(ctx)
+            .get_parent_op(ctx)
+            .expect("BlockTagOp must be in a basic block of a function");
+        let cur_func =
+            Operation::get_op::<FuncOp>(cur_func, ctx).expect("Block's parent op must be FuncOp");
+        let cur_func_name = cur_func.get_symbol_name(ctx);
+        let tag = self.get_tag_id(ctx);
+
+        let cur_llvm_block = cctx
+            .block_map
+            .get(&cur_block)
+            .expect("Current block must be in block_map");
+
+        // Later on, for all llvm.blockaddress that refers to this tag, we use this info.
+        cctx.block_tags
+            .insert((cur_func_name, tag), *cur_llvm_block);
+
+        // Actual LLVM doesn't need a BlockTagOp.
+        // Address is taken directly via the llvm.blockaddress instruction.
+        Ok(llvm_const_null(llvm_pointer_type_in_context(llvm_ctx, 0)))
+    }
+}
+
+#[op_interface_impl]
 impl ToLLVMValue for FreezeOp {
     fn convert(
         &self,
@@ -2088,6 +2166,7 @@ impl ToLLVMConstValue for AddressOfOp {
             .ok_or_else(|| input_error_noloc!(ToLLVMErr::CannotEvaluateToConst))
     }
 }
+
 #[op_interface_impl]
 impl ToLLVMConstValue for InsertValueOp {
     fn convert(
@@ -2357,6 +2436,23 @@ pub fn convert_module(
                 llvm_set_alignment(global_llvm, alignment);
             }
         }
+    }
+
+    // Replace all pending block address operations with the actual block addresses.
+    for (placeholder, (func_name, tag)) in cctx.pending_block_address_ops.iter() {
+        let function_llvm = cctx
+            .function_map
+            .get(func_name)
+            .ok_or_else(|| input_error_noloc!(ToLLVMErr::CannotEvaluateToConst))?;
+        let block_llvm = cctx
+            .block_tags
+            .get(&(func_name.clone(), *tag))
+            .ok_or_else(|| {
+                input_error_noloc!(ToLLVMErr::MissingBlockTag(func_name.to_string(), *tag))
+            })?;
+        let block_addr = llvm_block_address(*function_llvm, *block_llvm);
+        llvm_replace_all_uses_with(*placeholder, block_addr);
+        llvm_instruction_erase_from_parent(*placeholder);
     }
 
     Ok(llvm_module)

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -53,9 +53,9 @@ use crate::{
         llvm_build_atomic_cmpxchg, llvm_build_atomic_rmw, llvm_build_bitcast, llvm_build_br,
         llvm_build_call2, llvm_build_cond_br, llvm_build_extract_element, llvm_build_extract_value,
         llvm_build_fadd, llvm_build_fcmp, llvm_build_fdiv, llvm_build_fence, llvm_build_fmul,
-        llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui, llvm_build_fptrunc,
-        llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2, llvm_build_icmp,
-        llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
+        llvm_build_fneg, llvm_build_fpext, llvm_build_fptosi, llvm_build_fptoui,
+        llvm_build_fptrunc, llvm_build_freeze, llvm_build_frem, llvm_build_fsub, llvm_build_gep2,
+        llvm_build_icmp, llvm_build_insert_element, llvm_build_insert_value, llvm_build_int_to_ptr,
         llvm_build_load2, llvm_build_lshr, llvm_build_mul, llvm_build_or, llvm_build_phi,
         llvm_build_ptr_to_int, llvm_build_ret, llvm_build_ret_void, llvm_build_sdiv,
         llvm_build_select, llvm_build_sext, llvm_build_shl, llvm_build_shuffle_vector,
@@ -81,7 +81,7 @@ use crate::{
         AShrOp, AddOp, AddrSpaceCastOp, AddressOfOp, AllocaOp, AndOp, AtomicCmpxchgOp,
         AtomicLoadOp, AtomicRmwOp, AtomicStoreOp, BitcastOp, BrOp, CallIntrinsicOp, CallOp,
         CondBrOp, ConstantOp, ExtractElementOp, ExtractValueOp, FAddOp, FCmpOp, FDivOp, FMulOp,
-        FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FenceOp, FreezeOp, FuncOp,
+        FNegOp, FPExtOp, FPToSIOp, FPToUIOp, FPTruncOp, FRemOp, FSubOp, FenceOp, FreezeOp, FuncOp,
         GetElementPtrOp, GlobalOp, ICmpOp, InlineAsmOp, InsertElementOp, InsertValueOp, IntToPtrOp,
         LShrOp, LoadOp, MulOp, OrOp, PoisonOp, PtrToIntOp, ReturnOp, SDivOp, SExtOp, SIToFPOp,
         SRemOp, SelectOp, ShlOp, ShuffleVectorOp, StoreOp, SubOp, SwitchOp, TruncOp, UDivOp,
@@ -1715,6 +1715,26 @@ impl ToLLVMValue for FCmpOp {
             llvm_set_fast_math_flags(fcmp_op, fastmath.into());
         }
         Ok(fcmp_op)
+    }
+}
+
+#[op_interface_impl]
+impl ToLLVMValue for FNegOp {
+    fn convert(
+        &self,
+        ctx: &Context,
+        _llvm_ctx: &LLVMContext,
+        cctx: &mut ConversionContext,
+    ) -> Result<LLVMValue> {
+        let op = self.get_operation().deref(ctx);
+        let arg = convert_value_operand(cctx, ctx, &op.get_operand(0))?;
+        let inst = llvm_build_fneg(&cctx.builder, arg, &self.get_result(ctx).unique_name(ctx));
+        // The built value may not even be an instruction, but a folded constant.
+        if llvm_can_value_use_fast_math_flags(inst) {
+            let fastmath = self.fast_math_flags(ctx);
+            llvm_set_fast_math_flags(inst, fastmath.into());
+        }
+        Ok(inst)
     }
 }
 

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -260,6 +260,18 @@ fn test_select() {
     );
 }
 
+/// Test blockaddress by compiling blockaddress.ll via pliron.
+#[test]
+#[ignore = "LLI cannot process cross-function blockaddress"]
+fn test_blockaddress() {
+    init_env_logger_for_tests!();
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("blockaddress.ll").to_str().unwrap(),
+        Passes::default(),
+        6,
+    );
+}
+
 /// Test SwitchOp by compiling switch.ll via pliron.
 #[test]
 fn test_switch() {

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -326,7 +326,7 @@ fn test_blockaddress() {
     test_llvm_ir_via_pliron_compiled(
         RESOURCES_DIR.join("blockaddress.ll").to_str().unwrap(),
         Passes::default(),
-        6,
+        7,
     );
 }
 

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -341,6 +341,17 @@ fn test_switch() {
     );
 }
 
+/// Test IndirectBrOp by compiling indirectbr.ll via pliron.
+#[test]
+fn test_indirectbr() {
+    init_env_logger_for_tests!();
+    test_llvm_ir_via_pliron(
+        RESOURCES_DIR.join("indirectbr.ll").to_str().unwrap(),
+        Passes::default(),
+        66,
+    );
+}
+
 /// Test const structs and arrays
 #[test]
 fn test_consts() {

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -26,8 +26,8 @@ use pliron_llvm::{
 };
 use tempfile::tempdir;
 
-/// Get the LLI binary path based on the llvm-sys version used.
-static LLI_BINARY: LazyLock<PathBuf> = LazyLock::new(|| {
+/// Get the LLVM major version used, based on the llvm-sys dependency version.
+fn llvm_major_version() -> String {
     let manifest =
         Manifest::from_path(env!("CARGO_MANIFEST_PATH")).expect("Could not read Cargo.toml");
     let llvm_version = manifest.dependencies.expect("Expected llvm-sys dependency")["llvm-sys"]
@@ -38,17 +38,23 @@ static LLI_BINARY: LazyLock<PathBuf> = LazyLock::new(|| {
         "Unexpected llvm-sys version format: Expected two-digit major version and one digit minor version, got {}",
         llvm_version
     );
+    llvm_version[..2].to_string()
+}
 
-    let llvm_major_version = &llvm_version[..2];
-    let lli_binary_name = format!("lli-{}", llvm_major_version);
+/// Locate an LLVM tool binary (e.g. `lli`, `clang`) matching the llvm-sys version used.
+/// `path_env_var` (e.g. `LLI_BINARY_PATH`), if set, overrides the default `<tool_name>-<major>`
+/// lookup and may itself be a path to the binary.
+fn find_llvm_tool(tool_name: &str, path_env_var: &str) -> PathBuf {
+    let llvm_major_version = llvm_major_version();
+    let default_binary_name = format!("{}-{}", tool_name, llvm_major_version);
 
-    let env_var = env::var("LLI_BINARY_PATH");
+    let env_var = env::var(path_env_var);
     let is_env_var_set = env_var.is_ok();
 
-    // Use LLI_BINARY_PATH if set, otherwise default to lli_binary_name
-    let binary_to_find = env_var.unwrap_or(lli_binary_name.clone());
+    // Use path_env_var if set, otherwise default to default_binary_name
+    let binary_to_find = env_var.unwrap_or(default_binary_name.clone());
 
-    // If LLI_BINARY_PATH is set and it's an absolute/relative path, do a cheap existence check first
+    // If path_env_var is set and it's an absolute/relative path, do a cheap existence check first
     if is_env_var_set {
         let path = PathBuf::from(&binary_to_find);
         if path.exists() {
@@ -62,18 +68,25 @@ static LLI_BINARY: LazyLock<PathBuf> = LazyLock::new(|| {
         Err(_) => {
             if is_env_var_set {
                 panic!(
-                    "LLI binary not found at path specified by LLI_BINARY_PATH ({}) or in system PATH. Expected LLVM version {}.",
-                    binary_to_find, llvm_major_version
+                    "{} binary not found at path specified by {} ({}) or in system PATH. Expected LLVM version {}.",
+                    tool_name, path_env_var, binary_to_find, llvm_major_version
                 );
             } else {
                 panic!(
-                    "LLI binary '{}' not found in PATH. Please install LLVM version {} or set the LLI_BINARY_PATH environment variable to the path of your LLI binary.",
-                    lli_binary_name, llvm_major_version
+                    "{} binary '{}' not found in PATH. Please install LLVM version {} or set the {} environment variable to the path of your {} binary.",
+                    tool_name, default_binary_name, llvm_major_version, path_env_var, tool_name
                 );
             }
         }
     }
-});
+}
+
+/// The LLI binary path, based on the llvm-sys version used.
+static LLI_BINARY: LazyLock<PathBuf> = LazyLock::new(|| find_llvm_tool("lli", "LLI_BINARY_PATH"));
+
+/// The clang binary path, based on the llvm-sys version used.
+static CLANG_BINARY: LazyLock<PathBuf> =
+    LazyLock::new(|| find_llvm_tool("clang", "CLANG_BINARY_PATH"));
 
 static RESOURCES_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
     [env!("CARGO_MANIFEST_DIR"), "tests", "resources"]
@@ -81,10 +94,11 @@ static RESOURCES_DIR: LazyLock<PathBuf> = LazyLock::new(|| {
         .collect()
 });
 
-/// Test an LLVM-IR file by executing it and comparing the output.
-/// The input file is `input_file`, which contains LLVM IR / Bitcode.
-/// The expected output is `expected_output`.
-fn test_llvm_ir_via_pliron(input_file: &str, mut opts: impl Pass, expected_output: i32) {
+/// Convert `input_file` (LLVM IR / Bitcode) to pliron and back, running `opts`
+/// on the pliron module in between, and write out the resulting bitcode.
+/// Returns the `TempDir` holding the bitcode (kept alive by the caller) along
+/// with the path to the bitcode file within it.
+fn build_bitcode(input_file: &str, mut opts: impl Pass) -> (tempfile::TempDir, PathBuf) {
     let llvm_context = LLVMContext::default();
     let module = match LLVMModule::from_ir_in_file(&llvm_context, input_file) {
         Ok(module) => module,
@@ -197,6 +211,15 @@ fn test_llvm_ir_via_pliron(input_file: &str, mut opts: impl Pass, expected_outpu
         .map_err(|_err| arg_error_noloc!("{}", "Error writing bitcode to file"))
         .unwrap();
 
+    (tmp_dir, bc_path)
+}
+
+/// Test an LLVM-IR file by executing it with `lli` and comparing the output.
+/// The input file is `input_file`, which contains LLVM IR / Bitcode.
+/// The expected output is `expected_output`.
+fn test_llvm_ir_via_pliron(input_file: &str, opts: impl Pass, expected_output: i32) {
+    let (_tmp_dir, bc_path) = build_bitcode(input_file, opts);
+
     let mut cmd = Command::new(LLI_BINARY.clone());
 
     let run_output = cmd
@@ -204,6 +227,40 @@ fn test_llvm_ir_via_pliron(input_file: &str, mut opts: impl Pass, expected_outpu
         .args([bc_path.to_str().unwrap()])
         .output()
         .expect("failed to execute LLi to execute output.bc");
+    assert_eq!(
+        run_output.status.code(),
+        Some(expected_output),
+        "{}",
+        String::from_utf8(run_output.stderr).unwrap()
+    );
+}
+
+/// Test an LLVM-IR file by compiling it to a native executable with `clang`
+/// and running that, instead of interpreting it with `lli`.
+/// Useful for IR constructs (e.g. cross-function `blockaddress` materialization)
+/// that `lli`'s lazy JIT can't handle but that are well defined when statically
+/// compiled and linked.
+/// The input file is `input_file`, which contains LLVM IR / Bitcode.
+/// The expected output is `expected_output`.
+fn test_llvm_ir_via_pliron_compiled(input_file: &str, opts: impl Pass, expected_output: i32) {
+    let (tmp_dir, bc_path) = build_bitcode(input_file, opts);
+
+    let exe_path = tmp_dir.path().join("a.out");
+    let compile_output = Command::new(CLANG_BINARY.clone())
+        .args([bc_path.to_str().unwrap(), "-o", exe_path.to_str().unwrap()])
+        .output()
+        .expect("failed to execute clang to compile output.bc");
+    assert!(
+        compile_output.status.success(),
+        "clang failed to compile {}: {}",
+        bc_path.to_str().unwrap(),
+        String::from_utf8(compile_output.stderr).unwrap()
+    );
+
+    let run_output = Command::new(exe_path)
+        .current_dir(&*RESOURCES_DIR)
+        .output()
+        .expect("failed to execute compiled a.out");
     assert_eq!(
         run_output.status.code(),
         Some(expected_output),
@@ -261,11 +318,12 @@ fn test_select() {
 }
 
 /// Test blockaddress by compiling blockaddress.ll via pliron.
+/// `lli` can't process cross-function blockaddress materialization, so this
+/// is compiled to a native executable with clang instead of run under `lli`.
 #[test]
-#[ignore = "LLI cannot process cross-function blockaddress"]
 fn test_blockaddress() {
     init_env_logger_for_tests!();
-    test_llvm_ir_via_pliron(
+    test_llvm_ir_via_pliron_compiled(
         RESOURCES_DIR.join("blockaddress.ll").to_str().unwrap(),
         Passes::default(),
         6,

--- a/pliron-llvm/tests/resources/blockaddress.ll
+++ b/pliron-llvm/tests/resources/blockaddress.ll
@@ -1,3 +1,5 @@
+@block_table = constant [2 x ptr] [ptr blockaddress(@block_targets_1, %taken), ptr blockaddress(@block_targets_1, %other)]
+
 define void @block_targets_1(i1 %cond) {
 entry:
   br i1 %cond, label %taken, label %other
@@ -24,7 +26,13 @@ entry:
   %foo_val = call i32 @foo()
   %sum3 = add i32 %sum2, %foo_val
 
-  ret i32 %sum3
+  %table_ptr0 = getelementptr [2 x ptr], ptr @block_table, i32 0, i32 0
+  %table_val0 = load ptr, ptr %table_ptr0
+  %use4 = icmp ne ptr %table_val0, null
+  %use4_i32 = zext i1 %use4 to i32
+  %sum4 = add i32 %sum3, %use4_i32
+
+  ret i32 %sum4
 }
 
 define void @block_targets_2(i1 %cond) {

--- a/pliron-llvm/tests/resources/blockaddress.ll
+++ b/pliron-llvm/tests/resources/blockaddress.ll
@@ -1,0 +1,55 @@
+define void @block_targets_1(i1 %cond) {
+entry:
+  br i1 %cond, label %taken, label %other
+
+taken:
+  ret void
+
+other:
+  ret void
+}
+
+define i32 @main() {
+entry:
+  %use1 = icmp ne ptr blockaddress(@block_targets_1, %taken), null
+  %use2 = icmp ne ptr blockaddress(@block_targets_1, %other), null
+  %use3 = icmp ne ptr blockaddress(@block_targets_2, %other), null
+
+  %use1_i32 = zext i1 %use1 to i32
+  %use2_i32 = zext i1 %use2 to i32
+  %use3_i32 = zext i1 %use3 to i32
+  %sum = add i32 %use1_i32, %use2_i32
+  %sum2 = add i32 %sum, %use3_i32
+
+  %foo_val = call i32 @foo()
+  %sum3 = add i32 %sum2, %foo_val
+
+  ret i32 %sum3
+}
+
+define void @block_targets_2(i1 %cond) {
+entry:
+  br i1 %cond, label %taken, label %other
+
+taken:
+  ret void
+
+other:
+  ret void
+}
+
+define i32 @foo() {
+entry:
+  %use1 = icmp ne ptr blockaddress(@block_targets_2, %taken), null
+  %use2 = icmp ne ptr blockaddress(@block_targets_2, %other), null
+  %use3 = icmp ne ptr blockaddress(@block_targets_1, %taken), null
+
+  %use1_i32 = zext i1 %use1 to i32
+  %use2_i32 = zext i1 %use2 to i32
+  %use3_i32 = zext i1 %use3 to i32
+
+  %sum = add i32 %use1_i32, %use2_i32
+  %sum2 = add i32 %sum, %use3_i32
+
+  ret i32 %sum2
+}

--- a/pliron-llvm/tests/resources/fpops.ll
+++ b/pliron-llvm/tests/resources/fpops.ll
@@ -36,7 +36,8 @@ entry:
   %sum3 = fadd float %e_f, %f_f
   %sum4 = fadd float %sum1, %sum2
   %sum5 = fadd float %sum3, %g_f
-  %final_sum = fadd float %sum4, %sum5
+  %neg_sum4 = fneg float %sum4
+  %final_sum = fsub float %sum5, %neg_sum4
 
   ; Cast final result to int and return
   %result2 = fptosi float %final_sum to i32

--- a/pliron-llvm/tests/resources/indirectbr.ll
+++ b/pliron-llvm/tests/resources/indirectbr.ll
@@ -1,0 +1,35 @@
+; indirectbr.ll - Test indirectbr (computed goto) with block arguments.
+
+define i32 @dispatch(i32 %sel, i32 %base) {
+entry:
+  %c0 = icmp eq i32 %sel, 0
+  %tA = select i1 %c0, ptr blockaddress(@dispatch, %case0), ptr blockaddress(@dispatch, %case2)
+  %c1 = icmp eq i32 %sel, 1
+  %target = select i1 %c1, ptr blockaddress(@dispatch, %case1), ptr %tA
+  indirectbr ptr %target, [label %case0, label %case1, label %case2]
+
+case0:
+  %v0 = phi i32 [ %base, %entry ]
+  %r0 = add i32 %v0, 10
+  ret i32 %r0
+
+case1:
+  %v1 = phi i32 [ %base, %entry ]
+  %r1 = add i32 %v1, 20
+  ret i32 %r1
+
+case2:
+  %v2 = phi i32 [ %base, %entry ]
+  %r2 = add i32 %v2, 30
+  ret i32 %r2
+}
+
+define i32 @main() {
+entry:
+  %r0 = call i32 @dispatch(i32 0, i32 1)
+  %r1 = call i32 @dispatch(i32 1, i32 2)
+  %r2 = call i32 @dispatch(i32 5, i32 3)
+  %s0 = add i32 %r0, %r1
+  %s1 = add i32 %s0, %r2
+  ret i32 %s1
+}

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -139,7 +139,7 @@ impl Parsable for Identifier {
 }
 
 /// A utility to safely (i.e., without collisions) legalise identifiers.
-/// Generated [Identifier]s are unique only within this the this object.
+/// Generated [Identifier]s are unique only within an instance of this legaliser.
 /// ```
 /// use pliron::identifier::{Legaliser, Identifier};
 /// let mut legaliser = Legaliser::default();

--- a/src/irfmt/parsers.rs
+++ b/src/irfmt/parsers.rs
@@ -245,7 +245,7 @@ pub fn ssa_opd_parser<'a>()
 }
 
 /// Parse a block label into a [`Ptr<BasicBlock>`]. Typically called to parse
-/// the block operands of an [Operation]. If the block doesn't exist, it's created,
+/// the block (successor) operands of an [Operation]. If the block doesn't exist, it's created.
 pub fn block_opd_parse<'a>(
     state_stream: &mut StateStream<'a>,
     _arg: (),
@@ -263,7 +263,7 @@ pub fn block_opd_parse<'a>(
 }
 
 /// A parser to parse a block label into a [`Ptr<BasicBlock>`]. Typically called to parse
-/// the block operands of an [Operation]. If the block doesn't exist, it's created,
+/// the block (successor) operands of an [Operation]. If the block doesn't exist, it's created.
 pub fn block_opd_parser<'a>()
 -> Box<dyn Parser<StateStream<'a>, Output = Ptr<BasicBlock>, PartialState = ()> + 'a> {
     parser_combinator(block_opd_parse, ())


### PR DESCRIPTION
We can now compile [lua](https://github.com/lua/lua) and run its testsuite via `llvm-opt` (at `-O1`).

In the process, support block address and indirect branches in the LLVM dialect.