### PR TITLE
Replace unnecessary `Deref` with `AsRef` implementations

### DIFF
--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -532,7 +532,7 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
             };
             Ok(quote! {
                 let succ = self.get_operation().deref(ctx).get_successor(#index);
-                let succ_name = ::pliron::alloc::string::ToString::to_string("^") + &succ.unique_name(ctx);
+                let succ_name = ::pliron::alloc::string::ToString::to_string("^") + succ.unique_name(ctx).as_ref();
                 ::pliron::printable::Printable::fmt(&succ_name, ctx, state, fmt)?;
             })
         } else if d.name == "successors" {
@@ -551,7 +551,8 @@ impl PrintableBuilder<OpPrinterState> for DeriveOpPrintable {
             let sep = directive_to_list_separator(sep, true, input.ident.span())?;
             Ok(quote! {
                 let op = self.get_operation().deref(ctx);
-                let succs = op.successors().map(|succ| ::pliron::alloc::string::ToString::to_string("^") + &succ.unique_name(ctx));
+                let succs = op.successors().map(|succ|
+                    ::pliron::alloc::string::ToString::to_string("^") + succ.unique_name(ctx).as_ref());
                 let succs = ::pliron::irfmt::printers::iter_with_sep(succs, #sep);
                 ::pliron::printable::Printable::fmt(&succs, ctx, state, fmt)?;
             })

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -1331,10 +1331,11 @@ impl ToLLVMValue for CallOp {
             .collect::<Result<_>>()?;
         let ty = convert_type(ctx, llvm_ctx, cctx, self.callee_type(ctx))?;
         let res = self.get_result(ctx);
-        let unique_name = res.unique_name(ctx);
+        let unique_name;
         let name = if res.get_type(ctx).deref(ctx).is::<VoidType>() {
             ""
         } else {
+            unique_name = res.unique_name(ctx);
             unique_name.as_ref()
         };
         let callee = match self.callee(ctx) {
@@ -1395,10 +1396,11 @@ impl ToLLVMValue for CallIntrinsicOp {
             .unwrap_or_else(|| llvm_add_function(cctx.cur_llvm_module, &intrinsic_name, fn_ty));
 
         let res = self.get_result(ctx);
-        let unique_name = res.unique_name(ctx);
+        let unique_name;
         let name = if res.get_type(ctx).deref(ctx).is::<VoidType>() {
             ""
         } else {
+            unique_name = res.unique_name(ctx);
             unique_name.as_ref()
         };
 

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -384,7 +384,7 @@ impl ToLLVMType for StructType {
     ) -> Result<LLVMType> {
         if self.is_opaque() {
             let name = self.name().expect("Opaqaue struct must have a name");
-            Ok(llvm_struct_create_named(llvm_ctx, name.as_str()))
+            Ok(llvm_struct_create_named(llvm_ctx, name.as_ref()))
         } else {
             let field_types = self
                 .fields()
@@ -394,7 +394,7 @@ impl ToLLVMType for StructType {
                 match cctx.structs_map.entry(name) {
                     hash_map::Entry::Occupied(entry) => Ok(*entry.get()),
                     hash_map::Entry::Vacant(entry) => {
-                        let str_ty = llvm_struct_create_named(llvm_ctx, entry.key());
+                        let str_ty = llvm_struct_create_named(llvm_ctx, entry.key().as_ref());
                         llvm_struct_set_body(str_ty, &field_types, false);
                         entry.insert(str_ty);
                         Ok(str_ty)
@@ -528,7 +528,7 @@ macro_rules! to_llvm_value_int_bin_op {
                     &cctx.builder,
                     lhs,
                     rhs,
-                    &self.get_result(ctx).unique_name(ctx),
+                    self.get_result(ctx).unique_name(ctx).as_ref(),
                 ))
             }
         }
@@ -563,7 +563,7 @@ impl ToLLVMValue for AllocaOp {
             &cctx.builder,
             ty,
             size,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         if let Some(alignment) = self.alignment(ctx) {
             llvm_set_alignment(alloca_op, alignment);
@@ -586,7 +586,7 @@ impl ToLLVMValue for BitcastOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(bitcast_op)
     }
@@ -606,7 +606,7 @@ impl ToLLVMValue for AddrSpaceCastOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(addrspacecast_op)
     }
@@ -796,7 +796,7 @@ impl ToLLVMValue for LoadOp {
             &cctx.builder,
             pointee_ty,
             ptr,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         if let Some(alignment) = self.alignment(ctx) {
             llvm_set_alignment(load_op, alignment);
@@ -973,7 +973,12 @@ impl ToLLVMValue for AtomicLoadOp {
         };
         let pointee_ty = convert_type(ctx, llvm_ctx, cctx, result_val.get_type(ctx))?;
         let ptr = convert_value_operand(cctx, ctx, &ptr_opd)?;
-        let load = llvm_build_load2(&cctx.builder, pointee_ty, ptr, &result_val.unique_name(ctx));
+        let load = llvm_build_load2(
+            &cctx.builder,
+            pointee_ty,
+            ptr,
+            result_val.unique_name(ctx).as_ref(),
+        );
         let ordering = convert_atomic_ordering(
             &self
                 .get_attr_llvm_ld_ordering(ctx)
@@ -1105,7 +1110,7 @@ impl ToLLVMValue for ICmpOp {
             predicate,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(icmp_op)
     }
@@ -1180,7 +1185,7 @@ impl ToLLVMValue for IntToPtrOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(inttoptr_op)
     }
@@ -1201,7 +1206,7 @@ impl ToLLVMValue for PtrToIntOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(ptrtoint_op)
     }
@@ -1302,8 +1307,11 @@ impl ToLLVMValue for FreezeOp {
     ) -> Result<LLVMValue> {
         let op = self.get_operation().deref(ctx);
         let arg = convert_value_operand(cctx, ctx, &op.get_operand(0))?;
-        let freeze_op =
-            llvm_build_freeze(&cctx.builder, arg, &self.get_result(ctx).unique_name(ctx));
+        let freeze_op = llvm_build_freeze(
+            &cctx.builder,
+            arg,
+            self.get_result(ctx).unique_name(ctx).as_ref(),
+        );
         Ok(freeze_op)
     }
 }
@@ -1323,10 +1331,11 @@ impl ToLLVMValue for CallOp {
             .collect::<Result<_>>()?;
         let ty = convert_type(ctx, llvm_ctx, cctx, self.callee_type(ctx))?;
         let res = self.get_result(ctx);
+        let unique_name = res.unique_name(ctx);
         let name = if res.get_type(ctx).deref(ctx).is::<VoidType>() {
             ""
         } else {
-            &res.unique_name(ctx)
+            unique_name.as_ref()
         };
         let callee = match self.callee(ctx) {
             CallOpCallable::Direct(callee_sym) => {
@@ -1386,10 +1395,11 @@ impl ToLLVMValue for CallIntrinsicOp {
             .unwrap_or_else(|| llvm_add_function(cctx.cur_llvm_module, &intrinsic_name, fn_ty));
 
         let res = self.get_result(ctx);
+        let unique_name = res.unique_name(ctx);
         let name = if res.get_type(ctx).deref(ctx).is::<VoidType>() {
             ""
         } else {
-            &res.unique_name(ctx)
+            unique_name.as_ref()
         };
 
         let intrinsic_op = llvm_build_call2(&cctx.builder, fn_ty, intrinsic_fn, &args, name);
@@ -1419,7 +1429,7 @@ impl ToLLVMValue for SExtOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(sext_op)
     }
@@ -1440,7 +1450,7 @@ impl ToLLVMValue for ZExtOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_is_a::instruction(zext_op) {
@@ -1466,7 +1476,7 @@ impl ToLLVMValue for TruncOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(trunc_op)
     }
@@ -1501,7 +1511,7 @@ impl ToLLVMValue for GetElementPtrOp {
             src_elem_type,
             base,
             &indices,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(gep_op)
     }
@@ -1527,7 +1537,7 @@ impl ToLLVMValue for InsertValueOp {
             base,
             value,
             indices[0],
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(insert_op)
     }
@@ -1551,7 +1561,7 @@ impl ToLLVMValue for ExtractValueOp {
             &cctx.builder,
             base,
             indices[0],
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(extract_op)
     }
@@ -1573,7 +1583,7 @@ impl ToLLVMValue for InsertElementOp {
             base,
             value,
             index,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(insert_op)
     }
@@ -1593,7 +1603,7 @@ impl ToLLVMValue for ExtractElementOp {
             &cctx.builder,
             base,
             index,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(extract_op)
     }
@@ -1627,7 +1637,7 @@ impl ToLLVMValue for ShuffleVectorOp {
             vec1,
             vec2,
             mask,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(shuffle_op)
     }
@@ -1650,7 +1660,7 @@ impl ToLLVMValue for SelectOp {
             cond,
             true_val,
             false_val,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if let Some(fmf) = self.get_attr_llvm_select_fast_math_flags(ctx)
@@ -1678,7 +1688,7 @@ impl ToLLVMValue for FAddOp {
             &cctx.builder,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(inst) {
@@ -1705,7 +1715,7 @@ impl ToLLVMValue for FSubOp {
             &cctx.builder,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(inst) {
@@ -1732,7 +1742,7 @@ impl ToLLVMValue for FMulOp {
             &cctx.builder,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(inst) {
@@ -1759,7 +1769,7 @@ impl ToLLVMValue for FDivOp {
             &cctx.builder,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(inst) {
@@ -1786,7 +1796,7 @@ impl ToLLVMValue for FRemOp {
             &cctx.builder,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(inst) {
@@ -1814,7 +1824,7 @@ impl ToLLVMValue for FCmpOp {
             predicate,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(fcmp_op) {
@@ -1835,7 +1845,11 @@ impl ToLLVMValue for FNegOp {
     ) -> Result<LLVMValue> {
         let op = self.get_operation().deref(ctx);
         let arg = convert_value_operand(cctx, ctx, &op.get_operand(0))?;
-        let inst = llvm_build_fneg(&cctx.builder, arg, &self.get_result(ctx).unique_name(ctx));
+        let inst = llvm_build_fneg(
+            &cctx.builder,
+            arg,
+            self.get_result(ctx).unique_name(ctx).as_ref(),
+        );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(inst) {
             let fastmath = self.fast_math_flags(ctx);
@@ -1860,7 +1874,7 @@ impl ToLLVMValue for FPExtOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(fpext_op) {
@@ -1886,7 +1900,7 @@ impl ToLLVMValue for FPTruncOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_can_value_use_fast_math_flags(fptrunc_op) {
@@ -1911,7 +1925,7 @@ impl ToLLVMValue for FPToSIOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(fptosi_op)
     }
@@ -1932,7 +1946,7 @@ impl ToLLVMValue for SIToFPOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(sitofp_op)
     }
@@ -1953,7 +1967,7 @@ impl ToLLVMValue for FPToUIOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(fptoui_op)
     }
@@ -1974,7 +1988,7 @@ impl ToLLVMValue for UIToFPOp {
             &cctx.builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         // The built value may not even be an instruction, but a folded constant.
         if llvm_is_a::instruction(uitofp_op) {
@@ -2001,7 +2015,7 @@ impl ToLLVMValue for VAArgOp {
             &cctx.builder,
             opd,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         Ok(vaarg_op)
     }
@@ -2067,7 +2081,7 @@ fn convert_function(
         let llvm_entry_block = llvm_append_basic_block_in_context(
             llvm_ctx,
             func_llvm,
-            &entry.deref(ctx).unique_name(ctx),
+            entry.deref(ctx).unique_name(ctx).as_ref(),
         );
         cctx.block_map.insert(entry, llvm_entry_block);
     }
@@ -2075,12 +2089,12 @@ fn convert_function(
         let llvm_block = llvm_append_basic_block_in_context(
             llvm_ctx,
             func_llvm,
-            &block.deref(ctx).unique_name(ctx),
+            block.deref(ctx).unique_name(ctx).as_ref(),
         );
         llvm_position_builder_at_end(&cctx.builder, llvm_block);
         for arg in block.deref(ctx).arguments() {
             let arg_type = convert_type(ctx, llvm_ctx, cctx, arg.get_type(ctx))?;
-            let phi = llvm_build_phi(&cctx.builder, arg_type, &arg.unique_name(ctx));
+            let phi = llvm_build_phi(&cctx.builder, arg_type, arg.unique_name(ctx).as_ref());
             cctx.value_map.insert(arg, phi);
         }
         cctx.block_map.insert(block, llvm_block);
@@ -2285,7 +2299,7 @@ impl ToLLVMConstValue for InsertValueOp {
             base,
             value,
             indices[0],
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         if !llvm_is_a::constant(insert_op) {
             return input_err!(op.loc(), ToLLVMErr::CannotEvaluateToConst);
@@ -2314,7 +2328,7 @@ impl ToLLVMConstValue for InsertElementOp {
             base,
             value,
             index,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         if !llvm_is_a::constant(insert_op) {
             return input_err!(op.loc(), ToLLVMErr::CannotEvaluateToConst);
@@ -2340,7 +2354,7 @@ impl ToLLVMConstValue for TruncOp {
             &cctx.scratch_builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         if !llvm_is_a::constant(trunc_op) {
             return input_err!(op.loc(), ToLLVMErr::CannotEvaluateToConst);
@@ -2366,7 +2380,7 @@ impl ToLLVMConstValue for SubOp {
             &cctx.scratch_builder,
             lhs,
             rhs,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         if !llvm_is_a::constant(sub_op) {
             return input_err!(op.loc(), ToLLVMErr::CannotEvaluateToConst);
@@ -2392,7 +2406,7 @@ impl ToLLVMConstValue for PtrToIntOp {
             &cctx.scratch_builder,
             arg,
             ty,
-            &self.get_result(ctx).unique_name(ctx),
+            self.get_result(ctx).unique_name(ctx).as_ref(),
         );
         if !llvm_is_a::constant(ptoi_op) {
             return input_err!(op.loc(), ToLLVMErr::CannotEvaluateToConst);
@@ -2467,7 +2481,7 @@ pub fn convert_module(
     module: ModuleOp,
 ) -> Result<LLVMModule> {
     let mod_name = module.get_symbol_name(ctx);
-    let llvm_module = LLVMModule::new(&mod_name, llvm_ctx);
+    let llvm_module = LLVMModule::new(mod_name.as_ref(), llvm_ctx);
     let cctx = &mut ConversionContext::new(llvm_ctx, &llvm_module);
 
     // Setup the scratch builder for evaluating constants.

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -425,6 +425,12 @@ impl AsRef<str> for AttrName {
     }
 }
 
+impl AsRef<Identifier> for AttrName {
+    fn as_ref(&self) -> &Identifier {
+        &self.0
+    }
+}
+
 impl From<Identifier> for AttrName {
     fn from(value: Identifier) -> Self {
         AttrName(value)

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -419,11 +419,9 @@ impl Parsable for AttrName {
     }
 }
 
-impl Deref for AttrName {
-    type Target = Identifier;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl AsRef<str> for AttrName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
     }
 }
 

--- a/src/basic_block.rs
+++ b/src/basic_block.rs
@@ -292,7 +292,7 @@ impl BasicBlock {
             !ptr.has_pred(ctx),
             "BasicBlock {} with predecessor {} being erased",
             ptr.deref(ctx).unique_name(ctx),
-            *ptr.preds(ctx).first().unwrap().deref(ctx).unique_name(ctx)
+            ptr.preds(ctx).first().unwrap().deref(ctx).unique_name(ctx)
         );
         if let Some(op) = ptr.deref(ctx).iter(ctx).find(|op| op.deref(ctx).has_use()) {
             panic!(

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -3,9 +3,7 @@
 
 //! [Dialect]s are a mechanism to group related [Op](crate::op::Op)s, [Type](crate::type::Type)s
 //! and [Attribute](crate::attribute::Attribute)s.
-use core::{fmt::Display, ops::Deref};
-
-use alloc::string::String;
+use core::fmt::Display;
 
 use crate::{
     attribute::{AttrId, AttrParserFn},
@@ -73,7 +71,7 @@ impl Parsable for DialectName {
                 if state_stream.state.ctx.dialects.contains_key(&dialect_name) {
                     Ok(dialect_name).into_parse_result()
                 } else {
-                    input_err!(loc.clone(), "Unregistered dialect {}", *dialect_name)?
+                    input_err!(loc.clone(), "Unregistered dialect {}", dialect_name)?
                 }
             })
         });
@@ -81,11 +79,9 @@ impl Parsable for DialectName {
     }
 }
 
-impl Deref for DialectName {
-    type Target = String;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl AsRef<str> for DialectName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
     }
 }
 

--- a/src/graph/visualize.rs
+++ b/src/graph/visualize.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The pliron contributors
 
 use alloc::{format, string::String};
-use core::{fmt::Display, ops::Deref};
+use core::fmt::Display;
 use pliron::{
     basic_block::BasicBlock,
     common_traits::Named,
@@ -260,7 +260,7 @@ fn graphviz_callback(
                 .get_region_index(region.deref(ctx).get_parent_op())
                 .unwrap();
             let op_id = Operation::get_op_dyn(parent_op, ctx).get_opid();
-            let parent_op_label = op_id.name.deref();
+            let parent_op_label = &op_id.name;
             write!(
                 graph_state.f,
                 "subgraph cluster_region_{0}_{1}{{ \n style=dotted;\n label=\"parent_op : {2}, region_idx : {1}\";\n",

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -7,10 +7,7 @@ use alloc::{
     format,
     string::{String, ToString},
 };
-use core::{
-    fmt::Display,
-    ops::{Add, Deref},
-};
+use core::{fmt::Display, ops::Add};
 use thiserror::Error;
 
 use crate::{
@@ -101,10 +98,8 @@ impl From<Identifier> for String {
     }
 }
 
-impl Deref for Identifier {
-    type Target = String;
-
-    fn deref(&self) -> &Self::Target {
+impl AsRef<str> for Identifier {
+    fn as_ref(&self) -> &str {
         &self.0
     }
 }
@@ -147,27 +142,27 @@ impl Parsable for Identifier {
 /// use pliron::identifier::{Legaliser, Identifier};
 /// let mut legaliser = Legaliser::default();
 /// let id1 = legaliser.legalise("hello_");
-/// assert_eq!(*id1, "hello_");
+/// assert_eq!(id1.as_ref(), "hello_");
 /// assert_eq!(legaliser.source_name(&id1).unwrap(), "hello_");
 /// let id2 = legaliser.legalise("hello.");
-/// assert_eq!(*id2, "hello__0");
+/// assert_eq!(id2.as_ref(), "hello__0");
 /// assert_eq!(legaliser.source_name(&id2).unwrap(), "hello.");
 /// let id3 = legaliser.legalise("hello__0");
-/// assert_eq!(*id3, "hello__0_1");
+/// assert_eq!(id3.as_ref(), "hello__0_1");
 /// assert_eq!(legaliser.source_name(&id3).unwrap(), "hello__0");
 /// let id4 = legaliser.legalise("");
-/// assert_eq!(*id4, "_");
+/// assert_eq!(id4.as_ref(), "_");
 /// assert_eq!(legaliser.source_name(&id4).unwrap(), "");
 /// let id5 = legaliser.legalise("_");
-/// assert_eq!(*id5, "__2");
+/// assert_eq!(id5.as_ref(), "__2");
 /// assert_eq!(legaliser.source_name(&id5).unwrap(), "_");
 ///
 /// let mut another_legaliser = Legaliser::default();
 /// let id6 = another_legaliser.legalise("_");
-/// assert_eq!(*id6, "_");
+/// assert_eq!(id6.as_ref(), "_");
 /// assert_eq!(another_legaliser.source_name(&id6).unwrap(), "_");
 /// let id7 = another_legaliser.legalise("");
-/// assert_eq!(*id7, "__0");
+/// assert_eq!(id7.as_ref(), "__0");
 /// assert_eq!(another_legaliser.source_name(&id7).unwrap(), "");
 ///
 /// ```

--- a/src/op.rs
+++ b/src/op.rs
@@ -89,11 +89,9 @@ impl OpName {
     }
 }
 
-impl Deref for OpName {
-    type Target = Identifier;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl AsRef<str> for OpName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
     }
 }
 
@@ -421,7 +419,7 @@ pub fn canonical_syntax_print(
     let operands = iter_with_sep(op.operands(), sep);
     let successors = iter_with_sep(
         op.successors()
-            .map(|succ| "^".to_string() + &succ.unique_name(ctx)),
+            .map(|succ| "^".to_string() + succ.unique_name(ctx).as_ref()),
         sep,
     );
     let op_type = TypeSig {

--- a/src/op.rs
+++ b/src/op.rs
@@ -95,6 +95,12 @@ impl AsRef<str> for OpName {
     }
 }
 
+impl AsRef<Identifier> for OpName {
+    fn as_ref(&self) -> &Identifier {
+        &self.0
+    }
+}
+
 impl From<Identifier> for OpName {
     fn from(value: Identifier) -> Self {
         OpName(value)

--- a/src/type.rs
+++ b/src/type.rs
@@ -247,6 +247,12 @@ impl AsRef<str> for TypeName {
     }
 }
 
+impl AsRef<Identifier> for TypeName {
+    fn as_ref(&self) -> &Identifier {
+        &self.0
+    }
+}
+
 impl_printable_for_display!(TypeName);
 
 impl Display for TypeName {

--- a/src/type.rs
+++ b/src/type.rs
@@ -66,7 +66,6 @@ use core::{
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
     marker::PhantomData,
-    ops::Deref,
 };
 use downcast_rs::{Downcast, impl_downcast};
 use pliron_derive::format;
@@ -242,11 +241,9 @@ impl TryFrom<String> for TypeName {
     }
 }
 
-impl Deref for TypeName {
-    type Target = Identifier;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+impl AsRef<str> for TypeName {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
     }
 }
 


### PR DESCRIPTION
This is a breaking change

https://doc.rust-lang.org/std/ops/trait.Deref.html#when-to-implement-deref-or-derefmut