### PR TITLE
[mem2reg]: Fix placement of default value for uninitialized uses

### DIFF
--- a/src/opts/mem2reg.rs
+++ b/src/opts/mem2reg.rs
@@ -54,7 +54,8 @@ pub trait PromotableAllocationInterface {
     /// Get the default value for an allocation. This is used
     /// when there's no reaching definition for a use. The `alloc_info`
     /// passed is guaranteed to be one of the entries returned by `alloc_info`.
-    /// The inserter is positioned to be just before the alloc op.
+    /// The inserter is positioned in the entry block. If the allocation
+    /// is in the entry block, the inserter position will be before it.
     fn default_value(
         &self,
         ctx: &mut Context,
@@ -341,11 +342,31 @@ fn get_or_create_default_def(
             let alloc_obj = Operation::get_op_dyn(alloc_op, ctx);
             let alloc_iface = op_cast::<dyn PromotableAllocationInterface>(alloc_obj.as_ref())
                 .expect("Alloc op must implement PromotableAllocationInterface");
-            let default_val = alloc_iface.default_value(
-                ctx,
-                &mut IRInserter::<Recorder>::new_before_operation(alloc_op),
-                &alloc_cand.alloc_info,
-            )?;
+
+            // The default value must be at a place that dominates the alloc
+            // and all places that the promoted value may be live at. The safest
+            // such point is in the entry block, before the alloc itself.
+            let alloc_block = alloc_op
+                .deref(ctx)
+                .get_parent_block()
+                .expect("Alloc op must be in a block");
+            let alloc_region = alloc_block
+                .deref(ctx)
+                .get_parent_region()
+                .expect("Alloc op must be in a region");
+
+            let alloc_region_entry = alloc_region
+                .deref(ctx)
+                .get_entry_block()
+                .expect("Region must have entry block");
+            let mut inserter = if alloc_region_entry == alloc_block {
+                IRInserter::<Recorder>::new_before_operation(alloc_op)
+            } else {
+                IRInserter::<Recorder>::new_before_block_terminator(alloc_region_entry, ctx)
+            };
+
+            let default_val =
+                alloc_iface.default_value(ctx, &mut inserter, &alloc_cand.alloc_info)?;
             entry.insert(default_val);
             Ok(default_val)
         }

--- a/src/region.rs
+++ b/src/region.rs
@@ -83,6 +83,11 @@ impl Region {
         self.get_parent_op().deref(ctx).get_parent_block()
     }
 
+    /// Get the entry block of this region.
+    pub fn get_entry_block(&self) -> Option<Ptr<BasicBlock>> {
+        self.get_head()
+    }
+
     /// Find the index of this region in its parent operation.
     pub fn find_index_in_parent(&self, ctx: &Context) -> usize {
         let parent_op = self.get_parent_op();

--- a/tests/opts/mem2reg.rs
+++ b/tests/opts/mem2reg.rs
@@ -685,3 +685,52 @@ fn mem2reg_not_promoted_when_phi_pred_has_non_branch_successor_terminator() -> R
     assert!(after.contains("test.non_branch_succ_term"));
     Ok(())
 }
+
+#[test]
+fn mem2reg_alloca_inside_loop_body() -> Result<()> {
+    // An allocation inside a loop body, conditionally stored to. The promoted value is
+    // live at the loop entry, so placing a poison value just before the alloca isn't good
+    // enough, it must be placed in the entry block (i.e., dominate any use of the promoted
+    // value, not just the alloca itself).
+    // In other words, the places where the promoted value may be live need not be dominated
+    // by the alloca itself.
+    let input = r#"
+    llvm.func @f: llvm.func <builtin.integer i64 (builtin.integer i64, builtin.integer i1) variadic = false> [] {
+      ^entry(n: builtin.integer i64, cond: builtin.integer i1):
+      size = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
+      zero = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64;
+      one = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64;
+      llvm.br ^header(zero)
+
+      ^header(i: builtin.integer i64):
+      continue_loop = llvm.icmp i <ULT> n : builtin.integer i1;
+      llvm.cond_br if continue_loop ^body() else ^exit()
+
+      ^body():
+      alloc = llvm.alloca [builtin.integer i64 x size] : llvm.ptr (0);
+      llvm.cond_br if cond ^then() else ^merge()
+
+      ^then():
+      v = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64;
+      llvm.store *alloc <- v;
+      llvm.br ^merge()
+
+      ^merge():
+      out = llvm.load alloc : builtin.integer i64;
+      next_i = llvm.add i, one <{nsw=false,nuw=false}> : builtin.integer i64;
+      llvm.br ^header(next_i)
+
+      ^exit():
+      llvm.return zero
+    }
+  "#;
+
+    let (status, _before, after) = run_mem2reg(input)?;
+    assert_eq!(status, IRStatus::Changed);
+    assert!(!after.contains("llvm.alloca"));
+    assert!(!after.contains("llvm.store"));
+    assert!(!after.contains("llvm.load"));
+    // The uninitialized path through ^body needs a default value.
+    assert!(after.contains("llvm.poison"));
+    Ok(())
+}


### PR DESCRIPTION
Previously, we used to place the default value just before the alloca, assuming that any uses of the alloca (to load / store) will be dominated by this default value (as the alloca must dominate those loads / stores).

However, although each access must be dominated by the alloca itself, all points where the promoted value is live need not be (see test). In this case, the alloca, inside a loop will have its promoted value live at the loop beginning (a point which it doesn't dominate), where a PHI is actually needed.

So we now place the default definition in the entry block (before the alloca if the alloca is in the entry block).
