### PR TITLE
`Ptr<T>` shouldn't hash `T` and more `expect!` based testing

### DIFF
--- a/pliron-llvm/tests/common/mod.rs
+++ b/pliron-llvm/tests/common/mod.rs
@@ -12,6 +12,12 @@ use pliron::{
     result::Result,
 };
 
+#[cfg(feature = "llvm-sys")]
+use pliron_llvm::{
+    from_llvm_ir,
+    llvm_sys::core::{LLVMContext, LLVMMemoryBuffer, LLVMModule},
+};
+
 /// Parses an Op from the given input string, verifies, and returns it
 pub fn parse_op_verify<O: Op>(ctx: &mut Context, input: &str) -> Result<O> {
     let op = parse_from_str(spaced(Operation::top_level_parser()), ctx, input)?;
@@ -38,4 +44,22 @@ pub fn run_o1_passes_verify(ctx: &mut Context, module_op: ModuleOp) -> Result<()
     );
     verify_op(&module_op, ctx)?;
     Ok(())
+}
+
+/// Parses `input` as LLVM IR text, converts it into a pliron [ModuleOp], and verifies it.
+#[cfg(feature = "llvm-sys")]
+#[allow(dead_code)]
+pub fn parse_llvm_ir_verify(
+    ctx: &mut Context,
+    llvm_ctx: &LLVMContext,
+    input: &str,
+    name: &str,
+) -> Result<ModuleOp> {
+    let buf = LLVMMemoryBuffer::from_str(input, name);
+    let llvm_mod =
+        LLVMModule::from_ir_in_memory_buffer(llvm_ctx, buf).expect("LLVM IR input should parse");
+
+    let module_op = from_llvm_ir::convert_module(ctx, &llvm_mod)?;
+    verify_operation(module_op.get_operation(), ctx)?;
+    Ok(module_op)
 }

--- a/pliron-llvm/tests/ir_expect.rs
+++ b/pliron-llvm/tests/ir_expect.rs
@@ -6,15 +6,8 @@
 #![cfg(feature = "llvm-sys")]
 
 use expect_test::expect;
-use pliron::{
-    context::Context, init_env_logger_for_tests, op::Op, operation::verify_operation,
-    printable::Printable, result::Result,
-};
-use pliron_llvm::{
-    from_llvm_ir,
-    llvm_sys::core::{LLVMContext, LLVMMemoryBuffer, LLVMModule},
-    to_llvm_ir,
-};
+use pliron::{context::Context, init_env_logger_for_tests, printable::Printable, result::Result};
+use pliron_llvm::{llvm_sys::core::LLVMContext, to_llvm_ir};
 
 mod common;
 
