### PR TITLE
Add accessors to `IdentifierAttr` and `DictAttr`

### DIFF
--- a/src/builtin/attributes.rs
+++ b/src/builtin/attributes.rs
@@ -57,6 +57,18 @@ impl IdentifierAttr {
     }
 }
 
+impl AsRef<Identifier> for IdentifierAttr {
+    fn as_ref(&self) -> &Identifier {
+        &self.0
+    }
+}
+
+impl From<Identifier> for IdentifierAttr {
+    fn from(value: Identifier) -> Self {
+        IdentifierAttr(value)
+    }
+}
+
 impl From<IdentifierAttr> for Identifier {
     fn from(value: IdentifierAttr) -> Self {
         value.0
@@ -452,7 +464,7 @@ impl MaterializableAttr for FPDoubleAttr {
 /// Similar to MLIR's [DictionaryAttr](https://mlir.llvm.org/docs/Dialects/Builtin/#dictionaryattr),
 #[pliron_attr(name = "builtin.dict", verifier = "succ")]
 #[derive(PartialEq, Clone, Eq, Debug)]
-pub struct DictAttr(AttributeDict);
+pub struct DictAttr(pub AttributeDict);
 
 impl Printable for DictAttr {
     fn fmt(


### PR DESCRIPTION
Adds a way to get at the inner `AttributeDict` for `DictAttr` by making the field public (same as `AttributeDict` itself).
Also adds a missing `From` implementation and a by-ref accessor for `IdentifierAttr` (things like printing don't need an owned copy).