### PR TITLE
Enforce `OpName` and `AttrName` to be `Identifier`s

### DIFF
--- a/src/analyses/liveness.rs
+++ b/src/analyses/liveness.rs
@@ -705,11 +705,11 @@ mod tests {
         value::Value,
     };
 
-    #[pliron_op(name = "test.liveness.node", format, verifier = "succ")]
+    #[pliron_op(name = "test.liveness_node", format, verifier = "succ")]
     struct NodeOp;
 
     #[pliron_op(
-        name = "test.liveness.br",
+        name = "test.liveness_br",
         format,
         interfaces = [IsTerminatorInterface],
         verifier = "succ",

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -39,11 +39,7 @@
 //! [AttrObj]s can be downcasted to their concrete types using
 //! [downcast_rs](https://docs.rs/downcast-rs/latest/downcast_rs/#example-without-generics).
 
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, vec::Vec};
 use core::{
     fmt::{Debug, Display},
     ops::Deref,
@@ -388,12 +384,12 @@ pub fn attr_impls_static<A: Attribute, I: ?Sized + AttrInterfaceMarker + 'static
 
 #[derive(Clone, Hash, PartialEq, Eq)]
 /// An [Attribute]'s name (not including it's dialect).
-pub struct AttrName(String);
+pub struct AttrName(Identifier);
 
 impl AttrName {
     /// Create a new AttrName.
     pub fn new(name: &str) -> AttrName {
-        AttrName(name.to_string())
+        AttrName(name.try_into().expect("Invalid Identifier for AttrName"))
     }
 }
 
@@ -424,7 +420,7 @@ impl Parsable for AttrName {
 }
 
 impl Deref for AttrName {
-    type Target = String;
+    type Target = Identifier;
 
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/op.rs
+++ b/src/op.rs
@@ -34,11 +34,7 @@
 //! [OpObj]s can be downcasted to their concrete types using
 //! [downcast_rs](https://docs.rs/downcast-rs/latest/downcast_rs/#example-without-generics).
 
-use alloc::{
-    boxed::Box,
-    string::{String, ToString},
-    vec::Vec,
-};
+use alloc::{boxed::Box, string::ToString, vec::Vec};
 use core::{
     fmt::{self, Display},
     hash::Hash,
@@ -80,17 +76,17 @@ use crate::{
 
 #[derive(Clone, Hash, PartialEq, Eq)]
 /// An Op's name (not including it's dialect).
-pub struct OpName(String);
+pub struct OpName(Identifier);
 
 impl OpName {
     /// Create a new OpName.
     pub fn new(name: &str) -> OpName {
-        OpName(name.to_string())
+        OpName(name.try_into().expect("Invalid Identifier for OpName"))
     }
 }
 
 impl Deref for OpName {
-    type Target = String;
+    type Target = Identifier;
 
     fn deref(&self) -> &Self::Target {
         &self.0


### PR DESCRIPTION
This was already required before as their parsers don't allow parsing anything other than an `Identifier`.

This just enforces during programmatic construction too.