### PR TITLE
fix: add support for f16 constant

### DIFF
--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -13,7 +13,7 @@ use pliron::{
     attribute::AttrObj,
     basic_block::BasicBlock,
     builtin::{
-        attributes::{FPDoubleAttr, FPSingleAttr, IntegerAttr},
+        attributes::{FPDoubleAttr, FPHalfAttr, FPSingleAttr, IntegerAttr},
         op_interfaces::{
             AtMostOneRegionInterface, CallOpCallable, OneResultInterface,
             SingleBlockRegionInterface,
@@ -36,7 +36,7 @@ use pliron::{
     result::Result,
     std_deps::hash::{FxHashMap, FxHashSet},
     r#type::{Type, TypeHandle, TypedHandle, type_cast},
-    utils::apint::APInt,
+    utils::{apfloat::f64_to_half, apint::APInt},
     value::Value,
 };
 use thiserror::Error;
@@ -101,6 +101,13 @@ trait FloatAttrBuilder: FloatTypeInterface {
         Self: Sized,
     {
         Ok(())
+    }
+}
+
+#[type_interface_impl]
+impl FloatAttrBuilder for FP16Type {
+    fn value_from_f64(&self, val: f64) -> AttrObj {
+        FPHalfAttr(f64_to_half(val)).into()
     }
 }
 

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -994,7 +994,8 @@ pub fn llvm_const_real_get_double(val: LLVMValue) -> (f64, bool) {
 /// LLVMConstReal
 pub fn llvm_const_real(ty: LLVMType, n: f64) -> LLVMValue {
     assert!(
-        llvm_get_type_kind(ty) == LLVMTypeKind::LLVMFloatTypeKind
+        llvm_get_type_kind(ty) == LLVMTypeKind::LLVMHalfTypeKind
+            || llvm_get_type_kind(ty) == LLVMTypeKind::LLVMFloatTypeKind
             || llvm_get_type_kind(ty) == LLVMTypeKind::LLVMDoubleTypeKind
     );
     unsafe { LLVMConstReal(ty.into(), n).into() }

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -248,7 +248,7 @@ trait FloatAttrToFP64: FloatAttr {
 #[attr_interface_impl]
 impl FloatAttrToFP64 for FPHalfAttr {
     fn to_fp64(&self) -> f64 {
-        float_to_f64(self.0)
+        float_to_f64(self.0, &mut false)
     }
 }
 

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -12,7 +12,7 @@ use pliron::{
     basic_block::BasicBlock,
     builtin::{
         attr_interfaces::FloatAttr,
-        attributes::{FPDoubleAttr, FPSingleAttr, IntegerAttr, StringAttr},
+        attributes::{FPDoubleAttr, FPHalfAttr, FPSingleAttr, IntegerAttr, StringAttr},
         op_interfaces::{
             AtMostOneRegionInterface, BranchOpInterface, CallOpCallable, CallOpInterface,
             OneOpdInterface, OneResultInterface, SingleBlockRegionInterface, SymbolOpInterface,
@@ -35,7 +35,7 @@ use pliron::{
     result::Result,
     std_deps::hash::{FxHashMap, hash_map},
     r#type::{Type, TypeHandle, Typed, type_cast},
-    utils::apint::APInt,
+    utils::{apfloat::float_to_f64, apint::APInt},
     value::{DefiningEntity, Value},
 };
 
@@ -242,6 +242,13 @@ trait FloatAttrToFP64: FloatAttr {
         Self: Sized,
     {
         Ok(())
+    }
+}
+
+#[attr_interface_impl]
+impl FloatAttrToFP64 for FPHalfAttr {
+    fn to_fp64(&self) -> f64 {
+        float_to_f64(self.0)
     }
 }
 

--- a/pliron-llvm/tests/compile_run.rs
+++ b/pliron-llvm/tests/compile_run.rs
@@ -404,7 +404,7 @@ fn test_fpops() {
     test_llvm_ir_via_pliron(
         RESOURCES_DIR.join("fpops.ll").to_str().unwrap(),
         Passes::default(),
-        45,
+        47,
     );
 }
 

--- a/pliron-llvm/tests/resources/fpops.ll
+++ b/pliron-llvm/tests/resources/fpops.ll
@@ -39,9 +39,17 @@ entry:
   %neg_sum4 = fneg float %sum4
   %final_sum = fsub float %sum5, %neg_sum4
 
+  ; Same in half precision
+  %h = fptrunc float %c to half      ; h = 6.0
+  %h2 = fmul half %h, 0.5            ; h2 = 3.0
+  %h3 = fsub half %h2, 0.5           ; h3 = 2.5
+  %h_f = fpext half %h3 to float     ; h_f = 2.5
+
   ; Cast final result to int and return
   %result2 = fptosi float %final_sum to i32
   %result1 = fptoui float %sum5 to i32
-  %result = add i32 %result2, %result1
+  %result0 = fptosi float %h_f to i32
+  %result3 = add i32 %result2, %result1
+  %result = add i32 %result3, %result0
   ret i32 %result
 }

--- a/src/utils/apfloat.rs
+++ b/src/utils/apfloat.rs
@@ -37,7 +37,7 @@ use rustc_apfloat::ieee::{self, IeeeFloat, NonfiniteBehavior};
 use thiserror::Error;
 
 pub use rustc_apfloat::{
-    Category, ExpInt, Float, Round, StatusAnd,
+    Category, ExpInt, Float, FloatConvert, Round, StatusAnd,
     ieee::{BFloat, Double, Float8E4M3FN, Float8E5M2, Half, Quad, Single, X87DoubleExtended},
 };
 
@@ -79,6 +79,12 @@ pub fn double_to_f64(value: Double) -> f64 {
 /// Convert from Rust [f64] to [rustc_apfloat]'s [Double].
 pub fn f64_to_double(value: f64) -> Double {
     Double::from_bits(value.to_bits().into())
+}
+
+/// Convert any [Float] that is convertible to [Double] into a Rust [f64].
+pub fn float_to_f64<T: FloatConvert<Double>>(value: T) -> f64 {
+    let mut loses_info = false;
+    double_to_f64(value.convert(&mut loses_info).value)
 }
 
 #[derive(Debug, Error)]
@@ -757,11 +763,14 @@ mod tests {
         parsable::parse_from_str,
         printable::Printable,
         result::ExpectOk,
-        utils::apfloat::{double_to_f64, f32_to_single, f64_to_double, single_to_f32},
+        utils::apfloat::{
+            double_to_f64, f32_to_single, f64_to_double, float_to_f64, single_to_f32,
+        },
     };
 
     use super::{
-        BFloat, Double, Float8E4M3FN, Float8E5M2, Half, Parsable, Quad, Single, X87DoubleExtended,
+        BFloat, Double, Float, Float8E4M3FN, Float8E5M2, Half, Parsable, Quad, Single,
+        X87DoubleExtended,
     };
 
     fn print_and_parse<T>(value: T, ctx: &mut Context)
@@ -1013,5 +1022,40 @@ mod tests {
         let double = f64_to_double(val);
         let back = double_to_f64(double);
         assert_eq!(val, back);
+    }
+
+    #[test]
+    fn test_float_to_f64() {
+        // Every Half is exactly representable as an f64.
+        let cases: [(u128, f64); 8] = [
+            (0x0000, 0.0),                  // +0.0
+            (0x8000, -0.0),                 // -0.0
+            (0x3C00, 1.0),                  // 1.0
+            (0xC000, -2.0),                 // -2.0
+            (0x3555, 0.333251953125),       // nearest Half to 1/3
+            (0x7BFF, 65504.0),              // largest finite Half
+            (0x0001, 5.960464477539063e-8), // smallest positive subnormal Half
+            (0x7C00, f64::INFINITY),        // +Inf
+        ];
+
+        for (bits, expected) in cases {
+            let val = float_to_f64(Half::from_bits(bits));
+            assert_eq!(val, expected, "Failed for Half with bits {:#x}", bits);
+            assert_eq!(
+                val.is_sign_negative(),
+                expected.is_sign_negative(),
+                "Sign mismatch for Half with bits {:#x}",
+                bits
+            );
+        }
+
+        assert!(float_to_f64(Half::NAN).is_nan());
+
+        // Widening from Single and narrowing from Quad both go through the same path.
+        assert_eq!(
+            float_to_f64(f32_to_single(core::f32::consts::PI)),
+            core::f32::consts::PI as f64
+        );
+        assert_eq!(float_to_f64(Quad::from_str("1.5").unwrap()), 1.5);
     }
 }

--- a/src/utils/apfloat.rs
+++ b/src/utils/apfloat.rs
@@ -82,9 +82,15 @@ pub fn f64_to_double(value: f64) -> Double {
 }
 
 /// Convert any [Float] that is convertible to [Double] into a Rust [f64].
-pub fn float_to_f64<T: FloatConvert<Double>>(value: T) -> f64 {
-    let mut loses_info = false;
-    double_to_f64(value.convert(&mut loses_info).value)
+pub fn float_to_f64<T: FloatConvert<Double>>(value: T, loses_info: &mut bool) -> f64 {
+    double_to_f64(value.convert(loses_info).value)
+}
+
+/// Convert from Rust [f64] to [rustc_apfloat]'s [Half].
+pub fn f64_to_half(value: f64) -> Half {
+    Double::from_bits(value.to_bits().into())
+        .convert(&mut false)
+        .value
 }
 
 #[derive(Debug, Error)]
@@ -1039,7 +1045,7 @@ mod tests {
         ];
 
         for (bits, expected) in cases {
-            let val = float_to_f64(Half::from_bits(bits));
+            let val = float_to_f64(Half::from_bits(bits), &mut false);
             assert_eq!(val, expected, "Failed for Half with bits {:#x}", bits);
             assert_eq!(
                 val.is_sign_negative(),
@@ -1049,13 +1055,16 @@ mod tests {
             );
         }
 
-        assert!(float_to_f64(Half::NAN).is_nan());
+        assert!(float_to_f64(Half::NAN, &mut false).is_nan());
 
         // Widening from Single and narrowing from Quad both go through the same path.
         assert_eq!(
-            float_to_f64(f32_to_single(core::f32::consts::PI)),
+            float_to_f64(f32_to_single(core::f32::consts::PI), &mut false),
             core::f32::consts::PI as f64
         );
-        assert_eq!(float_to_f64(Quad::from_str("1.5").unwrap()), 1.5);
+        assert_eq!(
+            float_to_f64(Quad::from_str("1.5").unwrap(), &mut false),
+            1.5
+        );
     }
 }


### PR DESCRIPTION
## Description

F16 support in apfloat is lacking and without FloatAttrToFP64 implemented for F16, it canno't be used in LLVM constant.

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] A human is involved in writing this PR description and will handle
review interactions, per our [AI tool policy](../CONTRIBUTING.md).
- [x] I understand every part of this change (including any AI-generated
code) and can explain the reasoning behind it.
- [x] Intrusive / large changes were discussed on Discord before this PR.
- [x] `pre-ci.sh` passes locally.
