### PR TITLE
Fix basic-block parsing bug

### DIFF
--- a/pliron-derive/tests/format_op.rs
+++ b/pliron-derive/tests/format_op.rs
@@ -862,11 +862,11 @@ fn if_op() {
     expect![[r#"
         builtin.func @testfunc: builtin.function <() -> ()> 
         {
-          ^entry_block2v1() !0:
+          ^entry_block1v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
             test.if_op (res0_v0)
             {
-              ^then_block1v1() !2:
+              ^then_block2v1() !2:
                 res1_v1 = test.attr_op <1: si64>:builtin.integer si64 !3;
                 test.return res1_v1 !4
             } !5;
@@ -925,16 +925,16 @@ fn if_else_op() {
     expect![[r#"
         builtin.func @testfunc: builtin.function <() -> ()> 
         {
-          ^entry_block3v1() !0:
+          ^entry_block1v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
             test.if_else_op (res0_v0)
             {
-              ^then_block1v1() !2:
+              ^then_block2v1() !2:
                 res1_v1 = test.attr_op <1: si64>:builtin.integer si64 !3;
                 test.return res1_v1 !4
             }else
             {
-              ^else_block2v1() !5:
+              ^else_block3v1() !5:
                 res2_v2 = test.attr_op <2: si64>:builtin.integer si64 !6;
                 test.return res2_v2 !7
             } !8;
@@ -989,12 +989,12 @@ fn br_op() {
     expect![[r#"
         builtin.func @testfunc: builtin.function <() -> ()> 
         {
-          ^entry_block2v1() !0:
+          ^entry_block1v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
             test.br ^bb1_block3v1(res0_v0) !2
 
-          ^bb1_block3v1(arg0_v2: builtin.integer si64) !3:
-            test.return arg0_v2 !4
+          ^bb1_block3v1(arg0_v1: builtin.integer si64) !3:
+            test.return arg0_v1 !4
         } !5
 
         outlined_attributes:
@@ -1042,14 +1042,14 @@ fn multiple_successors_op() {
     expect![[r#"
         builtin.func @testfunc: builtin.function <() -> ()> 
         {
-          ^entry_block3v1() !0:
+          ^entry_block1v1() !0:
             res0_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
-            test.multiple_successors [^bb1_block4v1, ^bb2_block1v3] !2
+            test.multiple_successors [^bb1_block4v1, ^bb2_block2v3] !2
 
           ^bb1_block4v1() !3:
             test.return res0_v0 !4
 
-          ^bb2_block1v3() !5:
+          ^bb2_block2v3() !5:
             test.return res0_v0 !6
         } !7
 
@@ -1107,16 +1107,16 @@ fn multiple_regions_op() {
     expect![[r#"
         builtin.func @testfunc: builtin.function <() -> ()> 
         {
-          ^entry_block3v1() !0:
+          ^entry_block1v1() !0:
             res_v0 = test.attr_op <0: si64>:builtin.integer si64 !1;
             test.multiple_regions [
             {
-              ^reg1_entry_block1v1() !2:
+              ^reg1_entry_block2v1() !2:
                 res0_v1 = test.attr_op <0: si64>:builtin.integer si64 !3;
                 test.return res0_v1 !4
             }, 
             {
-              ^reg2_entry_block2v1() !5:
+              ^reg2_entry_block3v1() !5:
                 res1_v2 = test.attr_op <1: si64>:builtin.integer si64 !6;
                 test.return res1_v2 !7
             }] !8;

--- a/pliron-llvm/tests/builtin_to_llvm.rs
+++ b/pliron-llvm/tests/builtin_to_llvm.rs
@@ -70,7 +70,7 @@ fn mixed_constant_ops_fold_then_lower_to_llvm() -> Result<()> {
         source_filename = "m"
 
         define i64 @foo() {
-        entry_block_1_0_block1v1:
+        entry_block_1_0_block2v1:
           ret i64 7
         }
     "#]]
@@ -99,7 +99,7 @@ fn builtin_func_converts_to_llvm_func() -> Result<()> {
         source_filename = "m"
 
         define i64 @foo() {
-        entry_block_1_0_block1v1:
+        entry_block_1_0_block2v1:
           ret i64 42
         }
     "#]]

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -523,19 +523,6 @@ impl Parsable for BasicBlock {
             .into_result()?
             .0;
 
-        // Parse the ops in the block
-        let ops: Vec<_> = spaces()
-            .with(sep_by::<Vec<_>, _, _, _>(
-                Operation::parser(OperationParserConfig {
-                    look_for_outlined_attrs: false,
-                })
-                .skip(spaces()),
-                token(';').skip(spaces()),
-            ))
-            .parse_stream(state_stream)
-            .into_result()?
-            .0;
-
         // We've parsed the components. Now construct the result.
         let (arg_names, arg_types): (Vec<_>, Vec<_>) = args.into_iter().unzip();
         let block = BasicBlock::new(state_stream.state.ctx, Some(label.clone()), arg_types);
@@ -564,6 +551,19 @@ impl Parsable for BasicBlock {
         if let Some(outindex) = outindex_opt {
             register_block_for_outline(state_stream, outindex, block, outline_loc)?;
         }
+
+        // Parse the ops in the block
+        let ops: Vec<_> = spaces()
+            .with(sep_by::<Vec<_>, _, _, _>(
+                Operation::parser(OperationParserConfig {
+                    look_for_outlined_attrs: false,
+                })
+                .skip(spaces()),
+                token(';').skip(spaces()),
+            ))
+            .parse_stream(state_stream)
+            .into_result()?
+            .0;
 
         for op in ops {
             op.insert_at_back(block, state_stream.state.ctx);

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -552,6 +552,11 @@ impl Parsable for BasicBlock {
             register_block_for_outline(state_stream, outindex, block, outline_loc)?;
         }
 
+        state_stream
+            .state
+            .name_tracker
+            .block_def(state_stream.state.ctx, &(label, loc), block)?;
+
         // Parse the ops in the block
         let ops: Vec<_> = spaces()
             .with(sep_by::<Vec<_>, _, _, _>(
@@ -564,14 +569,10 @@ impl Parsable for BasicBlock {
             .parse_stream(state_stream)
             .into_result()?
             .0;
-
         for op in ops {
             op.insert_at_back(block, state_stream.state.ctx);
         }
-        state_stream
-            .state
-            .name_tracker
-            .block_def(state_stream.state.ctx, &(label, loc), block)?;
+
         Ok(block).into_parse_result()
     }
 }

--- a/tests/interfaces.rs
+++ b/tests/interfaces.rs
@@ -1022,10 +1022,10 @@ fn test_outline_printonce_attr() -> Result<()> {
     expect![[r#"
         builtin.module @bar 
         {
-          ^block1v1_block4v1() !0:
+          ^block1v1_block3v1() !0:
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
-              ^entry_block2v1_block3v1() !1:
+              ^entry_block2v1_block4v1() !1:
                 c0_v3 = test.constant builtin.integer <0: si64> !2;
                 v0_v4 = test.constant builtin.integer <42: si64> !3;
                 v1_v5 = test.constant builtin.integer <44: si64> !4;
@@ -1149,10 +1149,10 @@ fn test_outline_attr_on_block() -> Result<()> {
     expect![[r#"
         builtin.module @bar 
         {
-          ^block1v1_block4v1() !0:
+          ^block1v1_block3v1() !0:
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
-              ^entry_block2v1_block3v1() !1:
+              ^entry_block2v1_block4v1() !1:
                 c0_v1 = test.constant builtin.integer <0: si64> !2;
                 test.return c0_v1 !3
             } !4

--- a/tests/ir_construct.rs
+++ b/tests/ir_construct.rs
@@ -1058,11 +1058,11 @@ fn parse_function_with_attrs() -> Result<()> {
     expect![[r#"
         builtin.module @bar 
         {
-          ^block1v1_block4v1() !0:
+          ^block1v1_block3v1() !0:
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
               [test_on_func_value: builtin.string "func_attr_value"]
             {
-              ^entry_block2v1_block3v1() !1:
+              ^entry_block2v1_block4v1() !1:
                 c0_v1 = test.constant builtin.integer <0: si64> !2;
                 test.return c0_v1 !3
             } !4
@@ -1692,10 +1692,10 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
     expect![[r#"
         builtin.module @bar 
         {
-          ^block_0_0_block2v1() !0:
+          ^block_0_0_block1v1() !0:
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
-              ^entry_block_1_0_block1v1() [block_attr: builtin.string "hello"] !1:
+              ^entry_block_1_0_block2v1() [block_attr: builtin.string "hello"] !1:
                 c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;
                 test.return c0_op_2_0_res0_v0 !3
             } !4
@@ -1729,10 +1729,10 @@ fn block_attrs_parse_roundtrip() -> Result<()> {
     expect![[r#"
         builtin.module @bar 
         {
-          ^block_0_0_block2v1_block2v1() !0:
+          ^block_0_0_block1v1_block1v1() !0:
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
-              ^entry_block_1_0_block1v1_block1v1() [block_attr: builtin.string "hello"] !1:
+              ^entry_block_1_0_block2v1_block2v1() [block_attr: builtin.string "hello"] !1:
                 c0_op_2_0_res0_v0 = test.constant builtin.integer <0: si64> !2;
                 test.return c0_op_2_0_res0_v0 !3
             } !4


### PR DESCRIPTION
Block arguments etc must be fully parsed before the body of the block is parsed, so that the parsers inside the body can effectively refer to (for example, get the type of) the arguments.