### PR TITLE
pliron-llvm, without llvm-sys can be no_std

### DIFF
--- a/.github/workflows/ci-pliron-llvm-no-default-features.yml
+++ b/.github/workflows/ci-pliron-llvm-no-default-features.yml
@@ -30,6 +30,14 @@ jobs:
     - name: Clippy pliron-llvm - no default features
       run: cargo clippy -p pliron-llvm --all-targets --no-default-features -- -D warnings
 
+    # `std` without `llvm-sys`: Make sure that pliron is built with `std` on.
+    - name: Clippy pliron-llvm - std, no llvm-sys
+      run: cargo clippy -p pliron-llvm --no-default-features --features std -- -D warnings
+
+    # Same as the previous one
+    - name: Build pliron-llvm - std, no llvm-sys
+      run: RUSTFLAGS="-D warnings" cargo build -p pliron-llvm --no-default-features --features std --verbose
+
     - name: Test debug pliron-llvm - no default features
       run: RUSTFLAGS="-D warnings" cargo test -p pliron-llvm --no-default-features --verbose
 

--- a/.github/workflows/ci-pliron-no-default-features.yml
+++ b/.github/workflows/ci-pliron-no-default-features.yml
@@ -33,6 +33,19 @@ jobs:
     - name: Format
       run: cargo fmt --check
 
