### PR TITLE
feat: support multiple overloaded intrinsic

### DIFF
--- a/pliron-llvm/Cargo.toml
+++ b/pliron-llvm/Cargo.toml
@@ -28,6 +28,9 @@ bitflags = { workspace = true }
 # CI `.yml` files and the READMEs in `pliron-llvm` and `llvm-opt`.
 llvm-sys = { version = "221", optional = true }
 
+[build-dependencies]
+cc = "1"
+
 [dev-dependencies]
 expect-test.workspace = true
 tempfile.workspace = true

--- a/pliron-llvm/build.rs
+++ b/pliron-llvm/build.rs
@@ -4,4 +4,38 @@
 fn main() {
     // Tell Cargo to link to libffi
     println!("cargo::rustc-link-lib=ffi");
+
+    #[cfg(feature = "llvm-sys")]
+    build_cpp_shim();
+}
+
+/// Build the C++ shim exposing the bits of LLVM's C++ API that the C API doesn't cover.
+#[cfg(feature = "llvm-sys")]
+fn build_cpp_shim() {
+    const SHIM: &str = "cpp/intrinsic_signature.cpp";
+    println!("cargo::rerun-if-changed={SHIM}");
+
+    // llvm-sys publishes the llvm-config it settled on, so we build against the LLVM it linked.
+    let llvm_config = std::env::var("DEP_LLVM_22_CONFIG_PATH")
+        .expect("llvm-sys did not publish DEP_LLVM_22_CONFIG_PATH");
+
+    let out = std::process::Command::new(&llvm_config)
+        .arg("--cxxflags")
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run `{llvm_config} --cxxflags`: {e}"));
+    assert!(out.status.success(), "`{llvm_config} --cxxflags` failed");
+    let cxxflags = String::from_utf8(out.stdout).expect("llvm-config emitted non-UTF-8");
+
+    let mut build = cc::Build::new();
+    build.opt_level(3);
+    build.cpp(true).file(SHIM);
+    for flag in cxxflags.split_whitespace() {
+        // `cc` supplies its own codegen flags; we only need the include path, language version
+        // and the defines LLVM's headers expect.
+        if flag.starts_with("-I") || flag.starts_with("-D") || flag.starts_with("-std=") {
+            build.flag(flag);
+        }
+    }
+    build.flag_if_supported("-fno-rtti");
+    build.compile("pliron_llvm_shim");
 }

--- a/pliron-llvm/cpp/intrinsic_signature.cpp
+++ b/pliron-llvm/cpp/intrinsic_signature.cpp
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) The pliron contributors
+
+// Expose Intrinsic::getIntrinsicSignature with a C API
+
+#include "llvm-c/Core.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/Type.h"
+
+#include <cstddef>
+
+extern "C" {
+
+/// The types ID is overloaded at when instantiated as fn_ty, in the order
+/// LLVMGetIntrinsicDeclaration expects them.
+///
+/// Writes the count to out_count and, if it fits, that many types to out_tys. Returns 0 on success,
+/// -1 if fn_ty is not a function type, -2 if fn_ty is not a valid signature for ID, and -3 if OutCap
+/// was too small, in which case out_tys is untouched and out_count holds the size needed.
+int PlironIntrinsicGetSignature(unsigned ID, LLVMTypeRef fn_ty, LLVMTypeRef *out_tys,
+                                size_t OutCap, size_t *out_count) {
+  auto *f_ty = llvm::dyn_cast<llvm::FunctionType>(llvm::unwrap(fn_ty));
+  if (!f_ty)
+    return -1;
+
+  llvm::SmallVector<llvm::Type *, 8> arg_tys;
+  if (!llvm::Intrinsic::getIntrinsicSignature(static_cast<llvm::Intrinsic::ID>(ID), f_ty, arg_tys))
+    return -2;
+
+  *out_count = arg_tys.size();
+  if (arg_tys.size() > OutCap)
+    return -3;
+
+  for (size_t i = 0; i < arg_tys.size(); ++i)
+    out_tys[i] = llvm::wrap(arg_tys[i]);
+  return 0;
+}
+
+} // extern "C"