@@ -34,15 +27,15 @@ fn to_llvm_ir_o1(input: &str) -> Result<String> {
 #[test]
 fn float_select_preserves_fastmath_flags() -> Result<()> {
     let input = r#"
-            builtin.module @m {
-            ^block_0_0():
-              llvm.func @foo: llvm.func <builtin.fp32(builtin.integer i1, builtin.fp32, builtin.fp32) variadic = false> [] {
-              ^entry_block_1_0(c: builtin.integer i1, a: builtin.fp32, b: builtin.fp32):
-                s = llvm.select <NNAN> c ? a : b : builtin.fp32;
-                llvm.return s
-              }
-            }
-        "#;
+        builtin.module @m {
+        ^block_0_0():
+          llvm.func @foo: llvm.func <builtin.fp32(builtin.integer i1, builtin.fp32, builtin.fp32) variadic = false> [] {
+          ^entry_block_1_0(c: builtin.integer i1, a: builtin.fp32, b: builtin.fp32):
+            s = llvm.select <NNAN> c ? a : b : builtin.fp32;
+            llvm.return s
+          }
+        }
+    "#;
 
     let after = to_llvm_ir_o1(input)?;
 
@@ -66,15 +59,15 @@ fn float_select_preserves_fastmath_flags() -> Result<()> {
 #[test]
 fn int_select_with_fastmath_flags_is_rejected() {
     let input = r#"
-            builtin.module @m {
-            ^block_0_0():
-              llvm.func @foo: llvm.func <builtin.integer i64(builtin.integer i1, builtin.integer i64, builtin.integer i64) variadic = false> [] {
-              ^entry_block_1_0(c: builtin.integer i1, a: builtin.integer i64, b: builtin.integer i64):
-                s = llvm.select <NNAN> c ? a : b : builtin.integer i64;
-                llvm.return s
-              }
-            }
-        "#;
+        builtin.module @m {
+        ^block_0_0():
+          llvm.func @foo: llvm.func <builtin.integer i64(builtin.integer i1, builtin.integer i64, builtin.integer i64) variadic = false> [] {
+          ^entry_block_1_0(c: builtin.integer i1, a: builtin.integer i64, b: builtin.integer i64):
+            s = llvm.select <NNAN> c ? a : b : builtin.integer i64;
+            llvm.return s
+          }
+        }
+    "#;
 
     let err = to_llvm_ir_o1(input).expect_err("verifier must reject the flags");
     assert!(
@@ -90,35 +83,45 @@ fn int_select_with_fastmath_flags_is_rejected() {
 fn llvm_ir_select_fastmath_flags_roundtrip() -> Result<()> {
     init_env_logger_for_tests!();
     let input = r#"
-            define float @choose(i1 %c, float %a, float %b) {
-            entry:
-              %r = select nnan nsz i1 %c, float %a, float %b
-              ret float %r
-            }
-        "#;
+        define float @choose(i1 %c, float %a, float %b) {
+        entry:
+          %r = select nnan nsz i1 %c, float %a, float %b
+          ret float %r
+        }
+    "#;
 
     let llvm_ctx = LLVMContext::default();
-    let buf = LLVMMemoryBuffer::from_str(input, "select_fmf");
-    let llvm_mod =
-        LLVMModule::from_ir_in_memory_buffer(&llvm_ctx, buf).expect("LLVM IR input should parse");
-
     let ctx = &mut Context::new();
-    let module_op = from_llvm_ir::convert_module(ctx, &llvm_mod)?;
-    verify_operation(module_op.get_operation(), ctx)?;
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "select_fmf")?;
 
-    let pliron_text = module_op.get_operation().disp(ctx).to_string();
-    assert!(
-        pliron_text.contains("NNAN"),
-        "fast-math flags lost on import:\n{pliron_text}"
-    );
+    let pliron_text = module_op.disp(ctx).to_string();
+    expect![[r#"
+        builtin.module @select_fmf 
+        {
+          ^block1v1():
+            llvm.func @choose: llvm.func <builtin.fp32 (builtin.integer i1, builtin.fp32 , builtin.fp32 ) variadic = false>
+              [llvm_function_linkage: llvm.linkage ExternalLinkage] 
+            {
+              ^entry_block2v1(v0: builtin.integer i1, v1: builtin.fp32 , v2: builtin.fp32 ):
+                r_v3 = llvm.select <NNAN | NSZ> v0 ? v1 : v2 : builtin.fp32  !0;
+                llvm.return r_v3
+            }
+        }"#]].assert_eq(&pliron_text);
 
     let out_llvm_ctx = LLVMContext::default();
     let out_mod = to_llvm_ir::convert_module(ctx, &out_llvm_ctx, module_op)?;
     let out = out_mod.to_string();
-    assert!(
-        out.contains("select nnan nsz"),
-        "fast-math flags lost on export:\n{out}"
-    );
+    expect![[r#"
+        ; ModuleID = 'select_fmf'
+        source_filename = "select_fmf"
+
+        define float @choose(i1 %0, float %1, float %2) {
+        entry_block2v1:
+          %r_v3 = select nnan nsz i1 %0, float %1, float %2
+          ret float %r_v3
+        }
+    "#]]
+    .assert_eq(&out);
     Ok(())
 }
 
@@ -136,23 +139,22 @@ fn llvm_ir_select_without_fastmath_flags_omits_attr() -> Result<()> {
         "#;
 
     let llvm_ctx = LLVMContext::default();
-    let buf = LLVMMemoryBuffer::from_str(input, "select_no_fmf");
-    let llvm_mod =
-        LLVMModule::from_ir_in_memory_buffer(&llvm_ctx, buf).expect("LLVM IR input should parse");
-
     let ctx = &mut Context::new();
-    let module_op = from_llvm_ir::convert_module(ctx, &llvm_mod)?;
-    verify_operation(module_op.get_operation(), ctx)?;
+    let module_op = common::parse_llvm_ir_verify(ctx, &llvm_ctx, input, "select_no_fmf")?;
 
-    let pliron_text = module_op.get_operation().disp(ctx).to_string();
-    assert!(
-        pliron_text.contains("llvm.select"),
-        "expected a select op in the imported IR:\n{pliron_text}"
-    );
-    assert!(
-        !pliron_text.contains("<>"),
-        "select without fast-math flags should not print an empty attribute:\n{pliron_text}"
-    );
+    let pliron_text = module_op.disp(ctx).to_string();
+    expect![[r#"
+        builtin.module @select_no_fmf 
+        {
+          ^block1v1():
+            llvm.func @choose: llvm.func <builtin.fp32 (builtin.integer i1, builtin.fp32 , builtin.fp32 ) variadic = false>
+              [llvm_function_linkage: llvm.linkage ExternalLinkage] 
+            {
+              ^entry_block2v1(v0: builtin.integer i1, v1: builtin.fp32 , v2: builtin.fp32 ):
+                r_v3 = llvm.select  v0 ? v1 : v2 : builtin.fp32  !0;
+                llvm.return r_v3
+            }
+        }"#]].assert_eq(&pliron_text);
 
     Ok(())
 }

--- a/pliron-llvm/tests/opts/constants.rs
+++ b/pliron-llvm/tests/opts/constants.rs
@@ -4,6 +4,7 @@
 //! Test that llvm operations implement the constant folding interfaces
 //! [ConstFoldInterface] and [BranchOpFoldInterface] correctly
 
+use expect_test::expect;
 use pliron::{
     context::Context, init_env_logger_for_tests, irbuild::IRStatus, op::Op,
     operation::verify_operation, opts::constants::sccp::sccp, printable::Printable, result::Result,
@@ -13,17 +14,16 @@ use pliron_llvm::ops::FuncOp;
 
 use crate::common;
 
-fn run_sccp_on_text(input: &str) -> Result<(IRStatus, String, String)> {
+fn run_sccp_on_text(input: &str) -> Result<(IRStatus, String)> {
     init_env_logger_for_tests!();
     let ctx = &mut Context::new();
     let op: FuncOp = common::parse_op_verify(ctx, input)?;
 
-    let before = op.disp(ctx).to_string();
     let status = sccp(op.get_operation(), ctx)?;
     let after = op.disp(ctx).to_string();
-    log::debug!("After SCCP:\n{}", after);
+    log::trace!("After SCCP:\n{}", after);
     verify_operation(op.get_operation(), ctx)?;
-    Ok((status, before, after))
+    Ok((status, after))
 }
 
 // ---------------------------------------------------------------------------
@@ -42,9 +42,20 @@ fn add_folds_two_constants() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<7: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !1;
+            b_v1 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !2;
+            sum_v3 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !3;
+            sum_v2 = llvm.add a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return sum_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -60,9 +71,20 @@ fn add_wraps_on_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<128: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <127: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8 !2;
+            sum_v3 = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8 !3;
+            sum_v2 = llvm.add a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i8 !4;
+            llvm.return sum_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -77,7 +99,7 @@ fn add_does_not_fold_with_non_constant_operand() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -94,7 +116,7 @@ fn add_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -111,7 +133,7 @@ fn add_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -128,9 +150,20 @@ fn add_nsw_still_folds_without_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<7: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8 !2;
+            sum_v3 = builtin.constant <builtin.integer <7: i8>> : builtin.integer i8 !3;
+            sum_v2 = llvm.add a_v0, b_v1 <{nsw=true,nuw=true}>: builtin.integer i8 !4;
+            llvm.return sum_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -150,9 +183,20 @@ fn sub_folds_two_constants() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<6: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64 !1;
+            b_v1 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !2;
+            diff_v3 = builtin.constant <builtin.integer <6: i64>> : builtin.integer i64 !3;
+            diff_v2 = llvm.sub a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return diff_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -168,9 +212,20 @@ fn sub_wraps_on_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<255: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8 !2;
+            diff_v3 = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8 !3;
+            diff_v2 = llvm.sub a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i8 !4;
+            llvm.return diff_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -185,7 +240,7 @@ fn sub_does_not_fold_with_non_constant_operand() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -205,7 +260,7 @@ fn sub_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -222,7 +277,7 @@ fn sub_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -239,9 +294,20 @@ fn sub_nsw_still_folds_without_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<6: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8 !2;
+            diff_v3 = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8 !3;
+            diff_v2 = llvm.sub a_v0, b_v1 <{nsw=true,nuw=true}>: builtin.integer i8 !4;
+            llvm.return diff_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -261,9 +327,20 @@ fn mul_folds_two_constants() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<30: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64 !1;
+            b_v1 = builtin.constant <builtin.integer <6: i64>> : builtin.integer i64 !2;
+            prod_v3 = builtin.constant <builtin.integer <30: i64>> : builtin.integer i64 !3;
+            prod_v2 = llvm.mul a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return prod_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -279,9 +356,20 @@ fn mul_wraps_on_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<44: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <100: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8 !2;
+            prod_v3 = builtin.constant <builtin.integer <44: i8>> : builtin.integer i8 !3;
+            prod_v2 = llvm.mul a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i8 !4;
+            llvm.return prod_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -296,7 +384,7 @@ fn mul_does_not_fold_with_non_constant_operand() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -315,7 +403,7 @@ fn mul_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -332,7 +420,7 @@ fn mul_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -349,9 +437,20 @@ fn mul_nsw_still_folds_without_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<30: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8 !2;
+            prod_v3 = builtin.constant <builtin.integer <30: i8>> : builtin.integer i8 !3;
+            prod_v2 = llvm.mul a_v0, b_v1 <{nsw=true,nuw=true}>: builtin.integer i8 !4;
+            llvm.return prod_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -371,9 +470,20 @@ fn shl_folds_two_constants() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<8: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            b_v1 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !2;
+            shifted_v3 = builtin.constant <builtin.integer <8: i64>> : builtin.integer i64 !3;
+            shifted_v2 = llvm.shl a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return shifted_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -393,9 +503,20 @@ fn shl_wraps_on_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<128: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <7: i8>> : builtin.integer i8 !2;
+            shifted_v3 = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8 !3;
+            shifted_v2 = llvm.shl a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i8 !4;
+            llvm.return shifted_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -413,7 +534,7 @@ fn shl_does_not_fold_when_shift_amount_exceeds_bitwidth() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -429,7 +550,7 @@ fn shl_does_not_fold_with_non_constant_operand() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -449,7 +570,7 @@ fn shl_nuw_does_not_fold_on_unsigned_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -471,7 +592,7 @@ fn shl_nsw_does_not_fold_on_signed_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -491,9 +612,20 @@ fn shl_nsw_nuw_still_folds_without_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<8: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8 !2;
+            shifted_v3 = builtin.constant <builtin.integer <8: i8>> : builtin.integer i8 !3;
+            shifted_v2 = llvm.shl a_v0, b_v1 <{nsw=true,nuw=true}>: builtin.integer i8 !4;
+            llvm.return shifted_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -513,9 +645,20 @@ fn sdiv_folds_two_constants() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<3: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <2: i8>> : builtin.integer i8 !2;
+            q_v3 = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8 !3;
+            q_v2 = llvm.sdiv a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return q_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -531,7 +674,7 @@ fn sdiv_does_not_fold_on_division_by_zero() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -551,7 +694,7 @@ fn sdiv_does_not_fold_on_signed_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -572,9 +715,20 @@ fn srem_folds_two_constants() -> Result<()> {
       }
     "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<1: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <7: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8 !2;
+            r_v3 = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8 !3;
+            r_v2 = llvm.srem a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return r_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -590,7 +744,7 @@ fn srem_does_not_fold_on_division_by_zero() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -608,7 +762,7 @@ fn srem_does_not_fold_on_signed_overflow() -> Result<()> {
       }
     "#;
 
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -628,9 +782,20 @@ fn udiv_folds_two_constants() -> Result<()> {
         llvm.return q
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<3: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <13: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8 !2;
+            q_v3 = builtin.constant <builtin.integer <3: i8>> : builtin.integer i8 !3;
+            q_v2 = llvm.udiv a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return q_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -645,7 +810,7 @@ fn udiv_does_not_fold_on_division_by_zero() -> Result<()> {
         llvm.return q
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -665,9 +830,20 @@ fn urem_folds_two_constants() -> Result<()> {
         llvm.return r
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<1: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <13: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <4: i8>> : builtin.integer i8 !2;
+            r_v3 = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8 !3;
+            r_v2 = llvm.urem a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return r_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -682,7 +858,7 @@ fn urem_does_not_fold_on_division_by_zero() -> Result<()> {
         llvm.return r
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -703,9 +879,20 @@ fn and_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<8: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <12: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <8: i8>> : builtin.integer i8 !3;
+            c_v2 = llvm.and a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -719,7 +906,7 @@ fn and_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -734,9 +921,19 @@ fn and_folds_to_zero_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<0: i1>").count(), 2);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i1(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(x_v0: builtin.integer i1) !0:
+            z_v1 = builtin.constant <builtin.integer <0: i1>> : builtin.integer i1 !1;
+            c_v3 = builtin.constant <builtin.integer <0: i1>> : builtin.integer i1 !2;
+            c_v2 = llvm.and x_v0, z_v1 : builtin.integer i1 !3;
+            llvm.return c_v3 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -756,9 +953,20 @@ fn or_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<14: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <12: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <14: i8>> : builtin.integer i8 !3;
+            c_v2 = llvm.or a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -772,7 +980,7 @@ fn or_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -787,9 +995,19 @@ fn or_folds_to_one_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("<1: i1>").count(), 2);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i1(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(x_v0: builtin.integer i1) !0:
+            one_v1 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !1;
+            c_v3 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !2;
+            c_v2 = llvm.or x_v0, one_v1 : builtin.integer i1 !3;
+            llvm.return c_v3 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -809,9 +1027,20 @@ fn xor_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<6: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <12: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <10: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8 !3;
+            c_v2 = llvm.xor a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -825,7 +1054,7 @@ fn xor_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -845,9 +1074,20 @@ fn lshr_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<64: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <64: i8>> : builtin.integer i8 !3;
+            c_v2 = llvm.lshr a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -861,7 +1101,7 @@ fn lshr_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -877,7 +1117,7 @@ fn lshr_does_not_fold_when_shift_amount_exceeds_bitwidth() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -899,9 +1139,20 @@ fn ashr_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<192: i8>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i8() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <128: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <1: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <192: i8>> : builtin.integer i8 !3;
+            c_v2 = llvm.ashr a_v0, b_v1 : builtin.integer i8 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -915,7 +1166,7 @@ fn ashr_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -931,7 +1182,7 @@ fn ashr_does_not_fold_when_shift_amount_exceeds_bitwidth() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -951,9 +1202,20 @@ fn icmp_eq_folds_to_true() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<1: i1>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i1() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !3;
+            c_v2 = llvm.icmp a_v0 <EQ> b_v1 : builtin.integer i1 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -968,9 +1230,20 @@ fn icmp_eq_folds_to_false() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<0: i1>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i1() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <6: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <0: i1>> : builtin.integer i1 !3;
+            c_v2 = llvm.icmp a_v0 <EQ> b_v1 : builtin.integer i1 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -986,9 +1259,20 @@ fn icmp_signed_predicate_treats_high_bit_as_negative() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<1: i1>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i1() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !3;
+            c_v2 = llvm.icmp a_v0 <SLT> b_v1 : builtin.integer i1 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1005,9 +1289,20 @@ fn icmp_unsigned_predicate_treats_high_bit_as_large() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<0: i1>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i1() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8 !1;
+            b_v1 = builtin.constant <builtin.integer <0: i8>> : builtin.integer i8 !2;
+            c_v3 = builtin.constant <builtin.integer <0: i1>> : builtin.integer i1 !3;
+            c_v2 = llvm.icmp a_v0 <ULT> b_v1 : builtin.integer i1 !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1021,7 +1316,7 @@ fn icmp_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1040,9 +1335,19 @@ fn sext_folds_non_negative_constant() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<5: i16>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i16() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8 !1;
+            c_v2 = builtin.constant <builtin.integer <5: i16>> : builtin.integer i16 !2;
+            c_v1 = llvm.sext a_v0 to builtin.integer i16 !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1058,9 +1363,19 @@ fn sext_folds_negative_constant() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<65535: i16>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i16() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8 !1;
+            c_v2 = builtin.constant <builtin.integer <65535: i16>> : builtin.integer i16 !2;
+            c_v1 = llvm.sext a_v0 to builtin.integer i16 !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1073,7 +1388,7 @@ fn sext_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1093,9 +1408,19 @@ fn zext_folds_non_negative_constant() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<5: i16>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i16() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8 !1;
+            c_v2 = builtin.constant <builtin.integer <5: i16>> : builtin.integer i16 !2;
+            c_v1 = llvm.zext <nneg=false> a_v0 to builtin.integer i16 !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1111,9 +1436,19 @@ fn zext_folds_high_bit_set_constant() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<255: i16>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i16() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <255: i8>> : builtin.integer i8 !1;
+            c_v2 = builtin.constant <builtin.integer <255: i16>> : builtin.integer i16 !2;
+            c_v1 = llvm.zext <nneg=false> a_v0 to builtin.integer i16 !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1129,7 +1464,7 @@ fn zext_nneg_does_not_fold_negative_constant() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1145,9 +1480,19 @@ fn zext_nneg_folds_non_negative_constant() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<5: i16>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i16() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <5: i8>> : builtin.integer i8 !1;
+            c_v2 = builtin.constant <builtin.integer <5: i16>> : builtin.integer i16 !2;
+            c_v1 = llvm.zext <nneg=true> a_v0 to builtin.integer i16 !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1160,7 +1505,7 @@ fn zext_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1179,9 +1524,19 @@ fn fneg_folds_constant() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("-2.5"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 2.5> : builtin.fp32  !1;
+            c_v2 = builtin.constant <builtin.single -2.5> : builtin.fp32  !2;
+            c_v1 = llvm.fneg <> a_v0 : builtin.fp32  !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1195,10 +1550,20 @@ fn fneg_folds_negative_zero() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The result is positive zero; it must not still be -0.0.
-    assert!(after.contains("<builtin.single 0> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single -0> : builtin.fp32  !1;
+            c_v2 = builtin.constant <builtin.single 0> : builtin.fp32  !2;
+            c_v1 = llvm.fneg <> a_v0 : builtin.fp32  !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1211,7 +1576,7 @@ fn fneg_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1226,14 +1591,19 @@ fn fneg_folds_positive_infinity() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after
-            .matches("<builtin.single -Inf> : builtin.fp32")
-            .count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single +Inf> : builtin.fp32  !1;
+            c_v2 = builtin.constant <builtin.single -Inf> : builtin.fp32  !2;
+            c_v1 = llvm.fneg <> a_v0 : builtin.fp32  !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1247,14 +1617,19 @@ fn fneg_folds_negative_infinity() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after
-            .matches("<builtin.single +Inf> : builtin.fp32")
-            .count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single -Inf> : builtin.fp32  !1;
+            c_v2 = builtin.constant <builtin.single +Inf> : builtin.fp32  !2;
+            c_v1 = llvm.fneg <> a_v0 : builtin.fp32  !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1268,12 +1643,19 @@ fn fneg_folds_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single NaN> : builtin.fp32  !1;
+            c_v2 = builtin.constant <builtin.single NaN> : builtin.fp32  !2;
+            c_v1 = llvm.fneg <> a_v0 : builtin.fp32  !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1287,7 +1669,7 @@ fn fneg_nnan_does_not_fold_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1302,7 +1684,7 @@ fn fneg_ninf_does_not_fold_infinity() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1317,9 +1699,19 @@ fn fneg_nnan_still_folds_finite() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("-2.5"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 2.5> : builtin.fp32  !1;
+            c_v2 = builtin.constant <builtin.single -2.5> : builtin.fp32  !2;
+            c_v1 = llvm.fneg <NNAN> a_v0 : builtin.fp32  !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1338,9 +1730,20 @@ fn fadd_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 6.5> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 2.5> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 6.5> : builtin.fp32  !3;
+            c_v2 = llvm.fadd <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1354,7 +1757,7 @@ fn fadd_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1370,14 +1773,20 @@ fn fadd_folds_infinity_and_finite() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after
-            .matches("<builtin.single +Inf> : builtin.fp32")
-            .count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single +Inf> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 1> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single +Inf> : builtin.fp32  !3;
+            c_v2 = llvm.fadd <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1392,12 +1801,20 @@ fn fadd_folds_opposite_infinities_to_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single +Inf> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single -Inf> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fadd <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1412,12 +1829,20 @@ fn fadd_folds_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single NaN> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 1> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fadd <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1432,7 +1857,7 @@ fn fadd_ninf_does_not_fold_infinity() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1448,7 +1873,7 @@ fn fadd_nnan_does_not_fold_nan_result() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1464,9 +1889,20 @@ fn fadd_nnan_still_folds_finite() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 6.5> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 2.5> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 6.5> : builtin.fp32  !3;
+            c_v2 = llvm.fadd <NNAN> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1485,9 +1921,20 @@ fn fsub_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 7.5> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 10> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 2.5> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 7.5> : builtin.fp32  !3;
+            c_v2 = llvm.fsub <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1501,7 +1948,7 @@ fn fsub_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1517,14 +1964,20 @@ fn fsub_folds_finite_minus_infinity() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after
-            .matches("<builtin.single -Inf> : builtin.fp32")
-            .count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 1> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single +Inf> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single -Inf> : builtin.fp32  !3;
+            c_v2 = llvm.fsub <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1539,12 +1992,20 @@ fn fsub_folds_equal_infinities_to_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single +Inf> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single +Inf> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fsub <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1559,12 +2020,20 @@ fn fsub_folds_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single NaN> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 1> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fsub <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1579,7 +2048,7 @@ fn fsub_nnan_does_not_fold_nan_result() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1599,9 +2068,20 @@ fn fmul_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 10> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 2.5> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 10> : builtin.fp32  !3;
+            c_v2 = llvm.fmul <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1615,7 +2095,7 @@ fn fmul_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1631,9 +2111,20 @@ fn fmul_folds_negative_operands_to_positive() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 10> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single -2.5> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single -4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 10> : builtin.fp32  !3;
+            c_v2 = llvm.fmul <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1648,14 +2139,20 @@ fn fmul_folds_infinity_and_finite() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after
-            .matches("<builtin.single +Inf> : builtin.fp32")
-            .count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single +Inf> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 2> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single +Inf> : builtin.fp32  !3;
+            c_v2 = llvm.fmul <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1670,12 +2167,20 @@ fn fmul_folds_zero_times_infinity_to_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 0> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single +Inf> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fmul <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1690,12 +2195,20 @@ fn fmul_folds_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single NaN> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 2> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fmul <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1710,7 +2223,7 @@ fn fmul_ninf_does_not_fold_infinity() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1726,7 +2239,7 @@ fn fmul_nnan_does_not_fold_nan_result() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1742,9 +2255,20 @@ fn fmul_nnan_still_folds_finite() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 10> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 2.5> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 10> : builtin.fp32  !3;
+            c_v2 = llvm.fmul <NNAN> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1763,9 +2287,20 @@ fn fdiv_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 2.5> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 10> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 2.5> : builtin.fp32  !3;
+            c_v2 = llvm.fdiv <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1779,7 +2314,7 @@ fn fdiv_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1795,14 +2330,20 @@ fn fdiv_folds_finite_by_zero_to_infinity() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after
-            .matches("<builtin.single +Inf> : builtin.fp32")
-            .count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 1> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 0> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single +Inf> : builtin.fp32  !3;
+            c_v2 = llvm.fdiv <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1817,12 +2358,20 @@ fn fdiv_folds_zero_by_zero_to_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 0> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 0> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fdiv <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1837,12 +2386,20 @@ fn fdiv_folds_infinity_by_infinity_to_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single +Inf> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single +Inf> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fdiv <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1857,9 +2414,20 @@ fn fdiv_folds_finite_by_infinity_to_zero() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 0> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 1> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single +Inf> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 0> : builtin.fp32  !3;
+            c_v2 = llvm.fdiv <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1874,12 +2442,20 @@ fn fdiv_folds_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single NaN> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 2> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.fdiv <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1894,7 +2470,7 @@ fn fdiv_ninf_does_not_fold_division_by_zero() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1910,7 +2486,7 @@ fn fdiv_nnan_does_not_fold_nan_result() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1926,9 +2502,20 @@ fn fdiv_nnan_still_folds_finite() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 2.5> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 10> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 2.5> : builtin.fp32  !3;
+            c_v2 = llvm.fdiv <NNAN> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1947,9 +2534,20 @@ fn frem_folds_two_constants() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 2> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 10> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 2> : builtin.fp32  !3;
+            c_v2 = llvm.frem <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1963,7 +2561,7 @@ fn frem_does_not_fold_with_non_constant_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -1981,9 +2579,20 @@ fn frem_result_takes_sign_of_dividend() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single -2> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single -10> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single -2> : builtin.fp32  !3;
+            c_v2 = llvm.frem <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -1999,9 +2608,20 @@ fn frem_truncates_rather_than_rounding_to_nearest() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 1> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 3> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 2> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 1> : builtin.fp32  !3;
+            c_v2 = llvm.frem <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -2016,12 +2636,20 @@ fn frem_folds_by_zero_to_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 1> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 0> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.frem <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -2036,12 +2664,20 @@ fn frem_folds_infinity_dividend_to_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        1
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single +Inf> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 2> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.frem <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -2057,12 +2693,20 @@ fn frem_folds_infinity_divisor_to_dividend() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single 2.5> : builtin.fp32").count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 2.5> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single +Inf> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 2.5> : builtin.fp32  !3;
+            c_v2 = llvm.frem <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -2077,12 +2721,20 @@ fn frem_folds_nan() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(
-        after.matches("<builtin.single NaN> : builtin.fp32").count(),
-        2
-    );
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single NaN> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 2> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single NaN> : builtin.fp32  !3;
+            c_v2 = llvm.frem <> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -2097,7 +2749,7 @@ fn frem_nnan_does_not_fold_nan_result() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -2113,7 +2765,7 @@ fn frem_ninf_does_not_fold_infinite_operand() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, _after) = run_sccp_on_text(input)?;
+    let (status, _after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
     Ok(())
 }
@@ -2129,8 +2781,19 @@ fn frem_nnan_still_folds_finite() -> Result<()> {
         llvm.return c
       }
     "#;
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<builtin.single 2> : builtin.fp32"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.fp32 () variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.single 10> : builtin.fp32  !1;
+            b_v1 = builtin.constant <builtin.single 4> : builtin.fp32  !2;
+            c_v3 = builtin.constant <builtin.single 2> : builtin.fp32  !3;
+            c_v2 = llvm.frem <NNAN> a_v0, b_v1 : builtin.fp32  !4;
+            llvm.return c_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,7 @@
 //! [Context] and [Ptr] together provide memory management for `pliron`.
 
 use core::{
-    any::{Any, TypeId},
+    any::Any,
     cell::{Cell, Ref, RefCell, RefMut},
     fmt::Display,
     hash::Hash,
@@ -269,7 +269,6 @@ impl<T: ArenaObj> Eq for Ptr<T> {}
 
 impl<T: ArenaObj + 'static> Hash for Ptr<T> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        TypeId::of::<T>().hash(state);
         self.idx.hash(state);
     }
 }

--- a/tests/opts/dce.rs
+++ b/tests/opts/dce.rs
@@ -3,6 +3,7 @@
 
 //! DCE integration tests using textual LLVM dialect IR parsing.
 
+use expect_test::expect;
 use pliron::{
     basic_block::BasicBlock,
     context::{Context, Ptr},
@@ -13,7 +14,6 @@ use pliron::{
     operation::{Operation, verify_operation},
     opts::dce::{BlockArgRemoval, dce},
     parsable::parse_from_str,
-    printable::Printable,
     result::{ExpectOk, Result},
 };
 
@@ -85,21 +85,19 @@ impl SideEffects for MultiUseSinkOp {
     }
 }
 
-fn run_dce_on_text(input: &str) -> Result<(IRStatus, String, String)> {
+fn run_dce_on_text(input: &str) -> Result<(IRStatus, String)> {
     init_env_logger_for_tests!();
     let ctx = &mut Context::new();
     let op = parse_from_str(spaced(Operation::top_level_parser()), ctx, input).expect_ok(ctx);
 
-    let before = op.disp(ctx).to_string();
-    log::trace!("Before DCE:\n{}", before);
     verify_operation(op, ctx)?;
 
     let status = dce(op, ctx)?;
 
-    let after = op.disp(ctx).to_string();
+    let after = Operation::get_op_dyn(op, ctx).disp(ctx).to_string();
     log::trace!("After DCE:\n{}", after);
     verify_operation(op, ctx)?;
-    Ok((status, before, after))
+    Ok((status, after))
 }
 
 #[test]
@@ -113,10 +111,17 @@ fn dce_removes_dead_llvm_constant() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("<0: si64>"));
-    assert!(after.contains("<7: si64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            live_v0 = builtin.constant <builtin.integer <7: si64>> : builtin.integer si64 !1;
+            llvm.return live_v0 !2
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -130,9 +135,17 @@ fn dce_keeps_live_llvm_constant() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("<9: si64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            live_v0 = builtin.constant <builtin.integer <9: si64>> : builtin.integer si64 !1;
+            llvm.return live_v0 !2
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -146,9 +159,17 @@ fn dce_does_not_remove_unused_entry_block_arg_in_llvm_func() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("(arg0"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64(builtin.integer si64) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(arg0_v0: builtin.integer si64) !0:
+            c_v1 = builtin.constant <builtin.integer <5: si64>> : builtin.integer si64 !1;
+            llvm.return c_v1 !2
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -166,10 +187,20 @@ fn dce_removes_dead_non_entry_block_arg_and_br_operand() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("(arg0"));
-    assert!(!after.contains("<1: si64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            llvm.br ^bb1_block3v1() !1
+
+          ^bb1_block3v1() !2:
+            c_v2 = builtin.constant <builtin.integer <7: si64>> : builtin.integer si64 !3;
+            llvm.return c_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -186,9 +217,20 @@ fn dce_keeps_used_non_entry_block_arg() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("(arg0"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            x_v0 = builtin.constant <builtin.integer <1: si64>> : builtin.integer si64 !1;
+            llvm.br ^bb1_block3v1(x_v0) !2
+
+          ^bb1_block3v1(arg0_v1: builtin.integer si64) !3:
+            llvm.return arg0_v1 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -208,14 +250,23 @@ fn dce_dead_arg_cascades_to_successor_operands() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // Live constant should remain
-    assert!(after.contains("<42: si64>"));
     // Dead constant should be eliminated
-    assert!(!after.contains("<1: si64>"));
     // Dead block argument should be removed
-    assert!(!after.contains("dead_arg"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            live_val_v1 = builtin.constant <builtin.integer <42: si64>> : builtin.integer si64 !1;
+            llvm.br ^merge_block3v1(live_val_v1) !2
+
+          ^merge_block3v1(live_arg_v3: builtin.integer si64) !3:
+            llvm.return live_arg_v3 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -244,18 +295,30 @@ fn dce_multiple_preds_mixed_dead_live_operands() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Live constant should remain
-    assert!(after.contains("<10: si64>"));
-    assert!(after.contains("<20: si64>"));
-    // Dead constants should be eliminated
-    assert!(!after.contains("<1: si64>"));
-    assert!(!after.contains("<2: si64>"));
-    // Dead block argument should be removed
-    assert!(!after.contains("in_dead"));
-    assert!(!after.contains("left_dead"));
-    assert!(!after.contains("right_dead"));
+    // Live constants should remain.
+    // Dead constants should be eliminated.
+    // Dead block arguments should be removed.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            cond_v0 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !1;
+            live_left_v2 = builtin.constant <builtin.integer <10: si64>> : builtin.integer si64 !2;
+            live_right_v4 = builtin.constant <builtin.integer <20: si64>> : builtin.integer si64 !3;
+            llvm.cond_br if cond_v0 ^left_block4v1(live_left_v2) else ^right_block5v1(live_right_v4) !4
+
+          ^left_block4v1(left_live_v6: builtin.integer si64) !5:
+            llvm.br ^merge_block3v3(left_live_v6) !6
+
+          ^right_block5v1(right_live_v8: builtin.integer si64) !7:
+            llvm.br ^merge_block3v3(right_live_v8) !8
+
+          ^merge_block3v3(in_live_v10: builtin.integer si64) !9:
+            llvm.return in_live_v10 !10
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -276,15 +339,23 @@ fn dce_all_successor_operands_dead() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Both dead constants should be eliminated
-    assert!(!after.contains("<7: si64>"));
-    assert!(!after.contains("<8: si64>"));
-    // Live constant should remain
-    assert!(after.contains("<99: si64>"));
-    // Exit block should have no arguments
-    assert!(after.contains("^exit():") || !after.contains("unused1"));
+    // Both dead constants should be eliminated.
+    // The live constant should remain.
+    // The exit block should have no arguments.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            live_v2 = builtin.constant <builtin.integer <99: si64>> : builtin.integer si64 !1;
+            llvm.br ^exit_block3v1() !2
+
+          ^exit_block3v1() !3:
+            llvm.return live_v2 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -306,18 +377,23 @@ fn dce_chain_of_dead_computations() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Live constant should remain
-    assert!(after.contains("<99: si64>"));
-    // All dead constants should be eliminated
-    assert!(!after.contains("<1: si64>"));
-    assert!(!after.contains("<2: si64>"));
-    assert!(!after.contains("<3: si64>"));
-    // Exit block should have no arguments (check that unused args were removed)
-    assert!(!after.contains("unused1"));
-    assert!(!after.contains("unused2"));
-    assert!(!after.contains("unused3"));
+    // The live constant should remain.
+    // All dead constants should be eliminated.
+    // The exit block should have no arguments (unused args should be removed).
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            live_v3 = builtin.constant <builtin.integer <99: si64>> : builtin.integer si64 !1;
+            llvm.br ^exit_block3v1() !2
+
+          ^exit_block3v1() !3:
+            llvm.return live_v3 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -358,37 +434,28 @@ fn dce_region_containing_dead_op_safely_ignores_inner_dead_code() -> Result<()> 
     let func_op = parse_from_str(spaced(Operation::top_level_parser()), ctx, input).expect_ok(ctx);
 
     verify_operation(func_op, ctx)?;
-    let _before = func_op.disp(ctx).to_string();
 
-    // Run DCE - should:
-    // 1. Mark inner_dead1, inner_dead2 as dead
-    // 2. Mark region_dead1, region_dead2 as dead
-    // 3. Mark test.pure_region as dead (no uses, no side effects)
-    // 4. Eliminate all safely without panicking on inner dead ops
     let status = dce(func_op, ctx)?;
-    assert!(status == IRStatus::Changed);
+    assert_eq!(status, IRStatus::Changed);
+
+    //
+    // The main point of this test is that we get here without panicking, which means
+    // DCE safely handled the pure_region op elimination and its inner dead code.
 
     verify_operation(func_op, ctx)?;
-    let after = func_op.disp(ctx).to_string();
-
-    // The pure_region op should be eliminated
-    assert!(!after.contains("test.pure_region"));
-
-    // All dead constants should be eliminated (both outer and inner)
-    assert!(!after.contains("<10: i64>"));
-    assert!(!after.contains("<20: i64>"));
-    assert!(!after.contains("<100: i64>"));
-    assert!(!after.contains("<200: i64>"));
-    assert!(!after.contains("arg0"));
-
-    // Live constant should remain
-    assert!(after.contains("<99: i64>"));
-
-    // Function should still be valid
-    assert!(after.contains("@test"));
-
-    // The main point: we got here without panicking, which means
-    // DCE safely handled the pure_region op elimination and its inner dead code
+    let after = Operation::get_op_dyn(func_op, ctx).disp(ctx).to_string();
+    // The pure_region op should be eliminated.
+    // All dead constants should be eliminated (both outer and inner).
+    // The live constant should remain, and the function should still be valid.
+    expect![[r#"
+        llvm.func @test: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            live_v7 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !1;
+            llvm.return live_v7 !2
+        }"#]]
+    .assert_eq(&after);
 
     Ok(())
 }
@@ -408,17 +475,19 @@ fn dce_eliminates_multi_result_op_after_same_op_and_successor_uses_die() -> Resu
     }
   "#;
 
-    let (status, before, after) = run_dce_on_text(input)?;
+    let (status, after) = run_dce_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer si64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            llvm.br ^exit_block3v1() !1
 
-    assert!(before.contains("test.multi_result_def"));
-    assert!(before.contains("test.multi_use_sink"));
-
-    assert!(!after.contains("test.multi_result_def"));
-    assert!(!after.contains("test.multi_use_sink"));
-    assert!(!after.contains("(arg0"));
-    assert!(!after.contains("arg1"));
-    assert!(after.contains("<99: si64>"));
-
+          ^exit_block3v1() !2:
+            live_v4 = builtin.constant <builtin.integer <99: si64>> : builtin.integer si64 !3;
+            llvm.return live_v4 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }

--- a/tests/opts/mem2reg.rs
+++ b/tests/opts/mem2reg.rs
@@ -1012,20 +1012,20 @@ fn mem2reg_alloca_inside_loop_body() -> Result<()> {
             v13 = llvm.poison : builtin.integer i64;
             llvm.br ^header_block3v1(zero_v3, v13) !4
 
-          ^header_block3v1(i_v5: builtin.integer i64, alloc_v11: builtin.integer i64) !5:
+          ^header_block3v1(i_v5: builtin.integer i64, alloc_v12: builtin.integer i64) !5:
             continue_loop_v6 = llvm.icmp i_v5 <ULT> n_v0 : builtin.integer i1 !6;
             llvm.cond_br if continue_loop_v6 ^body_block5v1() else ^exit_block6v3() !7
 
           ^body_block5v1() !8:
-            llvm.cond_br if cond_v1 ^then_block7v1() else ^merge_block2v7(alloc_v11) !9
+            llvm.cond_br if cond_v1 ^then_block7v1() else ^merge_block2v7(alloc_v12) !9
 
           ^then_block7v1() !10:
             v_v8 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !11;
             llvm.br ^merge_block2v7(v_v8) !12
 
-          ^merge_block2v7(alloc_v12: builtin.integer i64) !13:
+          ^merge_block2v7(alloc_v11: builtin.integer i64) !13:
             next_i_v10 = llvm.add i_v5, one_v4 <{nsw=false,nuw=false}>: builtin.integer i64 !14;
-            llvm.br ^header_block3v1(next_i_v10, alloc_v12) !15
+            llvm.br ^header_block3v1(next_i_v10, alloc_v11) !15
 
           ^exit_block6v3() !16:
             llvm.return zero_v3 !17

--- a/tests/opts/mem2reg.rs
+++ b/tests/opts/mem2reg.rs
@@ -3,6 +3,7 @@
 
 //! Tests for the `mem2reg` optimization pass.
 
+use expect_test::expect;
 use pliron::{
     builtin::op_interfaces::{IsTerminatorInterface, NOpdsInterface, NResultsInterface},
     context::Context,
@@ -14,7 +15,6 @@ use pliron::{
     opts::mem2reg::{AllocInfo, PromotableOpInterface, PromotableOpKind, mem2reg},
     parsable::parse_from_str,
     pass::AnalysisManager,
-    printable::Printable,
     result::{ExpectOk, Result},
 };
 
@@ -69,22 +69,20 @@ impl PromotableOpInterface for NonPromotableUseOp {
     }
 }
 
-fn run_mem2reg(input: &str) -> Result<(IRStatus, String, String)> {
+fn run_mem2reg(input: &str) -> Result<(IRStatus, String)> {
     init_env_logger_for_tests!();
     let ctx = &mut Context::new();
     let op = parse_from_str(spaced(Operation::top_level_parser()), ctx, input).expect_ok(ctx);
 
-    let before = op.disp(ctx).to_string();
-    log::trace!("Before mem2reg:\n{}", before);
     verify_operation(op, ctx)?;
 
     let mut analyses = AnalysisManager::default();
     let status = mem2reg(op, ctx, &mut analyses)?;
 
-    let after = op.disp(ctx).to_string();
+    let after = Operation::get_op_dyn(op, ctx).disp(ctx).to_string();
     log::trace!("After mem2reg:\n{}", after);
     verify_operation(op, ctx)?;
-    Ok((status, before, after))
+    Ok((status, after))
 }
 
 #[test]
@@ -103,14 +101,21 @@ fn mem2reg_basic_store_and_load() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Alloca should be removed
-    assert!(!after.contains("llvm.alloca"));
-    // Store should be removed
-    assert!(!after.contains("llvm.store"));
-    // Load should be removed (replaced with constant)
-    assert!(!after.contains("llvm.load"));
+    // Alloca should be removed.
+    // Store should be removed.
+    // Load should be removed (replaced with the constant).
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            stored_val_v2 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !2;
+            llvm.return stored_val_v2 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -132,13 +137,21 @@ fn mem2reg_multiple_stores_one_load() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Should contain the final stored value
-    assert!(after.contains("<42: i64>"));
-    // Alloca and stores removed
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
+    // Should contain the final stored value.
+    // Alloca and stores removed.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            val1_v2 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !2;
+            val2_v3 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !3;
+            llvm.return val2_v3 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -156,14 +169,21 @@ fn mem2reg_no_store_uses_default() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Alloca removed
-    assert!(!after.contains("llvm.alloca"));
-    // Load removed
-    assert!(!after.contains("llvm.load"));
-    // Should have poison operation
-    assert!(after.contains("llvm.poison"));
+    // Alloca removed.
+    // Load removed.
+    // Should have a poison operation.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            loaded_v3 = llvm.poison : builtin.integer i64 !2;
+            llvm.return loaded_v3 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -183,11 +203,20 @@ fn mem2reg_no_load_dead_allocation() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Alloca and store should be removed
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
+    // Alloca and store should be removed.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            val_v2 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !2;
+            dead_val_v3 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64 !3;
+            llvm.return dead_val_v3 !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -218,16 +247,32 @@ fn mem2reg_phi_with_conditional_branch() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Alloca removed
-    assert!(!after.contains("llvm.alloca"));
-    // Stores removed (phis created instead)
-    assert!(!after.contains("llvm.store"));
-    // Load removed
-    assert!(!after.contains("llvm.load"));
+    // Alloca removed.
+    // Stores removed (phis created instead).
+    // Load removed.
     // Merge still exists and branch forwarding got materialized via successor operands.
-    assert!(after.contains("llvm.br ^") && after.contains("llvm.return"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            size_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            llvm.cond_br if cond_v0 ^then_block4v1() else ^else_block5v1() !2
+
+          ^then_block4v1() !3:
+            val_then_v3 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !4;
+            llvm.br ^merge_block3v3(val_then_v3) !5
+
+          ^else_block5v1() !6:
+            val_else_v4 = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64 !7;
+            llvm.br ^merge_block3v3(val_else_v4) !8
+
+          ^merge_block3v3(alloc_v6: builtin.integer i64) !9:
+            llvm.return alloc_v6 !10
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -252,16 +297,24 @@ fn mem2reg_multiple_allocations() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    // Both allocas removed
-    assert!(!after.contains("llvm.alloca"));
-    // All stores removed
-    assert!(!after.contains("llvm.store"));
-    // Both loads removed
-    assert!(!after.contains("llvm.load"));
-    // Add operation should work with the promoted values
-    assert!(after.contains("llvm.add"));
+    // Both allocas removed.
+    // All stores removed.
+    // Both loads removed.
+    // The add operation should work with the promoted values.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            val1_v3 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64 !2;
+            val2_v4 = builtin.constant <builtin.integer <20: i64>> : builtin.integer i64 !3;
+            result_v7 = llvm.add val1_v3, val2_v4 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return result_v7 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -281,11 +334,18 @@ fn mem2reg_linear_chain_of_stores_and_loads() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
-    assert!(!after.contains("llvm.load"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            val1_v2 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !2;
+            llvm.return val1_v2 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -317,11 +377,29 @@ fn mem2reg_diamond_pattern() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
-    assert!(!after.contains("llvm.load"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            size_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            init_val_v3 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64 !2;
+            llvm.cond_br if cond_v0 ^then_block4v1() else ^else_block5v1() !3
+
+          ^then_block4v1() !4:
+            then_val_v4 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64 !5;
+            llvm.br ^merge_block3v3(then_val_v4) !6
+
+          ^else_block5v1() !7:
+            else_val_v5 = builtin.constant <builtin.integer <20: i64>> : builtin.integer i64 !8;
+            llvm.br ^merge_block3v3(else_val_v5) !9
+
+          ^merge_block3v3(alloc_v7: builtin.integer i64) !10:
+            llvm.return alloc_v7 !11
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -363,11 +441,36 @@ fn mem2reg_nested_branches() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
-    assert!(!after.contains("llvm.load"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1, builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond1_v0: builtin.integer i1, cond2_v1: builtin.integer i1) !0:
+            size_v2 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            val0_v4 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64 !2;
+            llvm.cond_br if cond1_v0 ^if1_then_block4v1() else ^if1_else_block5v3() !3
+
+          ^if1_then_block4v1() !4:
+            val1_v5 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !5;
+            llvm.cond_br if cond2_v1 ^if2_then_block6v1() else ^if2_else_block7v1() !6
+
+          ^if2_then_block6v1() !7:
+            val2_v6 = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64 !8;
+            llvm.br ^merge_block3v3(val2_v6) !9
+
+          ^if2_else_block7v1() !10:
+            val3_v7 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !11;
+            llvm.br ^merge_block3v3(val3_v7) !12
+
+          ^if1_else_block5v3() !13:
+            val4_v8 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !14;
+            llvm.br ^merge_block3v3(val4_v8) !15
+
+          ^merge_block3v3(alloc_v10: builtin.integer i64) !16:
+            llvm.return alloc_v10 !17
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -399,9 +502,30 @@ fn mem2reg_unused_block_arguments() -> Result<()> {
     }
   "#;
 
-    let (_status, _before, _after) = run_mem2reg(input)?;
-    // Should be changed (stores are dead, can be eliminated)
-    // The exact behavior may vary, but alloca should be gone
+    let (status, after) = run_mem2reg(input)?;
+    // Stores are dead once promoted, so they should be eliminated along with the alloca.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            size_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            val_then_v3 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !2;
+            val_else_v4 = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64 !3;
+            llvm.cond_br if cond_v0 ^then_block4v1() else ^else_block5v1() !4
+
+          ^then_block4v1() !5:
+            llvm.br ^merge_block3v3(val_then_v3) !6
+
+          ^else_block5v1() !7:
+            llvm.br ^merge_block3v3(val_else_v4) !8
+
+          ^merge_block3v3(alloc_v7: builtin.integer i64) !9:
+            ret_val_v6 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !10;
+            llvm.return ret_val_v6 !11
+        }"#]]
+    .assert_eq(&after);
+    assert_eq!(status, IRStatus::Changed);
     Ok(())
 }
 
@@ -443,10 +567,36 @@ fn mem2reg_multiple_paths_convergence() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1, builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond1_v0: builtin.integer i1, cond2_v1: builtin.integer i1) !0:
+            size_v2 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            v0_v4 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64 !2;
+            llvm.cond_br if cond1_v0 ^path1_block4v1() else ^path2_block5v3() !3
+
+          ^path1_block4v1() !4:
+            v1_v5 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !5;
+            llvm.cond_br if cond2_v1 ^path1a_block6v1() else ^path1b_block7v1() !6
+
+          ^path1a_block6v1() !7:
+            v1a_v6 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64 !8;
+            llvm.br ^merge_block3v3(v1a_v6) !9
+
+          ^path1b_block7v1() !10:
+            v1b_v7 = builtin.constant <builtin.integer <11: i64>> : builtin.integer i64 !11;
+            llvm.br ^merge_block3v3(v1b_v7) !12
+
+          ^path2_block5v3() !13:
+            v2_v8 = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64 !14;
+            llvm.br ^merge_block3v3(v2_v8) !15
+
+          ^merge_block3v3(alloc_v10: builtin.integer i64) !16:
+            llvm.return alloc_v10 !17
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -467,13 +617,20 @@ fn mem2reg_load_before_any_store() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
-    assert!(!after.contains("llvm.load"));
-    // Should have poison for uninitialized load
-    assert!(after.contains("llvm.poison"));
+    // Should have poison for the uninitialized load.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            first_load_v6 = llvm.poison : builtin.integer i64 !2;
+            store_val_v3 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !3;
+            result_v5 = llvm.add first_load_v6, store_val_v3 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return result_v5 !5
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -508,9 +665,29 @@ fn mem2reg_complex_liveness() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            size_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            init_v3 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64 !2;
+            llvm.cond_br if cond_v0 ^then_block4v1() else ^else_block5v1() !3
+
+          ^then_block4v1() !4:
+            val_then_v5 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64 !5;
+            llvm.br ^merge_block3v3(val_then_v5) !6
+
+          ^else_block5v1() !7:
+            val_else_v6 = builtin.constant <builtin.integer <20: i64>> : builtin.integer i64 !8;
+            llvm.br ^merge_block3v3(val_else_v6) !9
+
+          ^merge_block3v3(alloc_v10: builtin.integer i64) !10:
+            result_v9 = llvm.add alloc_v10, alloc_v10 <{nsw=false,nuw=false}>: builtin.integer i64 !11;
+            llvm.return result_v9 !12
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -532,11 +709,24 @@ fn mem2reg_no_promotion_when_alloca_address_escapes() -> Result<()> {
     }
   "#;
 
-    let (_status, _before, after) = run_mem2reg(input)?;
-    // The allocation should not be promoted because its address is used
-    // However, some loads/stores might still be promotable depending on implementation
-    // This test documents the expected behavior
-    assert!(after.contains("llvm.alloca"));
+    // The allocation should not be promoted because its address is used.
+    // However, some loads/stores might still be promotable depending on implementation.
+    // This test documents the expected behavior.
+    let (_status, after) = run_mem2reg(input)?;
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            alloc_v1 = llvm.alloca [builtin.integer i64 x size_v0]  : llvm.ptr (0) !2;
+            val_v2 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !3;
+            llvm.store *alloc_v1 <- val_v2  !4;
+            loaded_v3 = llvm.load alloc_v1  : builtin.integer i64 !5;
+            casted_v4 = llvm.ptrtoint alloc_v1 to builtin.integer i64 !6;
+            result_v5 = llvm.add loaded_v3, casted_v4 <{nsw=false,nuw=false}>: builtin.integer i64 !7;
+            llvm.return result_v5 !8
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -568,9 +758,28 @@ fn mem2reg_repeated_forward_edges() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1, builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond1_v0: builtin.integer i1, cond2_v1: builtin.integer i1) !0:
+            size_v2 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            v0_v4 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64 !2;
+            llvm.cond_br if cond1_v0 ^block_a_block4v1() else ^block_b_block5v1() !3
+
+          ^block_a_block4v1() !4:
+            v_a_v5 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !5;
+            llvm.cond_br if cond2_v1 ^merge_block3v3(v_a_v5) else ^merge_block3v3(v_a_v5) !6
+
+          ^block_b_block5v1() !7:
+            v_b_v6 = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64 !8;
+            llvm.br ^merge_block3v3(v_b_v6) !9
+
+          ^merge_block3v3(alloc_v8: builtin.integer i64) !10:
+            llvm.return alloc_v8 !11
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -593,10 +802,26 @@ fn mem2reg_not_promoted_when_load_is_in_nested_region() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("llvm.alloca"));
-    assert!(after.contains("llvm.load alloc"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            alloc_v1 = llvm.alloca [builtin.integer i64 x size_v0]  : llvm.ptr (0) !2;
+            v_v2 = builtin.constant <builtin.integer <9: i64>> : builtin.integer i64 !3;
+            llvm.store *alloc_v1 <- v_v2  !4;
+            test.region_carrier 
+            {
+              ^nested_block2v1() !5:
+                inner_v3 = llvm.load alloc_v1  : builtin.integer i64 !6;
+                test.region_term term !7
+            } !8;
+            llvm.return v_v2 !9
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -619,11 +844,26 @@ fn mem2reg_not_promoted_when_store_is_in_nested_region() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("llvm.alloca"));
-    assert!(after.contains("llvm.store *alloc"));
-    assert!(after.contains("llvm.load alloc"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            alloc_v1 = llvm.alloca [builtin.integer i64 x size_v0]  : llvm.ptr (0) !2;
+            v_v2 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !3;
+            test.region_carrier 
+            {
+              ^nested_block2v1() !4:
+                llvm.store *alloc_v1 <- v_v2  !5;
+                test.region_term term !6
+            } !7;
+            out_v3 = llvm.load alloc_v1  : builtin.integer i64 !8;
+            llvm.return out_v3 !9
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -643,10 +883,22 @@ fn mem2reg_not_promoted_for_interface_declared_non_promotable_use() -> Result<()
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("llvm.alloca"));
-    assert!(after.contains("test.non_promotable_use"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            size_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            alloc_v1 = llvm.alloca [builtin.integer i64 x size_v0]  : llvm.ptr (0) !2;
+            v_v2 = builtin.constant <builtin.integer <13: i64>> : builtin.integer i64 !3;
+            llvm.store *alloc_v1 <- v_v2  !4;
+            test.non_promotable_use alloc_v1 !5;
+            out_v3 = llvm.load alloc_v1  : builtin.integer i64 !6;
+            llvm.return out_v3 !7
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -678,11 +930,32 @@ fn mem2reg_not_promoted_when_phi_pred_has_non_branch_successor_terminator() -> R
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("llvm.alloca"));
-    assert!(after.contains("llvm.load alloc"));
-    assert!(after.contains("test.non_branch_succ_term"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            size_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            alloc_v2 = llvm.alloca [builtin.integer i64 x size_v1]  : llvm.ptr (0) !2;
+            llvm.cond_br if cond_v0 ^left_block4v1() else ^right_block5v1() !3
+
+          ^left_block4v1() !4:
+            lv_v3 = builtin.constant <builtin.integer <11: i64>> : builtin.integer i64 !5;
+            llvm.store *alloc_v2 <- lv_v3  !6;
+            llvm.br ^merge_block3v3() !7
+
+          ^right_block5v1() !8:
+            rv_v4 = builtin.constant <builtin.integer <22: i64>> : builtin.integer i64 !9;
+            llvm.store *alloc_v2 <- rv_v4  !10;
+            test.non_branch_succ_term ^merge_block3v3() !11
+
+          ^merge_block3v3() !12:
+            out_v5 = llvm.load alloc_v2  : builtin.integer i64 !13;
+            llvm.return out_v5 !14
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -725,12 +998,37 @@ fn mem2reg_alloca_inside_loop_body() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_mem2reg(input)?;
+    let (status, after) = run_mem2reg(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(!after.contains("llvm.alloca"));
-    assert!(!after.contains("llvm.store"));
-    assert!(!after.contains("llvm.load"));
     // The uninitialized path through ^body needs a default value.
-    assert!(after.contains("llvm.poison"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i64, builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(n_v0: builtin.integer i64, cond_v1: builtin.integer i1) !0:
+            size_v2 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            zero_v3 = builtin.constant <builtin.integer <0: i64>> : builtin.integer i64 !2;
+            one_v4 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !3;
+            v13 = llvm.poison : builtin.integer i64;
+            llvm.br ^header_block3v1(zero_v3, v13) !4
+
+          ^header_block3v1(i_v5: builtin.integer i64, alloc_v11: builtin.integer i64) !5:
+            continue_loop_v6 = llvm.icmp i_v5 <ULT> n_v0 : builtin.integer i1 !6;
+            llvm.cond_br if continue_loop_v6 ^body_block5v1() else ^exit_block6v3() !7
+
+          ^body_block5v1() !8:
+            llvm.cond_br if cond_v1 ^then_block7v1() else ^merge_block2v7(alloc_v11) !9
+
+          ^then_block7v1() !10:
+            v_v8 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !11;
+            llvm.br ^merge_block2v7(v_v8) !12
+
+          ^merge_block2v7(alloc_v12: builtin.integer i64) !13:
+            next_i_v10 = llvm.add i_v5, one_v4 <{nsw=false,nuw=false}>: builtin.integer i64 !14;
+            llvm.br ^header_block3v1(next_i_v10, alloc_v12) !15
+
+          ^exit_block6v3() !16:
+            llvm.return zero_v3 !17
+        }"#]].assert_eq(&after);
     Ok(())
 }

--- a/tests/opts/sccp.rs
+++ b/tests/opts/sccp.rs
@@ -3,6 +3,7 @@
 
 //! SCCP integration tests using textual LLVM dialect IR parsing.
 
+use expect_test::expect;
 use pliron::{
     context::Context,
     init_env_logger_for_tests,
@@ -11,7 +12,6 @@ use pliron::{
     operation::{Operation, verify_operation},
     opts::constants::sccp::sccp,
     parsable::parse_from_str,
-    printable::Printable,
     result::{ExpectOk, Result},
 };
 
@@ -38,21 +38,19 @@ pub struct TestRegionOp;
 )]
 pub struct TestTwoRegionsOp;
 
-fn run_sccp_on_text(input: &str) -> Result<(IRStatus, String, String)> {
+fn run_sccp_on_text(input: &str) -> Result<(IRStatus, String)> {
     init_env_logger_for_tests!();
     let ctx = &mut Context::new();
     let op = parse_from_str(spaced(Operation::top_level_parser()), ctx, input).expect_ok(ctx);
 
-    let before = op.disp(ctx).to_string();
-    log::trace!("Before SCCP:\n{}", before);
     verify_operation(op, ctx)?;
 
     let status = sccp(op, ctx)?;
 
-    let after = op.disp(ctx).to_string();
+    let after = Operation::get_op_dyn(op, ctx).disp(ctx).to_string();
     log::trace!("After SCCP:\n{}", after);
     verify_operation(op, ctx)?;
-    Ok((status, before, after))
+    Ok((status, after))
 }
 
 #[test]
@@ -67,9 +65,20 @@ fn sccp_folds_add_of_two_constants() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<7: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !1;
+            b_v1 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !2;
+            sum_v3 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !3;
+            sum_v2 = llvm.add a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return sum_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -94,9 +103,32 @@ fn sccp_is_path_sensitive() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
-    assert!(after.contains("<2: i64>"));
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i64) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(x_v0: builtin.integer i64) !0:
+            y_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            one_v2 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !2;
+            llvm.cond_br if one_v2 ^bb0_block4v1(x_v0, y_v1) else ^bb1_block5v1(x_v0, y_v1) !3
+
+          ^bb0_block4v1(x0_v3: builtin.integer i64, y0_v4: builtin.integer i64) !4:
+            y0_v11 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !5;
+            llvm.br ^bb2_block3v3(y0_v11, y0_v11) !6
+
+          ^bb1_block5v1(x1_v5: builtin.integer i64, y1_v6: builtin.integer i64) !7:
+            llvm.br ^bb2_block3v3(x1_v5, y1_v6) !8
+
+          ^bb2_block3v3(x2_v7: builtin.integer i64, y2_v8: builtin.integer i64) !9:
+            y2_v13 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !10;
+            x2_v12 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !11;
+            z_v10 = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64 !12;
+            z_v9 = llvm.add x2_v12, y2_v13 <{nsw=false,nuw=false}>: builtin.integer i64 !13;
+            llvm.return z_v10 !14
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -123,9 +155,35 @@ fn sccp_folded_condition_makes_branch_dead() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<2: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i64) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(x_v0: builtin.integer i64) !0:
+            y_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            zero_i1_v2 = builtin.constant <builtin.integer <0: i1>> : builtin.integer i1 !2;
+            one_i1_v3 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !3;
+            one_v12 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !4;
+            one_v4 = llvm.add zero_i1_v2, one_i1_v3 <{nsw=false,nuw=false}>: builtin.integer i1 !5;
+            llvm.cond_br if one_v12 ^bb0_block4v1(x_v0, y_v1) else ^bb1_block5v1(x_v0, y_v1) !6
+
+          ^bb0_block4v1(x0_v5: builtin.integer i64, y0_v6: builtin.integer i64) !7:
+            y0_v14 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !8;
+            llvm.br ^bb2_block3v3(y0_v14, y0_v14) !9
+
+          ^bb1_block5v1(x1_v7: builtin.integer i64, y1_v8: builtin.integer i64) !10:
+            llvm.br ^bb2_block3v3(x1_v7, y1_v8) !11
+
+          ^bb2_block3v3(x2_v9: builtin.integer i64, y2_v10: builtin.integer i64) !12:
+            y2_v16 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !13;
+            x2_v15 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !14;
+            z_v13 = builtin.constant <builtin.integer <2: i64>> : builtin.integer i64 !15;
+            z_v11 = llvm.add x2_v15, y2_v16 <{nsw=false,nuw=false}>: builtin.integer i64 !16;
+            llvm.return z_v13 !17
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -154,10 +212,33 @@ fn sccp_meets_distinct_constants_from_live_predecessors_as_not_a_constant() -> R
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<10: i64>"));
-    assert!(after.contains("llvm.add"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            llvm.cond_br if cond_v0 ^bb0_block4v1() else ^bb1_block5v1() !1
+
+          ^bb0_block4v1() !2:
+            a0_v1 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !3;
+            b0_v2 = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64 !4;
+            llvm.br ^bb2_block3v3(a0_v1, b0_v2) !5
+
+          ^bb1_block5v1() !6:
+            a1_v3 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !7;
+            b1_v4 = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64 !8;
+            llvm.br ^bb2_block3v3(a1_v3, b1_v4) !9
+
+          ^bb2_block3v3(x_v5: builtin.integer i64, y_v6: builtin.integer i64) !10:
+            y_v11 = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64 !11;
+            x_plus_y_v7 = llvm.add x_v5, y_v11 <{nsw=false,nuw=false}>: builtin.integer i64 !12;
+            y_plus_y_v10 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64 !13;
+            y_plus_y_v8 = llvm.add y_v11, y_v11 <{nsw=false,nuw=false}>: builtin.integer i64 !14;
+            result_v9 = llvm.add x_plus_y_v7, y_plus_y_v10 <{nsw=false,nuw=false}>: builtin.integer i64 !15;
+            llvm.return result_v9 !16
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -182,10 +263,31 @@ fn sccp_is_path_sensitive_2() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
-    assert!(after.contains("llvm.add"));
+    let (status, after) = run_sccp_on_text(input)?;
     // Materialized constants inserted into ^bb0, ^bb1, and ^bb2
     assert_eq!(status, IRStatus::Changed);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i64) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(x_v0: builtin.integer i64) !0:
+            y_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            one_v2 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !2;
+            llvm.cond_br if one_v2 ^bb1_block5v1(x_v0, y_v1) else ^bb0_block4v1(x_v0, y_v1) !3
+
+          ^bb0_block4v1(x0_v3: builtin.integer i64, y0_v4: builtin.integer i64) !4:
+            llvm.br ^bb2_block2v3(y0_v4, y0_v4) !5
+
+          ^bb1_block5v1(x1_v5: builtin.integer i64, y1_v6: builtin.integer i64) !6:
+            y1_v10 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !7;
+            llvm.br ^bb2_block2v3(x1_v5, y1_v10) !8
+
+          ^bb2_block2v3(x2_v7: builtin.integer i64, y2_v8: builtin.integer i64) !9:
+            y2_v11 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !10;
+            z_v9 = llvm.add x2_v7, y2_v11 <{nsw=false,nuw=false}>: builtin.integer i64 !11;
+            llvm.return z_v9 !12
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -204,9 +306,23 @@ fn sccp_does_not_fold_when_operands_are_nested_region_entry_args() -> Result<()>
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("llvm.add"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            test.test_region 
+            {
+              ^region_entry_block2v1(a_v0: builtin.integer i64, b_v1: builtin.integer i64) !1:
+                sum_v2 = llvm.add a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !2;
+                llvm.return sum_v2 !3
+            } !4;
+            done_v3 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !5;
+            llvm.return done_v3 !6
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -227,9 +343,25 @@ fn sccp_folds_inside_nested_region_using_outer_constant() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert!(after.contains("<7: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            outer_a_v0 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !1;
+            outer_b_v1 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !2;
+            test.test_region 
+            {
+              ^region_entry_block2v1() !3:
+                inner_sum_v4 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !4;
+                inner_sum_v2 = llvm.add outer_a_v0, outer_b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !5;
+                llvm.return inner_sum_v4 !6
+            } !7;
+            done_v3 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !8;
+            llvm.return done_v3 !9
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -256,11 +388,35 @@ fn sccp_folds_inside_two_nested_regions() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // Both inner adds should fold.
-    assert!(after.contains("<7: i64>"));
-    assert!(after.contains("<30: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            test.test_two_regions 
+            {
+              ^r0_entry_block2v1() !1:
+                a0_v0 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !2;
+                b0_v1 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !3;
+                sum0_v7 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !4;
+                sum0_v2 = llvm.add a0_v0, b0_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !5;
+                llvm.return sum0_v7 !6
+            } 
+            {
+              ^r1_entry_block3v1() !7:
+                a1_v3 = builtin.constant <builtin.integer <10: i64>> : builtin.integer i64 !8;
+                b1_v4 = builtin.constant <builtin.integer <20: i64>> : builtin.integer i64 !9;
+                sum1_v8 = builtin.constant <builtin.integer <30: i64>> : builtin.integer i64 !10;
+                sum1_v5 = llvm.add a1_v3, b1_v4 <{nsw=false,nuw=false}>: builtin.integer i64 !11;
+                llvm.return sum1_v8 !12
+            } !13;
+            done_v6 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !14;
+            llvm.return done_v6 !15
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -281,10 +437,27 @@ fn sccp_folds_inside_nested_region() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The inner add should fold to 7.
-    assert!(after.contains("<7: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            test.test_region 
+            {
+              ^region_entry_block2v1() !1:
+                a_v0 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !2;
+                b_v1 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !3;
+                inner_sum_v4 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !4;
+                inner_sum_v2 = llvm.add a_v0, b_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !5;
+                llvm.return inner_sum_v4 !6
+            } !7;
+            outer_v3 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !8;
+            llvm.return outer_v3 !9
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -301,9 +474,21 @@ fn sccp_materializes_constant_block_arg() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("constant").count(), 2);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            c_v0 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !1;
+            llvm.br ^bb1_block3v1(c_v0) !2
+
+          ^bb1_block3v1(x_v1: builtin.integer i64) !3:
+            x_v2 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !4;
+            llvm.return x_v2 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -323,9 +508,25 @@ fn sccp_materializes_multiple_constant_block_args() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("constant").count(), 6);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            a0_v1 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !1;
+            b0_v2 = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64 !2;
+            a1_v3 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !3;
+            b1_v4 = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64 !4;
+            llvm.cond_br if cond_v0 ^bb1_block3v1(a0_v1, b0_v2) else ^bb1_block3v1(a1_v3, b1_v4) !5
+
+          ^bb1_block3v1(x_v5: builtin.integer i64, y_v6: builtin.integer i64) !6:
+            y_v8 = builtin.constant <builtin.integer <5: i64>> : builtin.integer i64 !7;
+            x_v7 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !8;
+            llvm.return x_v7 !9
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -345,9 +546,25 @@ fn sccp_materializes_constant_carried_through_loop_back_edge() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("constant").count(), 3);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            c_v1 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !1;
+            llvm.br ^loop_block3v1(c_v1) !2
+
+          ^loop_block3v1(x_v2: builtin.integer i64) !3:
+            x_v4 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !4;
+            llvm.cond_br if cond_v0 ^loop_block3v1(x_v4) else ^exit_block4v1(x_v4) !5
+
+          ^exit_block4v1(y_v3: builtin.integer i64) !6:
+            y_v5 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !7;
+            llvm.return y_v5 !8
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -368,9 +585,24 @@ fn sccp_loop_back_edge_with_different_constant_meets_to_not_a_constant() -> Resu
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert_eq!(after.matches("constant").count(), 2);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            c1_v1 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !1;
+            llvm.br ^loop_block3v1(c1_v1) !2
+
+          ^loop_block3v1(x_v2: builtin.integer i64) !3:
+            c2_v3 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !4;
+            llvm.cond_br if cond_v0 ^loop_block3v1(c2_v3) else ^exit_block4v1(x_v2) !5
+
+          ^exit_block4v1(y_v4: builtin.integer i64) !6:
+            llvm.return y_v4 !7
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -392,9 +624,22 @@ fn sccp_materialization_replaces_uses_of_block_arg() -> Result<()> {
     // operand of `llvm.add` -> 3 occurrences.
     assert_eq!(input.matches("califragilistic").count(), 3);
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
-    assert_eq!(after.matches("califragilistic").count(), 6);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            c_v0 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !1;
+            llvm.br ^bb1_block3v1(c_v0) !2
+
+          ^bb1_block3v1(califragilistic_v1: builtin.integer i64) !3:
+            califragilistic_v4 = builtin.constant <builtin.integer <42: i64>> : builtin.integer i64 !4;
+            sum_v3 = builtin.constant <builtin.integer <84: i64>> : builtin.integer i64 !5;
+            sum_v2 = llvm.add califragilistic_v4, califragilistic_v4 <{nsw=false,nuw=false}>: builtin.integer i64 !6;
+            llvm.return sum_v3 !7
+        }"#]].assert_eq(&after);
     Ok(())
 }
 
@@ -412,9 +657,21 @@ fn sccp_does_not_materialize_not_a_constant_block_arg() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_sccp_on_text(input)?;
+    let (status, after) = run_sccp_on_text(input)?;
     assert_eq!(status, IRStatus::Unchanged);
-    assert_eq!(after.matches("constant").count(), 2);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(cond_v0: builtin.integer i1) !0:
+            a0_v1 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !1;
+            a1_v2 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !2;
+            llvm.cond_br if cond_v0 ^bb1_block3v1(a0_v1) else ^bb1_block3v1(a1_v2) !3
+
+          ^bb1_block3v1(x_v3: builtin.integer i64) !4:
+            llvm.return x_v3 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -457,13 +714,28 @@ fn sccp_treats_free_variables_as_non_constant() -> Result<()> {
 
     let status = sccp(region_op, ctx)?;
     verify_operation(func_op, ctx)?;
-    let after = func_op.disp(ctx).to_string();
+    let after = Operation::get_op_dyn(func_op, ctx).disp(ctx).to_string();
 
     // Even though `outer_three` and `outer_four` are syntactically
     // `builtin.constant` ops, the analysis must treat them as NotAConstant when
     // they appear free inside the analysis root, so the inner `llvm.add` must
     // *not* fold.
     assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("llvm.add"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            outer_three_v0 = builtin.constant <builtin.integer <3: i64>> : builtin.integer i64 !1;
+            outer_four_v1 = builtin.constant <builtin.integer <4: i64>> : builtin.integer i64 !2;
+            test.test_region 
+            {
+              ^region_entry_block2v1() !3:
+                inner_sum_v2 = llvm.add outer_three_v0, outer_four_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+                llvm.return inner_sum_v2 !5
+            } !6;
+            done_v3 = builtin.constant <builtin.integer <99: i64>> : builtin.integer i64 !7;
+            llvm.return done_v3 !8
+        }"#]].assert_eq(&after);
     Ok(())
 }

--- a/tests/opts/simplify_cfg.rs
+++ b/tests/opts/simplify_cfg.rs
@@ -3,6 +3,7 @@
 
 //! simplify-cfg integration tests using textual LLVM dialect IR parsing.
 
+use expect_test::expect;
 use pliron::{
     context::Context,
     init_env_logger_for_tests,
@@ -11,7 +12,6 @@ use pliron::{
     operation::{Operation, verify_operation},
     opts::simplify_cfg::simplify_cfg,
     parsable::parse_from_str,
-    printable::Printable,
     result::{ExpectOk, Result},
 };
 
@@ -30,21 +30,19 @@ use pliron::{
 )]
 pub struct TestRegionOp;
 
-fn run_simplify_cfg_on_text(input: &str) -> Result<(IRStatus, String, String)> {
+fn run_simplify_cfg_on_text(input: &str) -> Result<(IRStatus, String)> {
     init_env_logger_for_tests!();
     let ctx = &mut Context::new();
     let op = parse_from_str(spaced(Operation::top_level_parser()), ctx, input).expect_ok(ctx);
 
-    let before = op.disp(ctx).to_string();
-    log::trace!("Before simplify-cfg:\n{}", before);
     verify_operation(op, ctx)?;
 
     let status = simplify_cfg(op, ctx)?;
 
-    let after = op.disp(ctx).to_string();
+    let after = Operation::get_op_dyn(op, ctx).disp(ctx).to_string();
     log::trace!("After simplify-cfg:\n{}", after);
     verify_operation(op, ctx)?;
-    Ok((status, before, after))
+    Ok((status, after))
 }
 
 /// A block whose only successor has it as its only predecessor should be merged
@@ -62,13 +60,19 @@ fn simplify_cfg_merges_single_succ_single_pred_blocks() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // ^bb1 should be merged into ^entry, so the unconditional branch goes away
     // and only the entry block remains.
-    assert!(!after.contains("llvm.br"));
-    assert!(!after.contains("^bb1"));
-    assert!(after.contains("llvm.return c"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            c_v0 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !1;
+            llvm.return c_v0 !2
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -87,12 +91,18 @@ fn simplify_cfg_culls_unreachable_block() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The unreachable ^dead block should be removed.
-    assert!(!after.contains("^dead"));
-    assert!(!after.contains("<2: i64>"));
-    assert!(after.contains("<1: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            a_v0 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !1;
+            llvm.return a_v0 !2
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -117,15 +127,21 @@ fn simplify_cfg_culls_untaken_branch_of_constant_cond_br() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The cond_br folds away, leaving only an unconditional branch to ^taken.
-    assert!(!after.contains("llvm.cond_br"));
     // The untaken branch becomes unreachable and is culled.
-    assert!(!after.contains("^untaken"));
-    assert!(!after.contains("<2: i64>"));
     // The taken branch survives.
-    assert!(after.contains("<1: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            cond_v0 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !1;
+            a_v1 = builtin.constant <builtin.integer <1: i64>> : builtin.integer i64 !2;
+            llvm.return a_v1 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -151,14 +167,22 @@ fn simplify_cfg_fold_preserves_taken_edge_args() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The branch folds and the untaken edge is culled.
-    assert!(!after.contains("llvm.cond_br"));
-    assert!(!after.contains("^untaken"));
     // The taken-edge value `pt` is forwarded into the add instead of `pf`.
-    assert!(after.contains("llvm.add pt"));
-    assert!(!after.contains("llvm.add pf"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            cond_v0 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !1;
+            pt_v1 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !2;
+            pf_v2 = builtin.constant <builtin.integer <9: i64>> : builtin.integer i64 !3;
+            sum_v4 = llvm.add pt_v1, pt_v1 <{nsw=false,nuw=false}>: builtin.integer i64 !4;
+            llvm.return sum_v4 !5
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -191,18 +215,21 @@ fn simplify_cfg_culls_untaken_cases_of_constant_switch() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The switch folds away, leaving only an unconditional branch to ^bb1.
-    assert!(!after.contains("llvm.switch"));
     // The default and untaken cases become unreachable and are culled.
-    assert!(!after.contains("^default"));
-    assert!(!after.contains("^bb0"));
-    assert!(!after.contains("<100: i64>"));
-    assert!(!after.contains("<0: i64>"));
-    // The taken (non-default) case survives but gets merged into ^entry
-    assert!(after.contains("<22: i64>"));
-    assert!(!after.contains("^bb1"));
+    // The taken (non-default) case survives but gets merged into ^entry.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            cond_v0 = builtin.constant <builtin.integer <1: i32>> : builtin.integer i32 !1;
+            z1_v3 = builtin.constant <builtin.integer <22: i64>> : builtin.integer i64 !2;
+            llvm.return z1_v3 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -246,24 +273,35 @@ fn simplify_cfg_keeps_join_block_with_surviving_predecessor() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The entry branch is on a non-constant condition, so it cannot fold and
     // both ^a and ^b remain live.
-    assert!(after.contains("llvm.cond_br"));
-    assert!(after.contains("^a"));
-    assert!(after.contains("^b"));
     // Each successor's constant-conditioned branch folds, culling its untaken
     // side along with the constant defined there.
-    assert!(!after.contains("^only_a"));
-    assert!(!after.contains("^only_b"));
-    assert!(!after.contains("<55: i64>"));
-    assert!(!after.contains("<66: i64>"));
     // The shared join block survives despite losing the ^only_a / ^only_b
     // predecessors, because ^a and ^b still branch to it. With two remaining
     // predecessors it is not merged into either, so the label is preserved.
-    assert!(after.contains("^join"));
-    assert!(after.contains("<33: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(c_v0: builtin.integer i1) !0:
+            llvm.cond_br if c_v0 ^a_block4v1() else ^b_block6v1() !1
+
+          ^a_block4v1() !2:
+            ta_v1 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !3;
+            llvm.br ^join_block3v5() !4
+
+          ^b_block6v1() !5:
+            tb_v2 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !6;
+            llvm.br ^join_block3v5() !7
+
+          ^join_block3v5() !8:
+            r_v5 = builtin.constant <builtin.integer <33: i64>> : builtin.integer i64 !9;
+            llvm.return r_v5 !10
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -293,15 +331,21 @@ fn simplify_cfg_cull_enables_subsequent_merge() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // ^b is culled once the entry branch folds.
-    assert!(!after.contains("^b"));
-    assert!(!after.contains("<9: i64>"));
     // The cascade: with ^b gone, ^join has a single predecessor ^a and should
     // merge into it, forwarding va to x so `return x` becomes `return va`.
-    assert!(!after.contains("^join"));
-    assert!(after.contains("llvm.return va"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            cond_v0 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !1;
+            va_v1 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !2;
+            llvm.return va_v1 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -334,18 +378,22 @@ fn simplify_cfg_culls_cases_of_constant_switch_to_default() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The constant condition matches no case, so the switch folds to an
     // unconditional branch to ^default, which is then merged into ^entry.
-    assert!(!after.contains("llvm.switch"));
     // The untaken case blocks become unreachable and are culled.
-    assert!(!after.contains("^bb0"));
-    assert!(!after.contains("^bb1"));
-    assert!(!after.contains("<0: i64>"));
-    assert!(!after.contains("<22: i64>"));
     // The default case's body survives, merged into the entry block.
-    assert!(after.contains("<100: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            cond_v0 = builtin.constant <builtin.integer <5: i32>> : builtin.integer i32 !1;
+            d_v1 = builtin.constant <builtin.integer <100: i64>> : builtin.integer i64 !2;
+            llvm.return d_v1 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -374,17 +422,21 @@ fn simplify_cfg_culls_unreachable_loop() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // ^entry's branch folds to an unconditional jump to ^exit, so the loop is
-    // never reached.
-    assert!(!after.contains("llvm.cond_br"));
-    // The cyclic loop subgraph is culled in its entirety.
-    assert!(!after.contains("^loop_header"));
-    assert!(!after.contains("^loop_body"));
-    assert!(!after.contains("<77: i64>"));
+    // never reached. The cyclic loop subgraph is culled in its entirety.
     // The reachable exit survives (and is merged into the entry block).
-    assert!(after.contains("<88: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(c_v0: builtin.integer i1) !0:
+            skip_v1 = builtin.constant <builtin.integer <1: i1>> : builtin.integer i1 !1;
+            r_v3 = builtin.constant <builtin.integer <88: i64>> : builtin.integer i64 !2;
+            llvm.return r_v3 !3
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -406,15 +458,26 @@ fn simplify_cfg_preserves_reachable_trivial_loop() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     // The non-constant back-edge can't fold and every block is reachable, so the
     // loop's structure is preserved.
-    assert_eq!(status, IRStatus::Unchanged);
-    assert!(after.contains("^loop"));
-    assert!(after.contains("^exit"));
     // The self-referential conditional branch is still present.
-    assert!(after.contains("llvm.cond_br"));
-    assert!(after.contains("<88: i64>"));
+    assert_eq!(status, IRStatus::Unchanged);
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64(builtin.integer i1) variadic = false>
+          [] 
+        {
+          ^entry_block1v1(c_v0: builtin.integer i1) !0:
+            llvm.br ^loop_block3v1() !1
+
+          ^loop_block3v1() !2:
+            llvm.cond_br if c_v0 ^loop_block3v1() else ^exit_block4v1() !3
+
+          ^exit_block4v1() !4:
+            r_v1 = builtin.constant <builtin.integer <88: i64>> : builtin.integer i64 !5;
+            llvm.return r_v1 !6
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -441,15 +504,25 @@ fn simplify_cfg_culls_inside_nested_region() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The unreachable block inside the nested region is culled.
-    assert!(!after.contains("^inner_dead"));
-    assert!(!after.contains("<99: i64>"));
     // The reachable inner block and the entire outer region survive.
-    assert!(after.contains("test.test_region"));
-    assert!(after.contains("<11: i64>"));
-    assert!(after.contains("<44: i64>"));
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            test.test_region 
+            {
+              ^region_entry_block2v1() !1:
+                inner_v0 = builtin.constant <builtin.integer <11: i64>> : builtin.integer i64 !2;
+                llvm.return inner_v0 !3
+            } !4;
+            outer_v2 = builtin.constant <builtin.integer <44: i64>> : builtin.integer i64 !5;
+            llvm.return outer_v2 !6
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -475,16 +548,24 @@ fn simplify_cfg_descends_into_func_nested_in_module() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // The dead block in the func's SSA region is culled, even though the func
     // sits inside the module's graph region.
-    assert!(!after.contains("^dead"));
-    assert!(!after.contains("<99: i64>"));
     // The module, the func, and everything reachable survives.
-    assert!(after.contains("builtin.module"));
-    assert!(after.contains("llvm.func"));
-    assert!(after.contains("<11: i64>"));
+    expect![[r#"
+        builtin.module @m 
+        {
+          ^module_block_block1v1() !0:
+            llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+              [] 
+            {
+              ^entry_block2v1() !1:
+                live_v0 = builtin.constant <builtin.integer <11: i64>> : builtin.integer i64 !2;
+                llvm.return live_v0 !3
+            } !4
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }
 
@@ -507,15 +588,19 @@ fn simplify_cfg_collapses_straight_line_chain() -> Result<()> {
     }
   "#;
 
-    let (status, _before, after) = run_simplify_cfg_on_text(input)?;
+    let (status, after) = run_simplify_cfg_on_text(input)?;
     assert_eq!(status, IRStatus::Changed);
     // All three blocks collapse into the entry block: no branches and no
-    // intermediate block labels remain.
-    assert!(!after.contains("llvm.br"));
-    assert!(!after.contains("^mid"));
-    assert!(!after.contains("^tail"));
-    // The value `c` is forwarded through both edges (c -> m -> t), so the final
-    // return uses `c`.
-    assert!(after.contains("llvm.return c"));
+    // intermediate block labels remain. The value `c` is forwarded through
+    // both edges (c -> m -> t), so the final return uses `c`.
+    expect![[r#"
+        llvm.func @f: llvm.func <builtin.integer i64() variadic = false>
+          [] 
+        {
+          ^entry_block1v1() !0:
+            c_v0 = builtin.constant <builtin.integer <7: i64>> : builtin.integer i64 !1;
+            llvm.return c_v0 !2
+        }"#]]
+    .assert_eq(&after);
     Ok(())
 }


### PR DESCRIPTION
This PR does two things

1. `impl Hash for Ptr<T> ` should not has `T` itself. This is because `TypeId::of::<T>()` is not stable even across binaries. This makes `iter()` over `FxHash(Map/Set)` that have `Ptr` keys non-deterministic across binaries (not just across versions or platform as it normally is). This affects testing. For example, the result of `cargo test --workspace` vs `cargo test -p pliron`, which may use different binaries may have different outputs (all correct, but can't `expect!`).
2. Move over many tests that just did `output.contains(...)` to actual `expect!` tests. Easier to see what's happening and easier to update.