+    # `--all-targets` pulls in pliron-llvm as a dev-dependency and
+    # pliron-llvm's default (llvm-sys -> std) feature unifies `std` back on for
+    # pliron, even under `--no-default-features`. So those steps don't actually
+    # exercise a std-free pliron. Just `--lib` doesn't need dev-dependencies,
+    # so it genuinely checks the no_std build.
+    - name: Clippy pliron (true no_std lib check) - no default features
+      run: cargo clippy -p pliron --lib --no-default-features -- -D warnings
+
+    # Same as the previous one
+    - name: Build pliron (true no_std lib check) - no default features
+      run: RUSTFLAGS="-D warnings" cargo build -p pliron --lib --no-default-features --verbose
+
+    # Now with all targets
     - name: Clippy pliron - no default features
       run: cargo clippy -p pliron --all-targets --no-default-features -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ keywords = ["pliron", "llvm", "mlir", "compiler"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-std = []
+std = ["dep:utf8-chars"]
 default = ["std"]
 
 [dependencies]
@@ -43,8 +43,9 @@ once_vec.workspace = true
 downcast-rs.workspace = true
 regex.workspace = true
 dyn-clone.workspace = true
-utf8-chars.workspace = true
+utf8-chars = { workspace = true, optional = true }
 
+# Only used in `no_std`, but can't express that.
 hashbrown = "0"
 spin = "0"
 

--- a/pliron-llvm/Cargo.toml
+++ b/pliron-llvm/Cargo.toml
@@ -14,12 +14,15 @@ license.workspace = true
 [features]
 default = ["llvm-sys"]
 
+llvm-sys = ["dep:llvm-sys", "std"]
+std = ["pliron/std", "bitflags/std"]
+
 [dependencies]
-pliron = { path = "../", version = "0" }
+pliron = { path = "../", version = "0", default-features = false }
 
 thiserror.workspace = true
 log.workspace = true
-bitflags = { workspace = true, features = ["std"] }
+bitflags = { workspace = true }
 
 # When upgrading the LLVM version, change the LLVM versions in
 # CI `.yml` files and the READMEs in `pliron-llvm` and `llvm-opt`.

--- a/pliron-llvm/src/attributes.rs
+++ b/pliron-llvm/src/attributes.rs
@@ -3,6 +3,10 @@
 
 //! Attributes belonging to the LLVM dialect.
 
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 use core::fmt::Display;
 use thiserror::Error;
 

--- a/pliron-llvm/src/builtin_to_llvm.rs
+++ b/pliron-llvm/src/builtin_to_llvm.rs
@@ -3,6 +3,8 @@
 
 //! Dialect conversion from builtin to LLVM dialect
 
+use alloc::vec::Vec;
+
 use pliron::{
     builtin::{
         op_interfaces::{OneRegionInterface, SymbolOpInterface},

--- a/pliron-llvm/src/function_call_utils.rs
+++ b/pliron-llvm/src/function_call_utils.rs
@@ -3,6 +3,8 @@
 
 //! Helper functions to call common simple C functions
 
+use alloc::{boxed::Box, vec, vec::Vec};
+
 use pliron::{
     arg_err,
     builtin::{

--- a/pliron-llvm/src/interface_impls.rs
+++ b/pliron-llvm/src/interface_impls.rs
@@ -3,6 +3,7 @@
 
 //! Implementation of various op interfaces for LLVM IR instructions.
 
+use alloc::{boxed::Box, vec, vec::Vec};
 use core::num::NonZero;
 use thiserror::Error;
 

--- a/pliron-llvm/src/lib.rs
+++ b/pliron-llvm/src/lib.rs
@@ -8,6 +8,13 @@
 
 extern crate alloc;
 
+// A static check to ensure that `std` on pliron-llvm pulls in pliron with `std`.
+#[cfg(feature = "std")]
+const _: () = assert!(
+    pliron::std_deps::STD_ENABLED,
+    "pliron-llvm's `std` feature must forward to `pliron/std`"
+);
+
 use pliron::{
     builtin::ops::ModuleOp,
     context::Context,

--- a/pliron-llvm/src/lib.rs
+++ b/pliron-llvm/src/lib.rs
@@ -3,6 +3,11 @@
 
 //! LLVM Dialect for [pliron]
 
+// Without llvm-sys, we should be able to build without std.
+#![cfg_attr(not(feature = "llvm-sys"), no_std)]
+
+extern crate alloc;
+
 use pliron::{
     builtin::ops::ModuleOp,
     context::Context,

--- a/pliron-llvm/src/op_interfaces.rs
+++ b/pliron-llvm/src/op_interfaces.rs
@@ -3,6 +3,8 @@
 
 //! [Op] Interfaces defined in the LLVM dialect.
 
+use alloc::{string::String, vec};
+
 use pliron::{
     builtin::{
         attributes::BoolAttr,

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -3,6 +3,13 @@
 
 //! [Op]s defined in the LLVM dialect
 
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec,
+    vec::Vec,
+};
 use core::num::NonZero;
 
 use pliron::{

--- a/pliron-llvm/src/types.rs
+++ b/pliron-llvm/src/types.rs
@@ -3,6 +3,7 @@
 
 //! [Type]s defined in the LLVM dialect.
 
+use alloc::{boxed::Box, string::String, vec, vec::Vec};
 use core::hash::Hash;
 use pliron::{
     builtin::type_interfaces::FunctionTypeInterface,
@@ -10,6 +11,7 @@ use pliron::{
     common_traits::Verify,
     context::Context,
     derive::{format, pliron_type, type_interface_impl},
+    dict_key,
     identifier::Identifier,
     input_err_noloc,
     irfmt::{
@@ -154,6 +156,39 @@ impl Verify for StructType {
     }
 }
 
+dict_key!(STRUCT_TYPE_IN_PRINTING, "llvm_struct_type_in_printing");
+
+/// Record that we're now printing `name`, returning `true` if it's already
+/// being printed higher up the stack (i.e., we've hit a recursive struct).
+fn struct_type_start_printing(state: &printable::State, name: &Identifier) -> bool {
+    let mut aux_data = state.aux_data_mut();
+    let in_printing = aux_data
+        .entry(STRUCT_TYPE_IN_PRINTING.clone())
+        // We use a vec instead of a set hoping that this isn't
+        // going to be large, in which case vec would be faster.
+        .or_insert_with(|| Box::new(Vec::<Identifier>::new()))
+        .downcast_mut::<Vec<Identifier>>()
+        .expect("failed to downcast struct-type-in-printing state");
+    if in_printing.contains(name) {
+        true
+    } else {
+        in_printing.push(name.clone());
+        false
+    }
+}
+
+// We're done printing `name`, so remove it from the list of "under printing" struct types.
+fn struct_type_done_printing(state: &printable::State, name: &Identifier) {
+    let mut aux_data = state.aux_data_mut();
+    let in_printing = aux_data
+        .get_mut(&*STRUCT_TYPE_IN_PRINTING)
+        .expect("struct-type-in-printing state must have been created by now")
+        .downcast_mut::<Vec<Identifier>>()
+        .expect("failed to downcast struct-type-in-printing state");
+    assert!(in_printing.last().unwrap() == name);
+    in_printing.pop();
+}
+
 impl Printable for StructType {
     fn fmt(
         &self,
@@ -163,20 +198,11 @@ impl Printable for StructType {
     ) -> core::fmt::Result {
         write!(f, "<")?;
 
-        use core::cell::RefCell;
-        // Ugly, but also the simplest way to avoid infinite recursion.
-        // MLIR does the same: see LLVMTypeSyntax::printStructType.
-        thread_local! {
-            // We use a vec instead of a HashMap hoping that this isn't
-            // going to be large, in which case vec would be faster.
-            static IN_PRINTING: RefCell<Vec<Identifier>>  = const { RefCell::new(vec![]) };
-        }
         if let Some(name) = &self.name {
-            let in_printing = IN_PRINTING.with(|f| f.borrow().contains(name));
-            if in_printing {
+            if struct_type_start_printing(state, name) {
                 return write!(f, "{}>", name.clone());
             }
-            IN_PRINTING.with(|f| f.borrow_mut().push(name.clone()));
+            // This is the first time we're seeing this struct in this session.
             write!(f, "{name}")?;
             if !self.is_opaque() {
                 write!(f, " ")?;
@@ -194,8 +220,7 @@ impl Printable for StructType {
 
         // Done processing this struct. Remove it from the stack.
         if let Some(name) = &self.name {
-            assert!(IN_PRINTING.with(|f| f.borrow().last().unwrap() == name));
-            IN_PRINTING.with(|f| f.borrow_mut().pop());
+            struct_type_done_printing(state, name);
         }
         write!(f, ">")
     }
@@ -411,6 +436,8 @@ impl VectorType {
 #[cfg(test)]
 mod tests {
 
+    use alloc::{format, string::ToString, vec};
+
     use crate::types::{FuncType, PointerType, StructType, VoidType};
     use expect_test::expect;
     use pliron::{
@@ -493,10 +520,10 @@ mod tests {
         fn fmt(
             &self,
             ctx: &Context,
-            _state: &printable::State,
+            state: &printable::State,
             f: &mut core::fmt::Formatter<'_>,
         ) -> core::fmt::Result {
-            write!(f, "<{}>", self.to.disp(ctx))
+            write!(f, "<{}>", self.to.print(ctx, state))
         }
     }
 

--- a/src/std_deps.rs
+++ b/src/std_deps.rs
@@ -6,6 +6,7 @@
 
 #[cfg(feature = "std")]
 mod r#impl {
+    /// Has pliron been built with `std`?
     pub const STD_ENABLED: bool = true;
 
     pub mod sync {
@@ -46,6 +47,7 @@ mod r#impl {
 
 #[cfg(not(feature = "std"))]
 mod r#impl {
+    /// Has pliron been built with `std`?
     pub const STD_ENABLED: bool = false;
 
     pub mod sync {

--- a/src/std_deps.rs
+++ b/src/std_deps.rs
@@ -6,6 +6,8 @@
 
 #[cfg(feature = "std")]
 mod r#impl {
+    pub const STD_ENABLED: bool = true;
+
     pub mod sync {
         pub use std::sync::{LazyLock, Mutex};
     }
@@ -44,6 +46,8 @@ mod r#impl {
 
 #[cfg(not(feature = "std"))]
 mod r#impl {
+    pub const STD_ENABLED: bool = false;
+
     pub mod sync {
         pub use spin::{LazyLock, Mutex};
     }
@@ -243,4 +247,4 @@ mod r#impl {
     }
 }
 
-pub use r#impl::{backtrace, fs, hash, io, path, sync, time, utf8_chars};
+pub use r#impl::{STD_ENABLED, backtrace, fs, hash, io, path, sync, time, utf8_chars};

--- a/src/std_deps.rs
+++ b/src/std_deps.rs
@@ -170,16 +170,31 @@ mod r#impl {
     }
 
     pub mod fs {
+        use core::fmt;
+
         /// A dummy file handle: without `std` there's no filesystem to back it.
         pub struct File;
 
+        /// Filesystem access is unavailable without the `std` feature.
+        #[derive(Debug)]
+        pub struct NoStdFsError;
+
+        impl fmt::Display for NoStdFsError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str("filesystem access is unavailable without the `std` feature")
+            }
+        }
+
         impl File {
-            pub fn open<P: AsRef<str>>(_path: P) -> Result<File, ()> {
+            pub fn open<P: AsRef<str>>(_path: P) -> Result<File, NoStdFsError> {
                 Ok(File)
             }
         }
 
-        pub fn write<P: AsRef<str>, C: AsRef<[u8]>>(_path: P, _contents: C) -> Result<(), ()> {
+        pub fn write<P: AsRef<str>, C: AsRef<[u8]>>(
+            _path: P,
+            _contents: C,
+        ) -> Result<(), NoStdFsError> {
             Ok(())
         }
     }


### PR DESCRIPTION
For @nihalpasham this means that, `--features=std` must be explicitly specified.