### PR TITLE
Follow-up to removal of `&mut` requirement on Context for type creation

### DIFF
--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -1753,7 +1753,7 @@ impl ParsableBuilder<()> for DeriveTypeParsable {
 
     fn build_final_ret_value(_input: &FmtInput, _state: &mut ()) -> TokenStream {
         quote! {
-            Ok(::pliron::r#type::Type::register_instance(final_ret_value, state_stream.state.ctx)).into_parse_result()
+            Ok(::pliron::r#type::Type::instantiate(final_ret_value, state_stream.state.ctx)).into_parse_result()
         }
     }
 }

--- a/pliron-derive/src/derive_type.rs
+++ b/pliron-derive/src/derive_type.rs
@@ -33,17 +33,6 @@ impl DefType {
             ));
         };
 
-        let is_singleton = match input.data {
-            syn::Data::Struct(ref data_struct) => data_struct.fields.is_empty(),
-            syn::Data::Enum(_) => false,
-            _ => {
-                return Err(syn::Error::new_spanned(
-                    &input,
-                    "Type can only be derived for structs or enums",
-                ));
-            }
-        };
-
         if !input.generics.params.is_empty() {
             return Err(syn::Error::new_spanned(
                 &input,
@@ -63,7 +52,6 @@ impl DefType {
             ident: input.ident.clone(),
             dialect_name: dialect_name.to_string(),
             type_name: type_name.to_string(),
-            is_singleton,
         };
         Ok(Self { input, impl_type })
     }
@@ -85,7 +73,6 @@ struct ImplType {
     ident: syn::Ident,
     dialect_name: String,
     type_name: String,
-    is_singleton: bool,
 }
 
 impl ToTokens for ImplType {
@@ -93,17 +80,8 @@ impl ToTokens for ImplType {
         let name = &self.ident;
         let dialect = &self.dialect_name;
         let type_name = &self.type_name;
-        let register = if self.is_singleton {
-            quote! {
-                |ctx: &mut ::pliron::context::Context| {
-                    <#name as ::pliron::r#type::Type>::register(ctx);
-                    ::pliron::r#type::Type::register_instance(#name {}, ctx);
-                }
-            }
-        } else {
-            quote! {
+        let register = quote! {
                 <#name as ::pliron::r#type::Type>::register
-            }
         };
 
         tokens.extend(quote! {
@@ -221,7 +199,7 @@ fn derive_type_get_impl(ident: &syn::Ident, fields: &syn::Fields) -> TokenStream
                 ctx: &::pliron::context::Context,
                 #field_params
             ) -> ::pliron::r#type::TypedHandle<Self> {
-                ::pliron::r#type::Type::register_instance(
+                ::pliron::r#type::Type::instantiate(
                     #struct_construction,
                     ctx,
                 )
@@ -342,10 +320,7 @@ mod tests {
                     Ok(())
                 }
             }
-            ::pliron::context_registration!(
-                | ctx : & mut ::pliron::context::Context | { < SimpleType as ::pliron::r#type::Type >
-                ::register(ctx); ::pliron::r#type::Type::register_instance(SimpleType {}, ctx); }
-            );
+            ::pliron::context_registration!(< SimpleType as ::pliron::r#type::Type > ::register);
         "##]]
         .assert_eq(&got);
     }
@@ -478,7 +453,7 @@ mod tests {
             impl UnitType {
                 /// Get or create a new instance.
                 pub fn get(ctx: &::pliron::context::Context) -> ::pliron::r#type::TypedHandle<Self> {
-                    ::pliron::r#type::Type::register_instance(UnitType {}, ctx)
+                    ::pliron::r#type::Type::instantiate(UnitType {}, ctx)
                 }
             }
         "#]]
@@ -513,7 +488,7 @@ mod tests {
                     num_elems: u32,
                     kind: VectorTypeKind,
                 ) -> ::pliron::r#type::TypedHandle<Self> {
-                    ::pliron::r#type::Type::register_instance(
+                    ::pliron::r#type::Type::instantiate(
                         VectorType {
                             elem_ty,
                             num_elems,
@@ -547,10 +522,7 @@ mod tests {
                     field_1: String,
                     field_2: bool,
                 ) -> ::pliron::r#type::TypedHandle<Self> {
-                    ::pliron::r#type::Type::register_instance(
-                        TupleType(field_0, field_1, field_2),
-                        ctx,
-                    )
+                    ::pliron::r#type::Type::instantiate(TupleType(field_0, field_1, field_2), ctx)
                 }
             }
         "#]]

--- a/pliron-llvm/src/builtin_to_llvm.rs
+++ b/pliron-llvm/src/builtin_to_llvm.rs
@@ -28,7 +28,7 @@ use pliron::{
 };
 
 use crate::{
-    ToLLVMDialect, ToLLVMType, ToLLVMTypeFn,
+    ToLLVMDialect, ToLLVMType,
     ops::{ConstantOp as LLVMConstantOp, FuncOp as LLVMFuncOp},
     types::FuncType as LLVMFuncType,
 };
@@ -41,23 +41,17 @@ pub enum BuiltinToLLVMConversionError {
 
 #[type_interface_impl]
 impl ToLLVMType for BuiltinFunctionType {
-    fn converter(&self) -> ToLLVMTypeFn {
-        |self_ty: TypeHandle, ctx: &mut Context| {
-            let func_type = self_ty.deref(ctx);
-            let func_type_ref = type_cast::<dyn FunctionTypeInterface>(&*func_type)
-                .expect("Expected a FunctionTypeInterface");
+    fn convert(&self, ctx: &Context) -> Result<TypeHandle> {
+        let arg_types = self.arg_types();
+        let res_types = self.res_types();
 
-            let arg_types = func_type_ref.arg_types();
-            let res_types = func_type_ref.res_types();
-
-            if res_types.is_empty() || res_types.len() > 1 {
-                return input_err_noloc!(BuiltinToLLVMConversionError::InvalidFunctionType);
-            }
-            let result_type = res_types[0];
-
-            let llvm_func_type = LLVMFuncType::get(ctx, result_type, arg_types, false);
-            Ok(llvm_func_type.into())
+        if res_types.is_empty() || res_types.len() > 1 {
+            return input_err_noloc!(BuiltinToLLVMConversionError::InvalidFunctionType);
         }
+        let result_type = res_types[0];
+
+        let llvm_func_type = LLVMFuncType::get(ctx, result_type, arg_types, false);
+        Ok(llvm_func_type.into())
     }
 }
 
@@ -109,12 +103,11 @@ impl ToLLVMDialect for BuiltinFuncOp {
 
         // Get the function type from builtin.func
         let builtin_func_type = self.get_type(ctx);
-        let llvm_converter = type_cast::<dyn ToLLVMType>(&*builtin_func_type.deref(ctx))
+        let llvm_func_type = type_cast::<dyn ToLLVMType>(&*builtin_func_type.deref(ctx))
             .ok_or_else(|| {
                 input_error_noloc!("builtin.func type does not implement ToLLVMType interface")
             })?
-            .converter();
-        let llvm_func_type = llvm_converter(builtin_func_type, ctx)?;
+            .convert(ctx)?;
         let llvm_func_type = TypedHandle::from_handle(llvm_func_type, ctx)?;
 
         // Create the LLVM function operation

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -632,8 +632,7 @@ impl ConstFoldInterface for ICmpOp {
             return vec![None];
         };
         let result = eval_icmp(&self.predicate(ctx), &lhs.value(), &rhs.value());
-        let bool_ty = IntegerType::get_existing(ctx, 1, Signedness::Signless)
-            .expect("i1 type must exist: it is the result type of this op");
+        let bool_ty = IntegerType::get(ctx, 1, Signedness::Signless);
         let res = Box::new(IntegerAttr::new(
             bool_ty,
             APInt::from_u8(result as u8, bw(1)),
@@ -665,8 +664,7 @@ impl ConstFoldInterface for SExtOp {
             .downcast_ref::<IntegerType>()
             .expect("sext result must be an integer type")
             .width();
-        let dest_ty = IntegerType::get_existing(ctx, dest_width, Signedness::Signless)
-            .expect("result type must exist: it is the result type of this op");
+        let dest_ty = IntegerType::get(ctx, dest_width, Signedness::Signless);
         let extended = operand
             .value()
             .sext(NonZero::new(dest_width as usize).expect("result has zero bitwidth"));
@@ -708,8 +706,7 @@ impl ConstFoldInterface for ZExtOp {
             .downcast_ref::<IntegerType>()
             .expect("zext result must be an integer type")
             .width();
-        let dest_ty = IntegerType::get_existing(ctx, dest_width, Signedness::Signless)
-            .expect("result type must exist: it is the result type of this op");
+        let dest_ty = IntegerType::get(ctx, dest_width, Signedness::Signless);
         let extended =
             value.zext(NonZero::new(dest_width as usize).expect("result has zero bitwidth"));
         let res = Box::new(IntegerAttr::new(dest_ty, extended)) as AttrObj;

--- a/pliron-llvm/src/lib.rs
+++ b/pliron-llvm/src/lib.rs
@@ -54,17 +54,10 @@ pub trait ToLLVMDialect {
     }
 }
 
-/// A function pointer type for the [ToLLVMType] interface.
-pub type ToLLVMTypeFn = fn(self_ty: TypeHandle, &mut Context) -> Result<TypeHandle>;
-
 /// Interface for converting to an LLVM type.
 #[type_interface]
 pub trait ToLLVMType {
-    /// Get a function to convert [self] to an LLVM type.
-    // We don't directly specify a conversion function here because
-    // the caller cannot get `&dyn ToLLVMType` (&self) while also
-    // passing `&mut Context` to the conversion function.
-    fn converter(&self) -> ToLLVMTypeFn;
+    fn convert(&self, ctx: &Context) -> Result<TypeHandle>;
 
     fn verify(_ty: &dyn Type, _ctx: &Context) -> Result<()>
     where

--- a/pliron-llvm/src/lib.rs
+++ b/pliron-llvm/src/lib.rs
@@ -57,6 +57,7 @@ pub trait ToLLVMDialect {
 /// Interface for converting to an LLVM type.
 #[type_interface]
 pub trait ToLLVMType {
+    /// Convert [self] to an LLVM type.
     fn convert(&self, ctx: &Context) -> Result<TypeHandle>;
 
     fn verify(_ty: &dyn Type, _ctx: &Context) -> Result<()>

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -59,7 +59,7 @@ impl StructType {
         name: Identifier,
         fields: Option<Vec<TypeHandle>>,
     ) -> Result<TypedHandle<Self>> {
-        let self_ptr = Type::register_instance(
+        let self_handle = Type::instantiate(
             StructType {
                 name: Some(name.clone()),
                 // Uniquing happens only on the name, so this doesn't matter.
@@ -68,7 +68,7 @@ impl StructType {
             ctx,
         );
         // Verify that we created a new or equivalent existing type.
-        let mut self_ref = self_ptr.to_handle().deref_mut(ctx);
+        let mut self_ref = self_handle.to_handle().deref_mut(ctx);
         let self_ref = self_ref.downcast_mut::<StructType>().unwrap();
         assert!(self_ref.name.as_ref().unwrap() == &name);
         if let Some(fields) = fields {
@@ -83,39 +83,13 @@ impl StructType {
                 self_ref.fields = Some(fields);
             }
         }
-        Ok(self_ptr)
+        Ok(self_handle)
     }
 
     /// Get or create a new unnamed (anonymous) struct.
     /// These are finalized upon creation, and uniqued based on the fields.
     pub fn get_unnamed(ctx: &Context, fields: Vec<TypeHandle>) -> TypedHandle<Self> {
-        Type::register_instance(
-            StructType {
-                name: None,
-                fields: Some(fields),
-            },
-            ctx,
-        )
-    }
-
-    /// If a named struct already exists, get a handle to it.
-    pub fn get_existing_named(ctx: &Context, name: &Identifier) -> Option<TypedHandle<Self>> {
-        Type::get_instance(
-            StructType {
-                name: Some(name.clone()),
-                // Named structs are uniqued only on the name.
-                fields: None,
-            },
-            ctx,
-        )
-    }
-
-    /// If an unnamed struct already exists, get a handle to it.
-    pub fn get_existing_unnamed(
-        ctx: &Context,
-        fields: Vec<TypeHandle>,
-    ) -> Option<TypedHandle<Self>> {
-        Type::get_instance(
+        Type::instantiate(
             StructType {
                 name: None,
                 fields: Some(fields),
@@ -451,15 +425,14 @@ mod tests {
         parsable::{self, Parsable, ParseResult, StateStream, state_stream_from_iterator},
         printable::{self, Printable},
         result::Result,
-        r#type::{Type, TypeHandle, TypedHandle},
+        r#type::{TypeHandle, TypedHandle},
     };
 
     #[test]
     fn test_struct() -> Result<()> {
         let ctx = Context::new();
-        let int64_ptr = IntegerType::get(&ctx, 64, Signedness::Signless).into();
+        let int64 = IntegerType::get(&ctx, 64, Signedness::Signless).into();
         let linked_list_id: Identifier = "LinkedList".try_into().unwrap();
-        let linked_list_2_id: Identifier = "LinkedList2".try_into().unwrap();
 
         // Create an opaque struct since we want a recursive type.
         let list_struct: TypeHandle =
@@ -472,7 +445,7 @@ mod tests {
                 .is_opaque()
         );
         let list_struct_ptr = TypedPointerType::get(&ctx, list_struct).into();
-        let fields = vec![int64_ptr, list_struct_ptr];
+        let fields = vec![int64, list_struct_ptr];
         // Set the struct body now.
         StructType::get_named(&ctx, linked_list_id.clone(), Some(fields))?;
         assert!(
@@ -483,22 +456,20 @@ mod tests {
                 .is_opaque()
         );
 
-        let list_struct_2 = StructType::get_existing_named(&ctx, &linked_list_id)
+        let list_struct_2 = StructType::get_named(&ctx, linked_list_id, None)
             .unwrap()
             .into();
         assert!(list_struct == list_struct_2);
-        assert!(StructType::get_existing_named(&ctx, &linked_list_2_id).is_none());
 
         assert_eq!(
             list_struct.disp(&ctx).to_string(),
             "llvm.struct <LinkedList { builtin.integer i64, llvm.typed_ptr <llvm.struct <LinkedList>> }>"
         );
 
-        let head_fields = vec![int64_ptr, list_struct_ptr];
+        let head_fields = vec![int64, list_struct_ptr];
         let head_struct = StructType::get_unnamed(&ctx, head_fields.clone());
-        let head_struct2 = StructType::get_existing_unnamed(&ctx, head_fields).unwrap();
+        let head_struct2 = StructType::get_unnamed(&ctx, head_fields);
         assert!(head_struct == head_struct2);
-        assert!(StructType::get_existing_unnamed(&ctx, vec![int64_ptr, list_struct]).is_none());
 
         Ok(())
     }
@@ -514,11 +485,6 @@ mod tests {
     }
 
     impl TypedPointerType {
-        /// Get, if it already exists, a handle to this typed pointer type.
-        pub fn get_existing(ctx: &Context, to: TypeHandle) -> Option<TypedHandle<Self>> {
-            Type::get_instance(TypedPointerType { to }, ctx)
-        }
-
         /// Get the pointee type.
         pub fn get_pointee_type(&self) -> TypeHandle {
             self.to
@@ -557,19 +523,18 @@ mod tests {
     #[test]
     fn test_pointer_types() {
         let ctx = Context::new();
-        let int32_1_ptr = IntegerType::get(&ctx, 32, Signedness::Signed);
-        let int64_ptr = IntegerType::get(&ctx, 64, Signedness::Signed).into();
+        let int32_1 = IntegerType::get(&ctx, 32, Signedness::Signed);
+        let int64 = IntegerType::get(&ctx, 64, Signedness::Signed).into();
 
-        let int64pointer_ptr = TypedPointerType { to: int64_ptr };
-        let int64pointer_ptr = Type::register_instance(int64pointer_ptr, &ctx);
+        let int64pointer = TypedPointerType::get(&ctx, int64);
         assert_eq!(
-            int64pointer_ptr.disp(&ctx).to_string(),
+            int64pointer.disp(&ctx).to_string(),
             "llvm.typed_ptr <builtin.integer si64>"
         );
-        assert!(int64pointer_ptr == TypedPointerType::get(&ctx, int64_ptr));
+        assert!(int64pointer == TypedPointerType::get(&ctx, int64));
 
         assert!(
-            int64_ptr
+            int64
                 .deref(&ctx)
                 .downcast_ref::<IntegerType>()
                 .unwrap()
@@ -577,9 +542,9 @@ mod tests {
                 == 64
         );
 
-        assert!(IntegerType::get_existing(&ctx, 32, Signedness::Signed).unwrap() == int32_1_ptr);
-        assert!(TypedPointerType::get_existing(&ctx, int64_ptr).unwrap() == int64pointer_ptr);
-        assert!(int64pointer_ptr.deref(&ctx).get_pointee_type() == int64_ptr);
+        assert!(IntegerType::get(&ctx, 32, Signedness::Signed) == int32_1);
+        assert!(TypedPointerType::get(&ctx, int64) == int64pointer);
+        assert!(int64pointer.deref(&ctx).get_pointee_type() == int64);
     }
 
     #[test]

--- a/src/builtin/types.rs
+++ b/src/builtin/types.rs
@@ -34,15 +34,6 @@ pub struct IntegerType {
 }
 
 impl IntegerType {
-    /// Get, if it already exists, an integer type.
-    pub fn get_existing(
-        ctx: &Context,
-        width: u32,
-        signedness: Signedness,
-    ) -> Option<TypedHandle<Self>> {
-        Type::get_instance(IntegerType { width, signedness }, ctx)
-    }
-
     /// Get width.
     pub fn width(&self) -> u32 {
         self.width
@@ -126,16 +117,7 @@ impl FunctionType {
         arguments: Vec<TypeHandle>,
         results: Vec<TypeHandle>,
     ) -> TypedHandle<Self> {
-        FunctionType::register_instance(FunctionType(TypeSig { arguments, results }), ctx)
-    }
-
-    /// Get, if it already exists, a Function type.
-    pub fn get_existing(
-        ctx: &Context,
-        arguments: Vec<TypeHandle>,
-        results: Vec<TypeHandle>,
-    ) -> Option<TypedHandle<Self>> {
-        Type::get_instance(FunctionType(TypeSig { arguments, results }), ctx)
+        FunctionType::instantiate(FunctionType(TypeSig { arguments, results }), ctx)
     }
 }
 
@@ -255,7 +237,7 @@ mod tests {
             .unwrap()
             .0
             .0;
-        assert!(res == IntegerType::get_existing(&ctx, 64, Signedness::Signed).unwrap())
+        assert!(res == IntegerType::get(&ctx, 64, Signedness::Signed))
     }
 
     #[test]
@@ -295,6 +277,6 @@ mod tests {
             .unwrap()
             .0
             .0;
-        assert!(res == FunctionType::get_existing(&ctx, vec![], vec![si32.into()]).unwrap())
+        assert!(res == FunctionType::get(&ctx, vec![], vec![si32.into()]))
     }
 }

--- a/src/type.rs
+++ b/src/type.rs
@@ -119,10 +119,8 @@ pub trait Type: Printable + Verify + Downcast + Sync + Send + Debug {
         TypeHandle(idx)
     }
 
-    /// Register an instance of a type in the provided [Context]
-    /// Returns [TypeHandle] to self. If the type was already registered,
-    /// the existing handle is returned.
-    fn register_instance(t: Self, ctx: &Context) -> TypedHandle<Self>
+    /// Instantiate a type in the provided [Context], returning a [TypeHandle] to self.
+    fn instantiate(t: Self, ctx: &Context) -> TypedHandle<Self>
     where
         Self: Sized,
     {
@@ -133,18 +131,6 @@ pub trait Type: Printable + Verify + Downcast + Sync + Send + Debug {
             &TypeObj::eq,
         );
         TypedHandle(TypeHandle(idx), PhantomData::<Self>)
-    }
-
-    /// If an instance of `t` already exists, get a [TypeHandle] to it.
-    /// Consumes `t` either way.
-    fn get_instance(t: Self, ctx: &Context) -> Option<TypedHandle<Self>>
-    where
-        Self: Sized,
-    {
-        let is = |other: &TypeObj| t.eq_type(&**other.0.borrow());
-        ctx.type_store
-            .get(t.hash_type(), &is)
-            .map(|idx| TypedHandle(TypeHandle(idx), PhantomData::<Self>))
     }
 
     /// Get a Type's static name. This is *not* per instantiation of the type.


### PR DESCRIPTION
This is a followup of #128. Also see #169 