--- a/pliron-llvm/src/llvm_sys/core.rs
+++ b/pliron-llvm/src/llvm_sys/core.rs
@@ -2645,6 +2645,54 @@ pub fn llvm_intrinsic_is_overloaded(id: IntrinsicID) -> bool {
     unsafe { LLVMIntrinsicIsOverloaded(id.0).to_bool() }
 }
 
+unsafe extern "C" {
+    /// See `cpp/intrinsic_signature.cpp`.
+    fn PlironIntrinsicGetSignature(
+        id: u32,
+        fn_ty: llvm_sys::prelude::LLVMTypeRef,
+        out_tys: *mut llvm_sys::prelude::LLVMTypeRef,
+        out_cap: usize,
+        out_count: *mut usize,
+    ) -> i32;
+}
+
+/// Intrinsic::getIntrinsicSignature
+///
+/// The types `id` is overloaded at when instantiated as `fn_ty`, in the order
+/// [llvm_get_intrinsic_declaration] wants them. Empty for a non-overloaded intrinsic,
+/// `Err` if `fn_ty` isn't a valid signature for `id`.
+pub fn llvm_intrinsic_get_signature(
+    id: IntrinsicID,
+    fn_ty: LLVMType,
+) -> Result<Vec<LLVMType>, String> {
+    let mut out: Vec<llvm_sys::prelude::LLVMTypeRef> = vec![core::ptr::null_mut(); 8];
+    let mut count = 0usize;
+
+    // Safety: `out` has `out.len()` writable elements, and the shim writes none unless it
+    // returns 0, and at most `count <= out.len()` then.
+    let mut rc = unsafe {
+        PlironIntrinsicGetSignature(id.0, fn_ty.into(), out.as_mut_ptr(), out.len(), &mut count)
+    };
+    if rc == -3 {
+        out.resize(count, core::ptr::null_mut());
+        rc = unsafe {
+            PlironIntrinsicGetSignature(id.0, fn_ty.into(), out.as_mut_ptr(), out.len(), &mut count)
+        };
+    }
+
+    match rc {
+        0 => Ok(out[..count].iter().map(|ty| (*ty).into()).collect()),
+        -1 => Err("intrinsic signature must be a function type".to_string()),
+        -2 => Err(format!(
+            "{fn_ty} is not a valid signature for intrinsic ID {}",
+            id.0
+        )),
+        other => Err(format!(
+            "unexpected intrinsic signature match result {other}"
+        )),
+    }
+}
+
 /// LLVMGetIntrinsicDeclaration
 pub fn llvm_get_intrinsic_declaration(
     module: &LLVMModule,

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -69,14 +69,15 @@ use crate::{
         llvm_const_int, llvm_const_null, llvm_const_real, llvm_const_string_in_context,
         llvm_const_vector, llvm_delete_global, llvm_double_type_in_context,
         llvm_float_type_in_context, llvm_function_type, llvm_get_inline_asm,
-        llvm_get_named_function, llvm_get_param, llvm_get_pointer_address_space, llvm_get_poison,
-        llvm_get_sync_scope_id, llvm_get_undef, llvm_half_type_in_context,
-        llvm_int_type_in_context, llvm_is_a, llvm_lookup_intrinsic_id,
-        llvm_pointer_type_in_context, llvm_position_builder_at_end, llvm_replace_all_uses_with,
-        llvm_scalable_vector_type, llvm_set_alignment, llvm_set_atomic_sync_scope_id,
-        llvm_set_fast_math_flags, llvm_set_initializer, llvm_set_linkage, llvm_set_nneg,
-        llvm_set_ordering, llvm_struct_create_named, llvm_struct_set_body,
-        llvm_struct_type_in_context, llvm_type_of, llvm_vector_type, llvm_void_type_in_context,
+        llvm_get_intrinsic_declaration, llvm_get_param, llvm_get_pointer_address_space,
+        llvm_get_poison, llvm_get_sync_scope_id, llvm_get_undef, llvm_half_type_in_context,
+        llvm_int_type_in_context, llvm_intrinsic_get_signature, llvm_is_a,
+        llvm_lookup_intrinsic_id, llvm_pointer_type_in_context, llvm_position_builder_at_end,
+        llvm_replace_all_uses_with, llvm_scalable_vector_type, llvm_set_alignment,
+        llvm_set_atomic_sync_scope_id, llvm_set_fast_math_flags, llvm_set_initializer,
+        llvm_set_linkage, llvm_set_nneg, llvm_set_ordering, llvm_struct_create_named,
+        llvm_struct_set_body, llvm_struct_type_in_context, llvm_type_of, llvm_vector_type,
+        llvm_void_type_in_context,
     },
     op_interfaces::{
         AlignableOpInterface, FastMathFlags, IsDeclaration, LlvmSymbolName, NNegFlag,
@@ -173,6 +174,8 @@ pub enum ToLLVMErr {
     CannotEvaluateToConst,
     #[error("BlockAddressOp refers to missing block tag {1} in function {0}")]
     MissingBlockTag(String, u64),
+    #[error("Call to intrinsic {0} has an invalid signature: {1}")]
+    IntrinsicSignatureMismatch(String, String),
 }
 
 pub fn convert_ipredicate(pred: ICmpPredicateAttr) -> LLVMIntPredicate {
@@ -1384,17 +1387,20 @@ impl ToLLVMValue for CallIntrinsicOp {
                 .clone(),
         );
 
-        let _intrinsic_id = llvm_lookup_intrinsic_id(&intrinsic_name).ok_or_else(|| {
+        let intrinsic_id = llvm_lookup_intrinsic_id(&intrinsic_name).ok_or_else(|| {
             input_error_noloc!(ToLLVMErr::UndefinedValue(intrinsic_name.to_string()))
         })?;
 
-        // We just use llvm_add_function instead of llvm_get_intrinsic_declaration here
-        // because the latter requires that (and I quote from Intrinsics.h::getOrInsertDeclaration):
-        //   "For a declaration of an overloaded intrinsic, Tys must provide exactly one
-        //    type for each overloaded type in the intrinsic."
-        // I don't know how to determine that from just the name and argument types.
-        let intrinsic_fn = llvm_get_named_function(cctx.cur_llvm_module, &intrinsic_name)
-            .unwrap_or_else(|| llvm_add_function(cctx.cur_llvm_module, &intrinsic_name, fn_ty));
+        // An overloaded intrinsic must be declared under its mangled name (llvm.maximum.f32,
+        // llvm.maximum.v2f32, ...), so recover the types it is overloaded at from the signature.
+        // Under the bare name, LLVM shares one declaration between every signature in the module
+        // and turns all but the first into indirect calls to an undefined symbol.
+        let overload_tys = llvm_intrinsic_get_signature(intrinsic_id, fn_ty).map_err(|err| {
+            input_error_noloc!(ToLLVMErr::IntrinsicSignatureMismatch(intrinsic_name, err))
+        })?;
+        let intrinsic_fn =
+            llvm_get_intrinsic_declaration(cctx.cur_llvm_module, intrinsic_id, &overload_tys)
+                .map_err(|err| input_error_noloc!(ToLLVMErr::UndefinedValue(err)))?;
 
         let res = self.get_result(ctx);
         let unique_name;

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -156,3 +156,72 @@ fn llvm_ir_select_without_fastmath_flags_omits_attr() -> Result<()> {
 
     Ok(())
 }
+
+/// An overloaded intrinsic used at two signatures in one module must get a separately mangled
+/// declaration for each. Sharing one declaration under the bare name makes the mismatching calls
+/// indirect calls to an undefined symbol.
+#[test]
+fn overloaded_intrinsic_is_mangled_per_signature() -> Result<()> {
+    let input = r#"
+            builtin.module @m {
+            ^block_0_0():
+              llvm.func @foo: llvm.func <builtin.fp32(builtin.fp32, llvm.vector <Fixed x 2 x builtin.fp32 >) variadic = false> [] {
+              ^entry_block_1_0(a: builtin.fp32, v: llvm.vector <Fixed x 2 x builtin.fp32 >):
+                w = llvm.call_intrinsic @"llvm.maximum" (v, v) : llvm.func <llvm.vector <Fixed x 2 x builtin.fp32 >(llvm.vector <Fixed x 2 x builtin.fp32 >, llvm.vector <Fixed x 2 x builtin.fp32 >) variadic = false>;
+                z = llvm.constant <builtin.integer <0: i32>> : builtin.integer i32;
+                e = llvm.extract_element w, z : builtin.fp32;
+                m = llvm.call_intrinsic @"llvm.maximum" (a, e) : llvm.func <builtin.fp32 (builtin.fp32, builtin.fp32) variadic = false>;
+                llvm.return m
+              }
+            }
+        "#;
+
+    let after = to_llvm_ir_o1(input)?;
+
+    expect![[r#"
+        ; ModuleID = 'm'
+        source_filename = "m"
+
+        define float @foo(float %0, <2 x float> %1) {
+        entry_block_1_0_block2v1:
+          %w_v2 = call <2 x float> @llvm.maximum.v2f32(<2 x float> %1, <2 x float> %1)
+          %e_v4 = extractelement <2 x float> %w_v2, i32 0
+          %m_v5 = call float @llvm.maximum.f32(float %0, float %e_v4)
+          ret float %m_v5
+        }
+
+        ; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+        declare <2 x float> @llvm.maximum.v2f32(<2 x float>, <2 x float>) #0
+
+        ; Function Attrs: nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none)
+        declare float @llvm.maximum.f32(float, float) #0
+
+        attributes #0 = { nocallback nocreateundeforpoison nofree nosync nounwind speculatable willreturn memory(none) }
+    "#]].assert_eq(&after);
+
+    Ok(())
+}
+
+/// The overload types are recovered from the call signature, so a call that isn't a valid
+/// instance of the intrinsic is rejected instead of silently declaring an external symbol.
+/// `llvm.abs` is `i_ (i_, i1 immarg)`; here it is called with only the first argument.
+#[test]
+fn intrinsic_call_with_invalid_signature_is_rejected() {
+    let input = r#"
+            builtin.module @m {
+            ^block_0_0():
+              llvm.func @foo: llvm.func <builtin.integer i32(builtin.integer i32) variadic = false> [] {
+              ^entry_block_1_0(a: builtin.integer i32):
+                r = llvm.call_intrinsic @"llvm.abs" (a) : llvm.func <builtin.integer i32(builtin.integer i32) variadic = false>;
+                llvm.return r
+              }
+            }
+        "#;
+
+    let err = to_llvm_ir_o1(input).expect_err("invalid intrinsic signature must be rejected");
+    assert!(
+        err.to_string()
+            .contains("Call to intrinsic llvm.abs has an invalid signature"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Description

Pliron didn't have a good way to support overloaded intrinsic, it would just crash if multiple intrinsic of the same ops where made where the result type is the same like for `llvm.minimum`. There is no good way to find which args are overloaded with the C api of LLVM, MLIR use `Intrinsic::getIntrinsicSignature`, but no C api is available for it. The PR add a small wrapper to be able to access it, but we would need it in upstream one day.

## Checklist
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] A human is involved in writing this PR description and will handle
review interactions, per our [AI tool policy](../CONTRIBUTING.md).
- [x] I understand every part of this change (including any AI-generated
code) and can explain the reasoning behind it.
- [x] Intrusive / large changes were discussed on Discord before this PR.
- [x] `pre-ci.sh` passes locally.
