### PR TITLE
Replace uses of `FxHashSet` and `FxHashMap` with `HMap`, `HSet`, `IMap` and `ISet`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ pliron-derive = { path = "./pliron-derive", version = "0" }
 awint.workspace = true
 rustc_apfloat.workspace = true
 rustc-hash.workspace = true
+hashbrown.workspace = true
+indexmap.workspace = true
 thiserror.workspace = true
 combine.workspace = true
 log.workspace = true
@@ -46,7 +48,6 @@ dyn-clone.workspace = true
 utf8-chars = { workspace = true, optional = true }
 
 # Only used in `no_std`, but can't express that.
-hashbrown = "0"
 spin = "0"
 
 [target.'cfg(target_family = "wasm")'.dependencies]
@@ -76,6 +77,8 @@ proc-macro2 = "1"
 quote = "1"
 prettyplease = "0"
 rustc-hash = "2"
+hashbrown = "0"
+indexmap = { version = "2", default-features = false }
 combine = "4"
 thiserror = "2"
 tempfile = "3"

--- a/pliron-llvm/src/from_llvm_ir.rs
+++ b/pliron-llvm/src/from_llvm_ir.rs
@@ -34,9 +34,12 @@ use pliron::{
     op::Op,
     operation::Operation,
     result::Result,
-    std_deps::hash::{FxHashMap, FxHashSet},
     r#type::{Type, TypeHandle, TypedHandle, type_cast},
-    utils::{apfloat::f64_to_half, apint::APInt},
+    utils::{
+        apfloat::f64_to_half,
+        apint::APInt,
+        table::{HMap, HSet, IMap},
+    },
     value::Value,
 };
 use thiserror::Error;
@@ -373,13 +376,13 @@ pub fn convert_linkage(linkage: LLVMLinkage) -> LinkageAttr {
 #[derive(Default)]
 struct ConversionContext {
     /// A map from LLVM's Values to pliron's Values.
-    value_map: FxHashMap<LLVMValue, Value>,
+    value_map: HMap<LLVMValue, Value>,
     /// A map from LLVM's basic blocks to plirons'.
-    block_map: FxHashMap<LLVMBasicBlock, Ptr<BasicBlock>>,
+    block_map: HMap<LLVMBasicBlock, Ptr<BasicBlock>>,
     /// Cache already converted types.
-    type_cache: FxHashMap<LLVMType, TypeHandle>,
+    type_cache: HMap<LLVMType, TypeHandle>,
     /// Tag addressed to a (function, block) pair.
-    block_tag_map: FxHashMap<(LLVMValue, LLVMBasicBlock), u64>,
+    block_tag_map: IMap<(LLVMValue, LLVMBasicBlock), u64>,
     /// Next block tag id to assign.
     /// This is unique across all functions in the module for simplicity.
     block_tag_counter: u64,
@@ -454,13 +457,13 @@ fn successors(block: LLVMBasicBlock) -> Vec<LLVMBasicBlock> {
 
 /// Return RPO ordering of blocks in an LLVM function.
 fn rpo(function: LLVMValue) -> Vec<LLVMBasicBlock> {
-    let visited = &mut FxHashSet::<LLVMBasicBlock>::default();
+    let visited = &mut HSet::<LLVMBasicBlock>::default();
     let mut po = Vec::<LLVMBasicBlock>::new();
     let mut revpo = Vec::<LLVMBasicBlock>::new();
 
     fn walk(
         block: LLVMBasicBlock,
-        visited: &mut FxHashSet<LLVMBasicBlock>,
+        visited: &mut HSet<LLVMBasicBlock>,
         po: &mut Vec<LLVMBasicBlock>,
     ) {
         if !visited.insert(block) {
@@ -1759,7 +1762,7 @@ pub fn convert_module(ctx: &mut Context, module: &LLVMModule) -> Result<ModuleOp
     }
 
     // Convert functions.
-    let mut func_map = FxHashMap::default();
+    let mut func_map = HMap::default();
     for fun in function_iter(module) {
         let llvm_name = llvm_get_value_name(fun).expect("Expected function to have a name");
         if llvm_lookup_intrinsic_id(&llvm_name).is_some() {

--- a/pliron-llvm/src/to_llvm_ir.rs
+++ b/pliron-llvm/src/to_llvm_ir.rs
@@ -33,9 +33,12 @@ use pliron::{
     operation::Operation,
     printable::Printable,
     result::Result,
-    std_deps::hash::{FxHashMap, hash_map},
     r#type::{Type, TypeHandle, Typed, type_cast},
-    utils::{apfloat::float_to_f64, apint::APInt},
+    utils::{
+        apfloat::float_to_f64,
+        apint::APInt,
+        table::{HMap, IMap, htable},
+    },
     value::{DefiningEntity, Value},
 };
 
@@ -101,22 +104,22 @@ pub struct ConversionContext<'a> {
     // The current LLVMModule being converted to.
     cur_llvm_module: &'a LLVMModule,
     // A map from pliron Values to LLVM Values.
-    value_map: FxHashMap<Value, LLVMValue>,
+    value_map: HMap<Value, LLVMValue>,
     // A map from pliron basic blocks to LLVM.
-    block_map: FxHashMap<Ptr<BasicBlock>, LLVMBasicBlock>,
+    block_map: HMap<Ptr<BasicBlock>, LLVMBasicBlock>,
     // A map from pliron functions to LLVM functions.
-    function_map: FxHashMap<Identifier, LLVMValue>,
+    function_map: HMap<Identifier, LLVMValue>,
     // A map from pliron globals to LLVM globals.
-    globals_map: FxHashMap<Identifier, LLVMValue>,
+    globals_map: HMap<Identifier, LLVMValue>,
     // A map from `(function symbol, block tag)` to the corresponding LLVM block.
-    block_tags: FxHashMap<(Identifier, u64), LLVMBasicBlock>,
+    block_tags: HMap<(Identifier, u64), LLVMBasicBlock>,
     // A map from every placeholder we insert to
     // its corresponding `(function symbol, block tag)`
-    pending_block_address_ops: FxHashMap<LLVMValue, (Identifier, u64)>,
+    pending_block_address_ops: IMap<LLVMValue, (Identifier, u64)>,
     // A map from pliron StructTypes to LLVM StructTypes.
-    structs_map: FxHashMap<Identifier, LLVMType>,
+    structs_map: HMap<Identifier, LLVMType>,
     // Type cache to avoid redundant conversions.
-    type_cache: FxHashMap<TypeHandle, LLVMType>,
+    type_cache: HMap<TypeHandle, LLVMType>,
     // The active LLVM builder.
     builder: LLVMBuilder,
     // Scratch builder in a scratch function for attempting to evaluate constants.
@@ -127,14 +130,14 @@ impl<'a> ConversionContext<'a> {
     pub fn new(llvm_ctx: &'a LLVMContext, cur_llvm_module: &'a LLVMModule) -> Self {
         Self {
             cur_llvm_module,
-            value_map: FxHashMap::default(),
-            block_map: FxHashMap::default(),
-            function_map: FxHashMap::default(),
-            globals_map: FxHashMap::default(),
-            block_tags: FxHashMap::default(),
-            pending_block_address_ops: FxHashMap::default(),
-            structs_map: FxHashMap::default(),
-            type_cache: FxHashMap::default(),
+            value_map: HMap::default(),
+            block_map: HMap::default(),
+            function_map: HMap::default(),
+            globals_map: HMap::default(),
+            block_tags: HMap::default(),
+            pending_block_address_ops: IMap::default(),
+            structs_map: HMap::default(),
+            type_cache: HMap::default(),
             builder: LLVMBuilder::new(llvm_ctx),
             scratch_builder: LLVMBuilder::new(llvm_ctx),
         }
@@ -393,8 +396,8 @@ impl ToLLVMType for StructType {
                 .collect::<Result<Vec<_>>>()?;
             if let Some(name) = self.name() {
                 match cctx.structs_map.entry(name) {
-                    hash_map::Entry::Occupied(entry) => Ok(*entry.get()),
-                    hash_map::Entry::Vacant(entry) => {
+                    htable::Entry::Occupied(entry) => Ok(*entry.get()),
+                    htable::Entry::Vacant(entry) => {
                         let str_ty = llvm_struct_create_named(llvm_ctx, entry.key().as_ref());
                         llvm_struct_set_body(str_ty, &field_types, false);
                         entry.insert(str_ty);

--- a/src/analyses/liveness.rs
+++ b/src/analyses/liveness.rs
@@ -24,7 +24,7 @@ use crate::{
     pass::{Analysis, AnalysisManager},
     region::Region,
     result::Result,
-    std_deps::hash::{FxHashMap, FxHashSet},
+    utils::table::{HMap, HSet},
     value::{DefiningEntity, Value},
 };
 
@@ -42,7 +42,7 @@ pub struct LivenessTq {
     /// Strict dominator subtree for each block in the region
     sdom_tree: Vec<BitSet>,
     /// Maps a block to its index in `blocks` for quick lookup.
-    block_to_index: FxHashMap<Ptr<BasicBlock>, usize>,
+    block_to_index: HMap<Ptr<BasicBlock>, usize>,
     /// For each block, the set of blocks reachable from it in the reduced CFG
     /// (i.e. excluding back edges).
     reduced_reachability: Vec<BitSet>,
@@ -61,7 +61,7 @@ impl LivenessTq {
             .reverse_post_order()
             .enumerate()
             .map(|(i, block)| (block, (block, i)))
-            .unzip::<_, _, Vec<_>, FxHashMap<_, _>>();
+            .unzip::<_, _, Vec<_>, HMap<_, _>>();
 
         let sdom_tree = Self::dom_tree_to_sdom_tree(&block_to_index, dom_tree);
 
@@ -131,14 +131,14 @@ impl LivenessTq {
 
     // Compute the strict dominator sub-tree for each node.
     fn dom_tree_to_sdom_tree(
-        block_to_index: &FxHashMap<Ptr<BasicBlock>, usize>,
+        block_to_index: &HMap<Ptr<BasicBlock>, usize>,
         dom_tree: &DomTree<Ptr<Region>, Context>,
     ) -> Vec<BitSet> {
         let mut sdom_tree = vec![BitSet::default(); block_to_index.len()];
 
         fn recurser(
             sdom_tree: &mut [BitSet],
-            block_to_index: &FxHashMap<Ptr<BasicBlock>, usize>,
+            block_to_index: &HMap<Ptr<BasicBlock>, usize>,
             dom_tree: &DomTree<Ptr<Region>, Context>,
             block: Ptr<BasicBlock>,
         ) {
@@ -473,13 +473,13 @@ pub trait RegionLiveness {
 
 /// Fast answers liveness queries, caching liveness pre-computation for regions.
 pub struct Liveness<T: RegionLiveness> {
-    regions: FxHashMap<Ptr<Region>, T>,
+    regions: HMap<Ptr<Region>, T>,
 }
 
 impl<T: RegionLiveness> Default for Liveness<T> {
     fn default() -> Self {
         Self {
-            regions: FxHashMap::default(),
+            regions: HMap::default(),
         }
     }
 }
@@ -534,7 +534,7 @@ impl<T: RegionLiveness> Liveness<T> {
             .get_insertion_block(ctx)
             .expect("Query point must be within a block for local use check");
 
-        let user_ops_in_point_block: FxHashSet<_> = value
+        let user_ops_in_point_block: HSet<_> = value
             .uses(ctx)
             .iter()
             .filter_map(|r#use| find_ancestor_op_of_op_in_block(ctx, r#use.user_op(), point_block))

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -64,7 +64,7 @@ use crate::{
     printable::{self, Printable},
     result::Result,
     std_deps::{hash::FxHashMap, sync::LazyLock},
-    utils::trait_cast::impls_trait_static,
+    utils::{table::HMap, trait_cast::impls_trait_static},
 };
 
 /// Convenience type to easily print and parse key-value pairs in an [AttributeDict].
@@ -539,5 +539,5 @@ pub mod statics {
 /// A map from every [Attribute] to its ordered (as per interface deps) list of interface verifiers.
 /// An interface's super-interfaces are to be verified before it itself is.
 pub static ATTR_INTERFACE_VERIFIERS_MAP: LazyLock<
-    FxHashMap<core::any::TypeId, Vec<AttrInterfaceVerifier>>,
+    HMap<core::any::TypeId, Vec<AttrInterfaceVerifier>>,
 > = LazyLock::new(|| collect_deduped_interface_verifiers(statics::get_attr_interface_verifiers()));

--- a/src/builtin/op_interfaces.rs
+++ b/src/builtin/op_interfaces.rs
@@ -26,10 +26,9 @@ use crate::{
     printable::Printable,
     region::Region,
     result::Result,
-    std_deps::hash::FxHashMap,
     symbol_table::{SymbolTableCollection, walk_symbol_table},
     r#type::{Type, TypeHandle, Typed, type_impls},
-    utils::const_bound_n::LessThanN,
+    utils::{const_bound_n::LessThanN, table::HMap},
     value::Value,
     verify_err, verify_error,
 };
@@ -611,7 +610,7 @@ pub trait SymbolTableInterface: SingleBlockRegionInterface + OneRegionInterface 
         let op = op_cast::<dyn SymbolTableInterface>(op).unwrap();
 
         // Check that every symbol is defined only once.
-        let mut seen = FxHashMap::<Identifier, Location>::default();
+        let mut seen = HMap::<Identifier, Location>::default();
         let table_ops_block = op.get_body(ctx, 0);
         for op in table_ops_block.deref(ctx).iter(ctx) {
             if let Some(sym_op) =

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,13 +21,11 @@ use crate::{
     printable::{self, Printable},
     region::Region,
     result::Result,
-    std_deps::{
-        hash::{FxHashMap, FxHashSet},
-        sync::LazyLock,
-    },
+    std_deps::sync::LazyLock,
     storage_uniquer::UniqueStore,
     r#type::TypeObj,
     uniqued_any::UniquedAny,
+    utils::table::{HMap, HSet, IMap},
     verify_err_noloc,
 };
 use alloc::{boxed::Box, format, string::ToString, vec, vec::Vec};
@@ -67,7 +65,7 @@ pub struct Context {
     /// Allocation pool for [Region]s.
     pub(crate) regions: Arena<Region>,
     /// Registered [Dialect]s.
-    pub(crate) dialects: FxHashMap<DialectName, Dialect>,
+    pub(crate) dialects: HMap<DialectName, Dialect>,
     /// Storage for uniqued [TypeObj]s.
     pub(crate) type_store: UniqueStore<TypeObj>,
     /// Storage for other uniqued objects.
@@ -75,7 +73,7 @@ pub struct Context {
     /// Arbitrary data storage. Use [Self::aux_data_map] for dictionary access.
     pub aux_data: SlotMap<AuxDataIndex, Box<dyn Any>>,
     /// A dictionary with keys mapping to an index in [Self::aux_data].
-    pub aux_data_map: FxHashMap<Identifier, AuxDataIndex>,
+    pub aux_data_map: HMap<Identifier, AuxDataIndex>,
 }
 
 impl Context {
@@ -113,11 +111,11 @@ impl Default for Context {
             operations: Arena::default(),
             basic_blocks: Arena::default(),
             regions: Arena::default(),
-            dialects: FxHashMap::default(),
+            dialects: HMap::default(),
             type_store: UniqueStore::default(),
             uniqued_any_store: UniqueStore::default(),
             aux_data: SlotMap::with_key(),
-            aux_data_map: FxHashMap::default(),
+            aux_data_map: HMap::default(),
         };
 
         // Verify that all dictionary keys are unique.
@@ -368,13 +366,13 @@ pub static DICT_KEYS_VERIFIER: LazyLock<Result<()>> = LazyLock::new(verify_dict_
 /// function) while deduplicating verifier function pointers.
 pub(crate) fn collect_deduped_interface_verifiers<Id, AllVerifiers, Verifier>(
     interface_verifiers: impl Iterator<Item = &'static (Id, AllVerifiers)>,
-) -> FxHashMap<Id, Vec<Verifier>>
+) -> HMap<Id, Vec<Verifier>>
 where
     Id: Eq + Hash + Clone + 'static,
     AllVerifiers: Fn() -> Vec<Verifier> + Clone + 'static,
     Verifier: Eq + Hash + Clone,
 {
-    let mut grouped = FxHashMap::default();
+    let mut grouped = IMap::default();
     for entry in interface_verifiers {
         let (id, all_verifiers_for_interface) = entry;
         grouped
@@ -392,7 +390,7 @@ where
         .into_iter()
         .map(|(id, verifiers)| {
             let mut dedupd_verifiers = Vec::new();
-            let mut seen = FxHashSet::default();
+            let mut seen = HSet::default();
             for verifier_fn_list in verifiers {
                 for verifier in verifier_fn_list() {
                     if seen.insert(verifier.clone()) {
@@ -410,7 +408,7 @@ where
 /// If any duplicate keys are found, a panic is raised with the file, line, and column
 /// information of the duplicate keys.
 pub fn verify_dict_keys() -> Result<()> {
-    let mut seen: FxHashMap<Identifier, (&'static str, u32, u32)> = FxHashMap::default();
+    let mut seen: HMap<Identifier, (&'static str, u32, u32)> = HMap::default();
     for key in get_dict_key_ids() {
         if let Some((file, line, column)) = seen.get(&key.id) {
             return verify_err_noloc!(

--- a/src/dialect.rs
+++ b/src/dialect.rs
@@ -16,8 +16,8 @@ use crate::{
     parsable::{IntoParseResult, Parsable, ParseResult, StateStream},
     printable::{self, Printable},
     result::Result,
-    std_deps::hash::FxHashMap,
     r#type::{TypeId, TypeParserFn},
+    utils::table::HMap,
 };
 
 /// Dialect name: Safe wrapper around a String.
@@ -91,11 +91,11 @@ pub struct Dialect {
     /// Name of this dialect.
     pub name: DialectName,
     /// Ops that are part of this dialect.
-    pub(crate) ops: FxHashMap<OpId, OpParserFn>,
+    pub(crate) ops: HMap<OpId, OpParserFn>,
     /// Types that are part of this dialect.
-    pub(crate) types: FxHashMap<TypeId, TypeParserFn>,
+    pub(crate) types: HMap<TypeId, TypeParserFn>,
     /// Attributes that are part of this dialect.
-    pub(crate) attributes: FxHashMap<AttrId, AttrParserFn>,
+    pub(crate) attributes: HMap<AttrId, AttrParserFn>,
 }
 
 impl Printable for Dialect {
@@ -114,9 +114,9 @@ impl Dialect {
     pub fn new(name: DialectName) -> Dialect {
         Dialect {
             name,
-            ops: FxHashMap::default(),
-            types: FxHashMap::default(),
-            attributes: FxHashMap::default(),
+            ops: HMap::default(),
+            types: HMap::default(),
+            attributes: HMap::default(),
         }
     }
 

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -14,7 +14,7 @@ use crate::{
     pass::{Analysis, AnalysisManager},
     region::Region,
     result::Result,
-    std_deps::hash::{FxHashMap, FxHashSet},
+    utils::table::{HMap, IMap, ISet},
     value::{DefiningEntity, Value},
 };
 
@@ -36,11 +36,11 @@ where
 {
     // An empty tree has no root.
     root: Option<G::Node>,
-    dominators_map: FxHashMap<G::Node, DomTreeNode<G, GraphContext>>,
+    dominators_map: IMap<G::Node, DomTreeNode<G, GraphContext>>,
 }
 
 /// Maps each node to its dominance frontier
-pub struct DomFrontierMap<G, GraphContext>(FxHashMap<G::Node, FxHashSet<G::Node>>)
+pub struct DomFrontierMap<G, GraphContext>(HMap<G::Node, ISet<G::Node>>)
 where
     G: ControlFlowGraph<GraphContext>;
 
@@ -58,7 +58,7 @@ where
     let Some(entry_node) = graph.entry_node(ctx) else {
         return DomTree {
             root: None,
-            dominators_map: FxHashMap::default(),
+            dominators_map: IMap::default(),
         };
     };
 
@@ -71,7 +71,7 @@ where
         .next()
         .expect("Graph has no components, but has an entry node");
 
-    let rpo_index: FxHashMap<G::Node, usize> = rpo
+    let rpo_index: HMap<G::Node, usize> = rpo
         .iter()
         .enumerate()
         .map(|(i, node)| (node.clone(), i))
@@ -132,7 +132,7 @@ where
 
     let mut dom_tree = DomTree {
         root: Some(entry_node),
-        dominators_map: FxHashMap::default(),
+        dominators_map: IMap::default(),
     };
     let entry = DomTreeNode {
         parent: None,
@@ -233,10 +233,8 @@ where
     /// generated from `graph`
     // This method implements the algorithm from "A Simple, Fast Dominance Algorithm" by Cooper et. al.
     pub fn new(ctx: &GraphContext, graph: &G, dom_tree: &DomTree<G, GraphContext>) -> Self {
-        let mut res: FxHashMap<G::Node, FxHashSet<G::Node>> = graph
-            .nodes(ctx)
-            .map(|n| (n, FxHashSet::default()))
-            .collect();
+        let mut res: HMap<G::Node, ISet<G::Node>> =
+            graph.nodes(ctx).map(|n| (n, ISet::default())).collect();
         for b in graph.nodes(ctx) {
             if graph.num_predecessors(ctx, &b) < 2 {
                 continue;
@@ -253,7 +251,7 @@ where
     }
 
     /// Gets the set of all nodes in `n`'s dominance frontier
-    pub fn frontier<'a>(&'a self, n: &G::Node) -> &'a FxHashSet<G::Node> {
+    pub fn frontier<'a>(&'a self, n: &G::Node) -> &'a ISet<G::Node> {
         &self.0[n]
     }
 }
@@ -327,7 +325,7 @@ fn try_get_blocks_in_same_region(
 
 /// Caches dominance trees for multiple regions in a program
 #[derive(Default)]
-pub struct DomInfo(FxHashMap<Ptr<Region>, DomTree<Ptr<Region>, Context>>);
+pub struct DomInfo(HMap<Ptr<Region>, DomTree<Ptr<Region>, Context>>);
 
 impl DomInfo {
     /// If dominator tree for `region` is cached, return it.
@@ -513,7 +511,7 @@ mod tests {
     use super::*;
     use crate::{
         graph::{ControlFlowGraph, HasLabel},
-        std_deps::hash::{FxHashSet, HashSet},
+        std_deps::hash::HashSet,
     };
 
     #[derive(Clone, Debug)]
@@ -743,7 +741,7 @@ mod tests {
         let ctx = vec![n(&[])];
         let dom = compute_dominator_tree(&ctx, &ArenaGraph);
         let df = DomFrontierMap::new(&ctx, &ArenaGraph, &dom);
-        assert_eq!(*df.frontier(&0), FxHashSet::from_iter([]));
+        assert_eq!(*df.frontier(&0), ISet::from_iter([]));
     }
 
     #[test]
@@ -762,10 +760,10 @@ mod tests {
         let dom = compute_dominator_tree(&ctx, &ArenaGraph);
         let df = DomFrontierMap::new(&ctx, &ArenaGraph, &dom);
 
-        assert_eq!(*df.frontier(&0), FxHashSet::from_iter([]));
-        assert_eq!(*df.frontier(&1), FxHashSet::from_iter([3]));
-        assert_eq!(*df.frontier(&2), FxHashSet::from_iter([3]));
-        assert_eq!(*df.frontier(&3), FxHashSet::from_iter([]));
+        assert_eq!(*df.frontier(&0), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&1), ISet::from_iter([3]));
+        assert_eq!(*df.frontier(&2), ISet::from_iter([3]));
+        assert_eq!(*df.frontier(&3), ISet::from_iter([]));
     }
 
     #[test]
@@ -789,15 +787,15 @@ mod tests {
         let dom = compute_dominator_tree(&ctx, &ArenaGraph);
         let df = DomFrontierMap::new(&ctx, &ArenaGraph, &dom);
 
-        assert_eq!(*df.frontier(&0), FxHashSet::from_iter([]));
-        assert_eq!(*df.frontier(&1), FxHashSet::from_iter([3]));
-        assert_eq!(*df.frontier(&2), FxHashSet::from_iter([3]));
-        assert_eq!(*df.frontier(&3), FxHashSet::from_iter([]));
-        assert_eq!(*df.frontier(&4), FxHashSet::from_iter([]));
-        assert_eq!(*df.frontier(&5), FxHashSet::from_iter([]));
-        assert_eq!(*df.frontier(&6), FxHashSet::from_iter([]));
-        assert_eq!(*df.frontier(&7), FxHashSet::from_iter([]));
-        assert_eq!(*df.frontier(&8), FxHashSet::from_iter([]));
+        assert_eq!(*df.frontier(&0), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&1), ISet::from_iter([3]));
+        assert_eq!(*df.frontier(&2), ISet::from_iter([3]));
+        assert_eq!(*df.frontier(&3), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&4), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&5), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&6), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&7), ISet::from_iter([]));
+        assert_eq!(*df.frontier(&8), ISet::from_iter([]));
     }
 
     #[test]
@@ -820,7 +818,7 @@ mod tests {
         ];
         let dom = compute_dominator_tree(&ctx, &ArenaGraph);
         let df = DomFrontierMap::new(&ctx, &ArenaGraph, &dom);
-        assert_eq!(*df.frontier(&4), FxHashSet::from_iter([3, 4, 11, 12]));
+        assert_eq!(*df.frontier(&4), ISet::from_iter([3, 4, 11, 12]));
     }
 
     // --- Operation-level dominance tests ---

--- a/src/graph/traversals.rs
+++ b/src/graph/traversals.rs
@@ -4,7 +4,7 @@
 //! Control-flow-graph traversals
 
 use super::ControlFlowGraph;
-use crate::std_deps::hash::{FxHashMap, FxHashSet};
+use crate::utils::table::{HMap, HSet, IMap};
 
 /// Region traversal utilities
 pub mod region {
@@ -18,7 +18,7 @@ pub mod region {
         ctx: &GraphContext,
         graph: &G,
         node: G::Node,
-        seen_nodes: &mut FxHashSet<G::Node>,
+        seen_nodes: &mut HSet<G::Node>,
         po: &mut Vec<G::Node>,
     ) where
         G: ControlFlowGraph<GraphContext>,
@@ -79,7 +79,7 @@ pub mod region {
     where
         G: ControlFlowGraph<GraphContext>,
     {
-        let seen_nodes = &mut FxHashSet::<G::Node>::default();
+        let seen_nodes = &mut HSet::<G::Node>::default();
         let mut po_by_component = Vec::<Vec<G::Node>>::new();
 
         // Walk every node (not just entry) since we may have unreachable nodes.
@@ -118,7 +118,7 @@ pub mod region {
     where
         G: ControlFlowGraph<GraphContext>,
     {
-        let seen_nodes = &mut FxHashSet::<G::Node>::default();
+        let seen_nodes = &mut HSet::<G::Node>::default();
         let mut rpo_by_component = Vec::<Vec<G::Node>>::new();
 
         // Walk every node (not just entry) since we may have unreachable nodes.
@@ -156,7 +156,7 @@ pub mod region {
     where
         G: ControlFlowGraph<GraphContext>,
     {
-        tree: FxHashMap<G::Node, DFSNumber>,
+        tree: IMap<G::Node, DFSNumber>,
     }
 
     fn dfs_walk<G, GraphContext>(
@@ -165,7 +165,7 @@ pub mod region {
         node: G::Node,
         pre_order_counter: &mut usize,
         post_order_counter: &mut usize,
-        result: &mut FxHashMap<G::Node, DFSNumber>,
+        result: &mut IMap<G::Node, DFSNumber>,
     ) where
         G: ControlFlowGraph<GraphContext>,
     {
@@ -236,7 +236,7 @@ pub mod region {
         /// Perform DFS traversal of the graph and compute pre-order,
         /// post-order and reverse-post-order numbers for each node.
         pub fn new(ctx: &GraphContext, graph: &G) -> Self {
-            let mut result = FxHashMap::<G::Node, DFSNumber>::default();
+            let mut result = IMap::<G::Node, DFSNumber>::default();
             let mut pre_order_counter = 0;
             let mut post_order_counter = 0;
 
@@ -375,13 +375,13 @@ pub mod region {
         G: ControlFlowGraph<GraphContext>,
     {
         // DFS visit index of each visited node.
-        let mut index_of = FxHashMap::<G::Node, usize>::default();
+        let mut index_of = HMap::<G::Node, usize>::default();
         // The lowest visit index reachable from each node's DFS subtree.
-        let mut lowlink = FxHashMap::<G::Node, usize>::default();
+        let mut lowlink = HMap::<G::Node, usize>::default();
         let mut next_index = 0usize;
         // Tarjan's component stack.
         let mut scc_stack = Vec::<G::Node>::new();
-        let mut on_scc_stack = FxHashSet::<G::Node>::default();
+        let mut on_scc_stack = HSet::<G::Node>::default();
         let mut sccs = Vec::<Scc<G::Node>>::new();
 
         // Start DFS at the entry node first (if any), then cover any remaining

--- a/src/graph/visualize.rs
+++ b/src/graph/visualize.rs
@@ -14,7 +14,7 @@ use pliron::{
     linked_list::ContainsLinkedList,
     operation::{self, Operation},
     region::Region,
-    std_deps::hash::FxHashMap,
+    utils::table::HMap,
 };
 
 /// Visualise an [Operation], as a graphviz DOT graph.
@@ -62,7 +62,7 @@ impl core::fmt::Display for Visualizer<'_> {
 
 /// State of graphviz generation to ensure uniqueness of nodes
 struct GraphState<'a, 'b> {
-    op_nodes: FxHashMap<Ptr<Operation>, (u32, u32)>,
+    op_nodes: HMap<Ptr<Operation>, (u32, u32)>,
     op_counter: u32,
     f: &'a mut core::fmt::Formatter<'b>,
 }
@@ -70,7 +70,7 @@ struct GraphState<'a, 'b> {
 impl<'a, 'b> GraphState<'a, 'b> {
     fn new(f: &'a mut core::fmt::Formatter<'b>) -> GraphState<'a, 'b> {
         GraphState {
-            op_nodes: FxHashMap::default(),
+            op_nodes: HMap::default(),
             op_counter: 0,
             f,
         }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -17,7 +17,7 @@ use crate::{
     impl_printable_for_display,
     parsable::{self, Parsable, ParseResult},
     result::{self, Result},
-    std_deps::hash::FxHashMap,
+    utils::table::HMap,
 };
 
 #[derive(Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
@@ -169,9 +169,9 @@ impl Parsable for Identifier {
 #[derive(Default)]
 pub struct Legaliser {
     /// A map from the source strings to [Identifier]s.
-    str_to_id: FxHashMap<String, Identifier>,
+    str_to_id: HMap<String, Identifier>,
     /// Reverse map from [Identifier]s to their source string.
-    rev_str_to_id: FxHashMap<String, String>,
+    rev_str_to_id: HMap<String, String>,
     /// A counter to generate unique (within this object) ids.
     counter: usize,
 }

--- a/src/irbuild/cloning.rs
+++ b/src/irbuild/cloning.rs
@@ -35,17 +35,17 @@ use crate::{
     location::Located,
     operation::Operation,
     region::Region,
-    std_deps::hash::FxHashMap,
     r#type::Typed,
+    utils::table::HMap,
     value::Value,
 };
 
 /// Mapping between IR entities
 #[derive(Debug, Default)]
 pub struct IrMapping {
-    values: FxHashMap<Value, Value>,
-    blocks: FxHashMap<Ptr<BasicBlock>, Ptr<BasicBlock>>,
-    ops: FxHashMap<Ptr<Operation>, Ptr<Operation>>,
+    values: HMap<Value, Value>,
+    blocks: HMap<Ptr<BasicBlock>, Ptr<BasicBlock>>,
+    ops: HMap<Ptr<Operation>, Ptr<Operation>>,
 }
 
 impl IrMapping {

--- a/src/irbuild/dialect_conversion.rs
+++ b/src/irbuild/dialect_conversion.rs
@@ -26,8 +26,8 @@ use crate::{
     pass::{AnalysisManager, Pass, PassResult},
     printable::{ListSeparator, Printable},
     result::Result,
-    std_deps::hash::{FxHashMap, FxHashSet},
     r#type::{Type, TypeHandle, Typed},
+    utils::table::{HMap, HSet},
     value::{DefiningEntity, Value},
 };
 
@@ -184,8 +184,8 @@ pub fn apply_dialect_conversion<C: DialectConversion>(
         rewriter: DialectConversionRewriter,
         worklist: VecDeque<Ptr<Operation>>,
         pending_block_arg_conversions: Vec<Ptr<BasicBlock>>,
-        op_states: FxHashMap<Ptr<Operation>, OpState>,
-        previous_types: FxHashMap<Value, Vec<TypeHandle>>,
+        op_states: HMap<Ptr<Operation>, OpState>,
+        previous_types: HMap<Value, Vec<TypeHandle>>,
     }
 
     impl<'a, C: DialectConversion> Driver<'a, C> {
@@ -197,8 +197,8 @@ pub fn apply_dialect_conversion<C: DialectConversion>(
                 rewriter,
                 worklist: VecDeque::new(),
                 pending_block_arg_conversions: Vec::new(),
-                op_states: FxHashMap::default(),
-                previous_types: FxHashMap::default(),
+                op_states: HMap::default(),
+                previous_types: HMap::default(),
             }
         }
 
@@ -348,7 +348,7 @@ pub fn apply_dialect_conversion<C: DialectConversion>(
                 core::mem::take(&mut listener.events)
             };
 
-            let mut erased_blocks = FxHashSet::default();
+            let mut erased_blocks = HSet::default();
             for event in &events {
                 match event {
                     RecorderEvent::ErasedOperation(op) => self.mark_erased(*op),

--- a/src/irbuild/equivalence.rs
+++ b/src/irbuild/equivalence.rs
@@ -17,8 +17,8 @@ use crate::{
     operation::{OpDbg, Operation},
     printable::{Printable, State},
     region::Region,
-    std_deps::hash::FxHashMap,
     r#type::Typed,
+    utils::table::IMap,
 };
 
 /// Configuration to decide what parts of the IR must be ignored.
@@ -93,10 +93,10 @@ pub fn attributes_eq(
 ) -> bool {
     let is_relevant = |attr: &AttrObj| !(ignore_config.ignore_attr)(ctx, attr.as_ref());
 
-    let lhs_relevant: FxHashMap<&Identifier, &AttrObj> =
+    let lhs_relevant: IMap<&Identifier, &AttrObj> =
         lhs.0.iter().filter(|(_, attr)| is_relevant(attr)).collect();
 
-    let rhs_relevant: FxHashMap<&Identifier, &AttrObj> =
+    let rhs_relevant: IMap<&Identifier, &AttrObj> =
         rhs.0.iter().filter(|(_, attr)| is_relevant(attr)).collect();
 
     if lhs_relevant.len() != rhs_relevant.len() {

--- a/src/irbuild/match_rewrite.rs
+++ b/src/irbuild/match_rewrite.rs
@@ -18,7 +18,7 @@ use crate::{
     operation::Operation,
     pass::{AnalysisManager, Pass, PassResult},
     result::Result,
-    std_deps::hash::FxHashSet,
+    utils::table::HSet,
 };
 
 /// A rewriter that uses the [Recorder] listener.
@@ -85,7 +85,7 @@ pub fn apply_match_rewrite<M: MatchRewrite>(
     // Walk the operation tree.
     walk_op(ctx, &mut state, &order.collect, op, walker_callback);
 
-    let mut erased = FxHashSet::<Ptr<Operation>>::default();
+    let mut erased = HSet::<Ptr<Operation>>::default();
     let mut rewriter = MatchRewriter::default();
     rewriter.set_listener(Recorder::default());
 

--- a/src/irfmt/outlined.rs
+++ b/src/irfmt/outlined.rs
@@ -23,8 +23,10 @@ use crate::{
     parsable::{Parsable, StateStream},
     printable::{self, Printable},
     result::Result,
-    std_deps::hash::FxHashMap,
-    utils::vec_exns::VecExtns,
+    utils::{
+        table::{HMap, IMap},
+        vec_exns::VecExtns,
+    },
 };
 
 use super::parsers::{delimited_list_parser, location, spaced, zero_or_more_parser};
@@ -81,7 +83,7 @@ struct OutlinePrintState {
     /// Items (operations or blocks) that have some outline item to be printed.
     outlined_items: Vec<OutlinedItem>,
     /// [PrintOnceAttr]s, mapped to their outindex.
-    print_once_attrs: FxHashMap<PrintOnceAttrWrapper, usize>,
+    print_once_attrs: IMap<PrintOnceAttrWrapper, usize>,
 }
 
 dict_key!(OUTLINED_STATE, "outlined_state");
@@ -190,7 +192,7 @@ pub(crate) fn print_outlines(
     fn print_outlined_attrs_for(
         ctx: &Context,
         f: &mut core::fmt::Formatter<'_>,
-        print_once_attrs: &mut FxHashMap<PrintOnceAttrWrapper, usize>,
+        print_once_attrs: &mut IMap<PrintOnceAttrWrapper, usize>,
         print_once_attr_indices: &mut usize,
         attributes: &AttributeDict,
         loc: Location,
@@ -271,9 +273,9 @@ pub(crate) fn print_outlines(
 #[derive(Default)]
 struct OutlineParseState {
     /// Map an outline item number to the [Operation] it refers to.
-    outindex_op_map: FxHashMap<usize, Ptr<Operation>>,
+    outindex_op_map: HMap<usize, Ptr<Operation>>,
     /// Map an outline item number to the [BasicBlock] it refers to.
-    outindex_block_map: FxHashMap<usize, Ptr<BasicBlock>>,
+    outindex_block_map: HMap<usize, Ptr<BasicBlock>>,
 }
 
 /// Each [Operation] is associated with an optional [Location] and
@@ -421,7 +423,7 @@ pub(crate) fn parse_outlines(state_stream: &mut StateStream) -> Result<()> {
             })?;
 
     // Separate the two kinds of entries we have.
-    let print_once_entries: FxHashMap<_, _> = entries
+    let print_once_entries: HMap<_, _> = entries
         .extract_if(0..entries.len(), |e| {
             matches!(e.1, OutlineEntry::PrintOnceAttr(_))
         })

--- a/src/location.rs
+++ b/src/location.rs
@@ -22,8 +22,9 @@ use crate::{
     },
     parsable::Parsable,
     printable::{self, Printable},
-    std_deps::{hash::FxHashSet, path::PathBuf},
+    std_deps::path::PathBuf,
     uniqued_any::{self, UniquedKey},
+    utils::table::ISet,
 };
 
 /// Where is the source program?
@@ -132,8 +133,8 @@ impl Location {
 
     /// Get all sources that this location is associated with.
     pub fn sources(&self) -> Vec<Source> {
-        let mut res = FxHashSet::default();
-        fn sources(loc: &Location, res: &mut FxHashSet<Source>) {
+        let mut res = ISet::default();
+        fn sources(loc: &Location, res: &mut ISet<Source>) {
             match loc {
                 Location::SrcPos { src, pos: _ } => {
                     res.insert(*src);

--- a/src/op.rs
+++ b/src/op.rs
@@ -73,9 +73,9 @@ use crate::{
     printable::{self, Printable},
     region::Region,
     result::{Error, Result},
-    std_deps::{hash::FxHashMap, sync::LazyLock},
+    std_deps::sync::LazyLock,
     r#type::{TypeSig, Typed},
-    utils::trait_cast::impls_trait_static,
+    utils::{table::HMap, trait_cast::impls_trait_static},
 };
 
 #[derive(Clone, Hash, PartialEq, Eq)]
@@ -406,9 +406,8 @@ pub mod statics {
 #[doc(hidden)]
 /// A map from every [Op] to its ordered (as per interface deps) list of interface verifiers.
 /// An interface's super-interfaces are to be verified before it itself is.
-pub static OP_INTERFACE_VERIFIERS_MAP: LazyLock<
-    FxHashMap<core::any::TypeId, Vec<OpInterfaceVerifier>>,
-> = LazyLock::new(|| collect_deduped_interface_verifiers(statics::get_op_interface_verifiers()));
+pub static OP_INTERFACE_VERIFIERS_MAP: LazyLock<HMap<core::any::TypeId, Vec<OpInterfaceVerifier>>> =
+    LazyLock::new(|| collect_deduped_interface_verifiers(statics::get_op_interface_verifiers()));
 
 /// Printer for an [Op] in canonical syntax.
 /// `res_1, res_2, ... res_n =

--- a/src/opts/constants/sccp.rs
+++ b/src/opts/constants/sccp.rs
@@ -54,7 +54,7 @@ use crate::{
     opts::constants::{BranchOpFoldInterface, ConstFoldInterface},
     pass::{AnalysisManager, Pass, PassResult},
     result::Result,
-    std_deps::hash::FxHashSet,
+    utils::table::HSet,
     value::Value,
 };
 use alloc::vec::Vec;
@@ -101,7 +101,7 @@ fn process_branch_op(branch_op: &dyn BranchOpInterface, ctx: &Context, state: &m
     let op = branch_op.get_operation();
     let op_dyn = Operation::get_op_dyn(op, ctx);
     let attrs = operand_attrs(op, ctx, state);
-    let feasible_successors: FxHashSet<Ptr<BasicBlock>> =
+    let feasible_successors: HSet<Ptr<BasicBlock>> =
         match op_cast::<dyn BranchOpFoldInterface>(op_dyn.as_ref()) {
             Some(branch_op_fold) => branch_op_fold.check_fold(ctx, &attrs).into_iter().collect(),
             None => {

--- a/src/opts/constants/state.rs
+++ b/src/opts/constants/state.rs
@@ -11,7 +11,7 @@ use crate::{
     linked_list::ContainsLinkedList,
     operation::Operation,
     printable::{self, Printable},
-    std_deps::hash::{FxHashMap, FxHashSet},
+    utils::table::{HMap, ISet},
     value::Value,
 };
 
@@ -130,19 +130,19 @@ impl Constness {
 pub(super) struct SccpState {
     /// Maps each block to information about whether the block is reachable
     /// Blocks not present as keys are assumed to be unreachable.
-    block_states: FxHashMap<Ptr<BasicBlock>, BlockState>,
+    block_states: HMap<Ptr<BasicBlock>, BlockState>,
     /// Maps each [Value] to information about whether the [Value] is known to be const
     /// [Value]s not present are assumed to be undetermined.
-    val_states: FxHashMap<Value, Constness>,
+    val_states: HMap<Value, Constness>,
     /// After a [BasicBlock] has been marked as reachable, we must traverse
     /// each of its operations and process them to draw inferences.
     /// This set contains all blocks marked as reachable but not yet traversed.
-    block_worklist: FxHashSet<Ptr<BasicBlock>>,
+    block_worklist: ISet<Ptr<BasicBlock>>,
     /// When we infer information about the constness of a [Value], we must
     /// process all its uses to try to infer more information about the constness
     /// of its uses' results. This set contains such [Value]s that we have not yet
     /// processed.
-    val_worklist: FxHashSet<Value>,
+    val_worklist: ISet<Value>,
 }
 
 impl SccpState {
@@ -150,10 +150,10 @@ impl SccpState {
     /// regions' entry blocks as Reachable and their entry-block arguments as NotAConstant.
     pub(super) fn new(root_op: Ptr<Operation>, ctx: &Context) -> SccpState {
         let mut state = SccpState {
-            block_states: FxHashMap::default(),
-            val_states: FxHashMap::default(),
-            block_worklist: FxHashSet::default(),
-            val_worklist: FxHashSet::default(),
+            block_states: HMap::default(),
+            val_states: HMap::default(),
+            block_worklist: ISet::default(),
+            val_worklist: ISet::default(),
         };
         state.seed_nested_regions(root_op, ctx);
         state
@@ -240,16 +240,12 @@ impl SccpState {
 
     /// Pop an arbitrary block from the block worklist, if any.
     pub(super) fn pop_block(&mut self) -> Option<Ptr<BasicBlock>> {
-        let block = self.block_worklist.iter().next().copied()?;
-        self.block_worklist.remove(&block);
-        Some(block)
+        self.block_worklist.pop()
     }
 
     /// Pop an arbitrary value from the value worklist, if any.
     pub(super) fn pop_val(&mut self) -> Option<Value> {
-        let val = self.val_worklist.iter().next().copied()?;
-        self.val_worklist.remove(&val);
-        Some(val)
+        self.val_worklist.pop()
     }
 
     /// Are both block and value worklists empty?

--- a/src/opts/dce.rs
+++ b/src/opts/dce.rs
@@ -39,7 +39,7 @@ use crate::{
     pass::{AnalysisManager, Pass, PassResult},
     printable::Printable,
     result::Result,
-    std_deps::hash::FxHashSet,
+    utils::table::HSet,
     value::{DefiningEntity, Value},
 };
 
@@ -161,8 +161,8 @@ fn is_safe_to_erase(cand: DCECandidate, ctx: &Context) -> bool {
 /// Process the events in the recorder to note down erased operations.
 fn note_erased_ops(
     recorder: &mut Recorder,
-    erased_ops: &mut FxHashSet<Ptr<Operation>>,
-    erased_blocks: &mut FxHashSet<Ptr<BasicBlock>>,
+    erased_ops: &mut HSet<Ptr<Operation>>,
+    erased_blocks: &mut HSet<Ptr<BasicBlock>>,
 ) {
     for event in recorder.events.drain(..) {
         match event {
@@ -193,8 +193,8 @@ pub fn dce(op: Ptr<Operation>, ctx: &mut Context) -> Result<IRStatus> {
     let mut rewriter = IRRewriter::<Recorder>::default();
 
     let mut cemetery: Vec<DCECandidate> = Vec::new();
-    let mut erased_blocks: FxHashSet<Ptr<BasicBlock>> = FxHashSet::default();
-    let mut erased_ops: FxHashSet<Ptr<Operation>> = FxHashSet::default();
+    let mut erased_blocks: HSet<Ptr<BasicBlock>> = HSet::default();
+    let mut erased_ops: HSet<Ptr<Operation>> = HSet::default();
 
     // Step 1: Recursively walk the operation tree to collect all dead operations
     walk_op(

--- a/src/opts/mem2reg.rs
+++ b/src/opts/mem2reg.rs
@@ -30,8 +30,8 @@ use crate::{
     pass::{AnalysisManager, Pass, PassResult},
     region::Region,
     result::Result,
-    std_deps::hash::{FxHashMap, FxHashSet, hash_map::Entry},
     r#type::TypeHandle,
+    utils::table::{HMap, HSet, IMap, ISet, htable},
     value::Value,
 };
 
@@ -200,15 +200,15 @@ fn prune_candidates(candidates: &mut Vec<AllocCandidate>, ctx: &Context) {
 fn compute_candidate_live_in_and_defining_blocks(
     ctx: &Context,
     cand: &AllocCandidate,
-) -> (FxHashSet<Ptr<BasicBlock>>, FxHashSet<Ptr<BasicBlock>>) {
+) -> (HSet<Ptr<BasicBlock>>, ISet<Ptr<BasicBlock>>) {
     let ptr = cand.alloc_info.ptr;
 
-    let mut defining_blocks: FxHashSet<Ptr<BasicBlock>> = FxHashSet::default();
-    let mut live_in: FxHashSet<Ptr<BasicBlock>> = FxHashSet::default();
+    let mut defining_blocks: ISet<Ptr<BasicBlock>> = ISet::default();
+    let mut live_in: HSet<Ptr<BasicBlock>> = HSet::default();
     let mut live_in_worklist: Vec<Ptr<BasicBlock>> = Vec::new();
 
     // Compute blocks that contain uses of this pointer.
-    let mut user_blocks: FxHashSet<Ptr<BasicBlock>> = FxHashSet::default();
+    let mut user_blocks: ISet<Ptr<BasicBlock>> = ISet::default();
     for u in ptr.uses(ctx) {
         if let Some(block) = u.user_op().deref(ctx).get_parent_block() {
             user_blocks.insert(block);
@@ -269,11 +269,11 @@ fn compute_candidate_live_in_and_defining_blocks(
 /// dominance frontier and keeps only blocks where the candidate is live-in.
 fn compute_candidate_phi_blocks(
     df_map: &DomFrontierMap<Ptr<Region>, Context>,
-    live_in: &FxHashSet<Ptr<BasicBlock>>,
-    defining_blocks: &FxHashSet<Ptr<BasicBlock>>,
-) -> FxHashSet<Ptr<BasicBlock>> {
+    live_in: &HSet<Ptr<BasicBlock>>,
+    defining_blocks: &ISet<Ptr<BasicBlock>>,
+) -> ISet<Ptr<BasicBlock>> {
     // Compute liveness-pruned IDF for this candidate.
-    let mut phi_blocks: FxHashSet<Ptr<BasicBlock>> = FxHashSet::default();
+    let mut phi_blocks: ISet<Ptr<BasicBlock>> = ISet::default();
     let mut worklist: Vec<Ptr<BasicBlock>> = defining_blocks.iter().cloned().collect();
     while let Some(block) = worklist.pop() {
         for &df_block in df_map.frontier(&block) {
@@ -303,10 +303,10 @@ fn compute_candidate_phi_blocks(
 fn prune_candidates_with_unknown_branch_from_pred(
     ctx: &Context,
     alloc_candidates: &mut Vec<AllocCandidate>,
-    phi_blocks: &mut FxHashMap<Value, FxHashSet<Ptr<BasicBlock>>>,
+    phi_blocks: &mut HMap<Value, ISet<Ptr<BasicBlock>>>,
 ) {
     // Track invalid individual candidates by their allocation pointer.
-    let mut invalid_ptrs: FxHashSet<Value> = FxHashSet::default();
+    let mut invalid_ptrs: HSet<Value> = HSet::default();
     for cand in alloc_candidates.iter() {
         let ptr = cand.alloc_info.ptr;
         let invalid = phi_blocks
@@ -333,11 +333,11 @@ fn prune_candidates_with_unknown_branch_from_pred(
 fn get_or_create_default_def(
     alloc_cand: &AllocCandidate,
     ctx: &mut Context,
-    default_defs: &mut FxHashMap<Value, Value>,
+    default_defs: &mut HMap<Value, Value>,
 ) -> Result<Value> {
     match default_defs.entry(alloc_cand.alloc_info.ptr) {
-        Entry::Occupied(entry) => Ok(*entry.get()),
-        Entry::Vacant(entry) => {
+        htable::Entry::Occupied(entry) => Ok(*entry.get()),
+        htable::Entry::Vacant(entry) => {
             let alloc_op = alloc_cand.alloc_op;
             let alloc_obj = Operation::get_op_dyn(alloc_op, ctx);
             let alloc_iface = op_cast::<dyn PromotableAllocationInterface>(alloc_obj.as_ref())
@@ -374,7 +374,7 @@ fn get_or_create_default_def(
 }
 
 /// Process the events in the recorder to note down erased operations.
-fn note_erased_ops(recorder: &mut Recorder, erased: &mut FxHashSet<Ptr<Operation>>) {
+fn note_erased_ops(recorder: &mut Recorder, erased: &mut HSet<Ptr<Operation>>) {
     for event in recorder.events.drain(..) {
         match event {
             RecorderEvent::ErasedOperation(op) => {
@@ -397,7 +397,7 @@ fn note_erased_ops(recorder: &mut Recorder, erased: &mut FxHashSet<Ptr<Operation
 }
 
 /// For each promotable allocation pointer, stores the current reaching definition.
-type ReachingDefMap = FxHashMap<Value, Option<Value>>;
+type ReachingDefMap = IMap<Value, Option<Value>>;
 
 /// Process one block during SSA rename for mem2reg.
 ///
@@ -407,9 +407,9 @@ type ReachingDefMap = FxHashMap<Value, Option<Value>>;
 fn process_rename_block(
     ctx: &mut Context,
     block: Ptr<BasicBlock>,
-    new_phis_in_block: &FxHashMap<Ptr<BasicBlock>, Vec<(AllocCandidate, usize)>>,
+    new_phis_in_block: &HMap<Ptr<BasicBlock>, Vec<(AllocCandidate, usize)>>,
     incoming_reaching_def_map: &ReachingDefMap,
-    default_def_map: &mut FxHashMap<Value, Value>,
+    default_def_map: &mut HMap<Value, Value>,
     alloc_candidates: &[AllocCandidate],
 ) -> Result<ReachingDefMap> {
     let mut reaching_def_map = incoming_reaching_def_map
@@ -423,7 +423,7 @@ fn process_rename_block(
                 stack
             })
         })
-        .collect::<FxHashMap<_, _>>();
+        .collect::<IMap<_, _>>();
 
     // Push phi args for this block.
     for &(ref cand, arg_idx) in new_phis_in_block.get(&block).into_iter().flatten() {
@@ -435,7 +435,7 @@ fn process_rename_block(
     }
 
     let ops: Vec<Ptr<Operation>> = block.deref(ctx).iter(ctx).collect();
-    let mut erased_ops = FxHashSet::default();
+    let mut erased_ops = HSet::default();
     for &op in &ops {
         if erased_ops.contains(&op) {
             continue;
@@ -520,9 +520,9 @@ fn rename_blocks(
     ctx: &mut Context,
     entry_block: Ptr<BasicBlock>,
     dom_tree: &DomTree<Ptr<Region>, Context>,
-    new_phis_in_block: &FxHashMap<Ptr<BasicBlock>, Vec<(AllocCandidate, usize)>>,
+    new_phis_in_block: &HMap<Ptr<BasicBlock>, Vec<(AllocCandidate, usize)>>,
     reaching_def_map: &ReachingDefMap,
-    default_def_map: &mut FxHashMap<Value, Value>,
+    default_def_map: &mut HMap<Value, Value>,
     alloc_candidates: &[AllocCandidate],
 ) -> Result<()> {
     type RenameWorkItem = (Ptr<BasicBlock>, Rc<ReachingDefMap>);
@@ -569,7 +569,7 @@ pub fn mem2reg(
     // Categorize by region for efficiency.
     // We process all candidates in a region together to amortize
     // the cost of computing dominator trees, frontiers, etc.
-    let mut by_region: FxHashMap<Ptr<Region>, Vec<AllocCandidate>> = FxHashMap::default();
+    let mut by_region: IMap<Ptr<Region>, Vec<AllocCandidate>> = IMap::default();
     for cand in candidates {
         let region = cand
             .alloc_op
@@ -588,7 +588,7 @@ pub fn mem2reg(
         let df_map = DomFrontierMap::new(ctx, &region, dom_tree);
 
         // Compute liveness and phi-placement per candidate.
-        let mut phi_blocks: FxHashMap<Value, FxHashSet<Ptr<BasicBlock>>> = FxHashMap::default();
+        let mut phi_blocks: HMap<Value, ISet<Ptr<BasicBlock>>> = HMap::default();
         for cand in alloc_candidates.iter() {
             let ptr = cand.alloc_info.ptr;
             let (live_in, defining_blocks) =
@@ -606,8 +606,8 @@ pub fn mem2reg(
         opt_status |= IRStatus::Changed;
 
         // Add block arguments for phis, record arg indices.
-        let mut new_phis_in_block: FxHashMap<Ptr<BasicBlock>, Vec<(AllocCandidate, usize)>> =
-            FxHashMap::default();
+        let mut new_phis_in_block: HMap<Ptr<BasicBlock>, Vec<(AllocCandidate, usize)>> =
+            HMap::default();
         for cand in alloc_candidates.iter() {
             let ptr = cand.alloc_info.ptr;
             if let Some(needed_blocks) = phi_blocks.get(&ptr) {
@@ -628,7 +628,7 @@ pub fn mem2reg(
             .iter()
             .map(|c| (c.alloc_info.ptr, None))
             .collect();
-        let mut default_def_map: FxHashMap<Value, Value> = FxHashMap::default();
+        let mut default_def_map: HMap<Value, Value> = HMap::default();
 
         // SSA rename via dominator tree walk, starting from the entry block.
         let entry_block = region
@@ -647,7 +647,7 @@ pub fn mem2reg(
 
         // "Promote" (remove) the allocations themselves. Group them into
         // a single promote call per alloc op and then invoke the interface method.
-        let mut alloc_op_to_infos: FxHashMap<Ptr<Operation>, Vec<AllocInfo>> = FxHashMap::default();
+        let mut alloc_op_to_infos: IMap<Ptr<Operation>, Vec<AllocInfo>> = IMap::default();
         let rewriter = &mut IRRewriter::default();
 
         for cand in alloc_candidates.iter() {
@@ -657,7 +657,7 @@ pub fn mem2reg(
                 .push(cand.alloc_info.clone());
         }
 
-        let mut erased_ops = FxHashSet::default();
+        let mut erased_ops = HSet::default();
         for (op, infos) in alloc_op_to_infos {
             if erased_ops.contains(&op) {
                 panic!("Alloc op was already erased during promotion of another candidate");

--- a/src/opts/simplify_cfg.rs
+++ b/src/opts/simplify_cfg.rs
@@ -44,7 +44,7 @@ use crate::{
     pass::{AnalysisManager, Pass, PassResult},
     region::Region,
     result::Result,
-    std_deps::hash::FxHashSet,
+    utils::table::{HSet, ISet},
     value::Value,
 };
 
@@ -192,7 +192,7 @@ pub fn remove_blocks_inside_region(
 
     let mut status = IRStatus::Unchanged;
     let mut stack: Vec<Ptr<BasicBlock>> = vec![entry];
-    let mut visited = FxHashSet::<Ptr<BasicBlock>>::default();
+    let mut visited = HSet::<Ptr<BasicBlock>>::default();
     while let Some(block) = stack.pop() {
         if !visited.insert(block) {
             continue;
@@ -205,7 +205,7 @@ pub fn remove_blocks_inside_region(
         }
     }
 
-    let dead_blocks: FxHashSet<Ptr<BasicBlock>> = region
+    let dead_blocks: ISet<Ptr<BasicBlock>> = region
         .deref(ctx)
         .iter(ctx)
         .filter(|b| !visited.contains(b))
@@ -278,7 +278,7 @@ pub fn merge_inside_region(
 
     let mut status = IRStatus::Unchanged;
     let mut stack: Vec<Ptr<BasicBlock>> = vec![entry];
-    let mut visited = FxHashSet::<Ptr<BasicBlock>>::default();
+    let mut visited = HSet::<Ptr<BasicBlock>>::default();
     while let Some(block) = stack.pop() {
         if !visited.insert(block) {
             continue;

--- a/src/parsable.rs
+++ b/src/parsable.rs
@@ -32,12 +32,10 @@ use crate::{
     op::op_impls,
     operation::Operation,
     result::{self, Result},
-    std_deps::{
-        fs::File,
-        hash::{FxHashMap, hash_map::Entry},
-        io::BufReader,
-        path::Path,
-        utf8_chars::BufReadCharsExt,
+    std_deps::{fs::File, io::BufReader, path::Path, utf8_chars::BufReadCharsExt},
+    utils::table::{
+        HMap,
+        itable::{Entry, IMap},
     },
     value::{DefiningEntity, Value},
 };
@@ -53,7 +51,7 @@ pub struct State<'a> {
     /// The [Source] from which the input is being read.
     pub src: Source,
     /// Aribtrary state data that different parsers may want to use.
-    pub aux_data: FxHashMap<Identifier, Box<dyn Any>>,
+    pub aux_data: HMap<Identifier, Box<dyn Any>>,
 }
 
 impl<'a> State<'a> {
@@ -63,7 +61,7 @@ impl<'a> State<'a> {
             ctx,
             name_tracker: NameTracker::default(),
             src,
-            aux_data: FxHashMap::default(),
+            aux_data: HMap::default(),
         }
     }
 }
@@ -397,8 +395,8 @@ impl LabelRef {
 /// Utility for parsing SSA names and block labels.
 #[derive(Default)]
 pub(crate) struct NameTracker {
-    ssa_name_scope: Vec<FxHashMap<Identifier, Value>>,
-    block_label_scope: Vec<FxHashMap<Identifier, LabelRef>>,
+    ssa_name_scope: Vec<IMap<Identifier, Value>>,
+    block_label_scope: Vec<IMap<Identifier, LabelRef>>,
 }
 
 #[derive(Error, Debug)]
@@ -537,14 +535,14 @@ impl NameTracker {
         if op_impls::<dyn IsolatedFromAboveInterface>(
             Operation::get_op_dyn(parent_op, ctx).as_ref(),
         ) {
-            self.ssa_name_scope.push(FxHashMap::default());
+            self.ssa_name_scope.push(IMap::default());
         } else if self.ssa_name_scope.is_empty() {
             input_err!(
                 parent_op.deref(ctx).loc(),
                 ParserNameTrackerError::TopLevelOpRegionNotIsolatedFromAbove
             )?
         }
-        self.block_label_scope.push(FxHashMap::default());
+        self.block_label_scope.push(IMap::default());
         Ok(())
     }
 

--- a/src/pass.rs
+++ b/src/pass.rs
@@ -185,10 +185,12 @@ use crate::{
     std_deps::{
         self,
         fs::{create_dir_all, write},
-        hash::{FxHashMap, FxHashSet},
         path::PathBuf,
     },
-    utils::timer::Timer,
+    utils::{
+        table::{HMap, HSet, IMap},
+        timer::Timer,
+    },
 };
 
 #[derive(Default)]
@@ -200,7 +202,7 @@ use crate::{
 /// [IRStatus::Unchanged] implies all analyses are preserved.
 pub struct PassResult {
     pub ir_changed: IRStatus,
-    preserved_analyses: FxHashSet<core::any::TypeId>,
+    preserved_analyses: HSet<core::any::TypeId>,
 }
 
 impl PassResult {
@@ -554,25 +556,25 @@ pub struct PMConfig {
     /// The directory is created (including parents) if it doesn't exist.
     pub ir_printing_dir: Option<PathBuf>,
     /// Set of pass names for which to print the IR before execution.
-    pub print_before: FxHashSet<String>,
+    pub print_before: HSet<String>,
     /// Set of pass names for which to print the IR after execution.
-    pub print_after: FxHashSet<String>,
+    pub print_after: HSet<String>,
     /// If true, verify the IR before running each pass.
     pub verify_before_all: bool,
     /// If true, verify the IR after running each pass.
     pub verify_after_all: bool,
     /// Set of pass names for which to verify the IR before execution.
-    pub verify_before: FxHashSet<String>,
+    pub verify_before: HSet<String>,
     /// Set of pass names for which to verify the IR after execution.
-    pub verify_after: FxHashSet<String>,
+    pub verify_after: HSet<String>,
     /// If true, time the execution of each pass.
     pub time_all_passes: bool,
     /// Set of pass names for which to time the execution.
-    pub time_passes: FxHashSet<String>,
+    pub time_passes: HSet<String>,
     /// Set of pass names to skip execution.
-    pub skip_passes: FxHashSet<String>,
+    pub skip_passes: HSet<String>,
     /// Custom configuration for extensibility.
-    pub custom_config: FxHashMap<Identifier, Box<dyn core::any::Any>>,
+    pub custom_config: HMap<Identifier, Box<dyn core::any::Any>>,
 }
 
 /// Internal state maintained across [PassManager]s.
@@ -582,9 +584,9 @@ pub struct PMState {
     /// Statistics reported by passes, keyed by pass name.
     /// These statistics are printed (as requested in [PMConfig])
     /// at the end of a pass.
-    pub stats: FxHashMap<&'static str, Box<dyn Printable>>,
+    pub stats: IMap<&'static str, Box<dyn Printable>>,
     /// Custom state for extensibility.
-    pub custom_state: FxHashMap<Identifier, Box<dyn core::any::Any>>,
+    pub custom_state: HMap<Identifier, Box<dyn core::any::Any>>,
     /// A count of the number of non-manager passes run so far
     pub pass_run_count: usize,
 }
@@ -642,7 +644,7 @@ pub struct AnalysisManager {
     /// Common data across [PassManager]s.
     pub pm_data: PMData,
     /// Cached analyses keyed by (TypeId of the analysis, Operation).
-    analyses: FxHashMap<AnalysisManagerKey, Box<RefCell<dyn Analysis>>>,
+    analyses: IMap<AnalysisManagerKey, Box<RefCell<dyn Analysis>>>,
 }
 
 impl AnalysisManager {
@@ -720,7 +722,7 @@ impl AnalysisManager {
     }
 
     /// Get a list of all analyses currently cached.
-    fn list_analyses(&self) -> FxHashSet<core::any::TypeId> {
+    fn list_analyses(&self) -> HSet<core::any::TypeId> {
         self.analyses.keys().map(|(type_id, _)| *type_id).collect()
     }
 

--- a/src/printable.rs
+++ b/src/printable.rs
@@ -10,9 +10,7 @@ use core::{
     fmt::{self, Display},
 };
 
-use crate::{
-    common_traits::RcShare, context::Context, identifier::Identifier, std_deps::hash::FxHashMap,
-};
+use crate::{common_traits::RcShare, context::Context, identifier::Identifier, utils::table::HMap};
 
 struct StateInner {
     // Number of spaces per indentation
@@ -20,7 +18,7 @@ struct StateInner {
     // Current indentation
     cur_indent: u16,
     // Aribtrary state data that different printers may want to use.
-    aux_data: FxHashMap<Identifier, Box<dyn Any>>,
+    aux_data: HMap<Identifier, Box<dyn Any>>,
 }
 
 impl Default for StateInner {
@@ -28,7 +26,7 @@ impl Default for StateInner {
         Self {
             indent_width: 2,
             cur_indent: 0,
-            aux_data: FxHashMap::default(),
+            aux_data: HMap::default(),
         }
     }
 }
@@ -73,13 +71,13 @@ impl State {
 
     /// Get a reference to the aux data table. The returned [Ref] is borrowed
     /// from the entire [State] object, so release it at the earliest.
-    pub fn aux_data_ref(&self) -> Ref<'_, FxHashMap<Identifier, Box<dyn Any>>> {
+    pub fn aux_data_ref(&self) -> Ref<'_, HMap<Identifier, Box<dyn Any>>> {
         Ref::map(self.0.borrow(), |inner| &inner.aux_data)
     }
 
     /// Get a mutable reference to the aux data table. The returned [RefMut] is borrowed
     /// from the entire [State] object, so release it at the earliest.
-    pub fn aux_data_mut(&self) -> RefMut<'_, FxHashMap<Identifier, Box<dyn Any>>> {
+    pub fn aux_data_mut(&self) -> RefMut<'_, HMap<Identifier, Box<dyn Any>>> {
         RefMut::map(self.0.borrow_mut(), |inner| &mut inner.aux_data)
     }
 }

--- a/src/storage_uniquer.rs
+++ b/src/storage_uniquer.rs
@@ -13,7 +13,10 @@ use core::{
 };
 use once_vec::OnceVec;
 
-use crate::std_deps::hash::{FxHashMap, FxHasher, hash_map::Entry};
+use crate::{
+    std_deps::hash::FxHasher,
+    utils::table::htable::{Entry, HMap},
+};
 
 /// Computes the hash of a rust value and its rust type.
 /// ```rust
@@ -60,7 +63,7 @@ pub(crate) struct UniqueStore<T: 'static> {
     /// The actual store, owning the objects.
     pub(crate) unique_store: OnceVec<T>,
     /// A hash index into the store.
-    unique_stores_map: RefCell<FxHashMap<TypeValueHash, Vec<usize>>>,
+    unique_stores_map: RefCell<HMap<TypeValueHash, Vec<usize>>>,
 }
 
 impl<T: 'static> Default for UniqueStore<T> {

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -28,7 +28,7 @@ use crate::{
     operation::Operation,
     printable::Printable,
     result::Result,
-    std_deps::hash::FxHashMap,
+    utils::table::HMap,
 };
 
 /// A utility to efficiently lookup and update [Symbol](SymbolOpInterface)s
@@ -37,7 +37,7 @@ use crate::{
 /// erase from the Operation given to it at construction.
 pub struct SymbolTable {
     symbol_table_op: Box<dyn SymbolTableInterface>,
-    symbol_table: FxHashMap<Identifier, Box<dyn SymbolOpInterface>>,
+    symbol_table: HMap<Identifier, Box<dyn SymbolOpInterface>>,
 }
 
 #[derive(Error, Debug)]
@@ -61,7 +61,7 @@ impl SymbolTable {
     /// Create a new [SymbolTable] from a [SymbolTableInterface] Op.
     pub fn new(ctx: &Context, symbol_table_op: Box<dyn SymbolTableInterface>) -> Self {
         // Go through the all operations in symbol_table_op and build a table.
-        let mut symbol_table = FxHashMap::<Identifier, Box<dyn SymbolOpInterface>>::default();
+        let mut symbol_table = HMap::<Identifier, Box<dyn SymbolOpInterface>>::default();
         let table_ops_block = symbol_table_op.get_body(ctx, 0);
         for op in table_ops_block.deref(ctx).iter(ctx) {
             if let Some(sym_op) =
@@ -236,7 +236,7 @@ pub fn walk_symbol_table<State>(
 /// See MLIR's [SymbolTableCollection](https://mlir.llvm.org/doxygen/classmlir_1_1SymbolTableCollection.html).
 #[derive(Default)]
 pub struct SymbolTableCollection {
-    symbol_tables: FxHashMap<Ptr<Operation>, SymbolTable>,
+    symbol_tables: HMap<Ptr<Operation>, SymbolTable>,
 }
 
 /// Returns the nearest symbol table from a given operation `from`

--- a/src/type.rs
+++ b/src/type.rs
@@ -51,9 +51,9 @@ use crate::{
     parsable::{Parsable, ParseResult, StateStream},
     printable::{self, Printable},
     result::{Error, Result},
-    std_deps::{hash::FxHashMap, sync::LazyLock},
+    std_deps::sync::LazyLock,
     storage_uniquer::TypeValueHash,
-    utils::trait_cast::impls_trait_static,
+    utils::{table::HMap, trait_cast::impls_trait_static},
 };
 
 use alloc::{
@@ -664,7 +664,7 @@ pub mod statics {
 /// A map from every [Type] to its ordered (as per interface deps) list of interface verifiers.
 /// An interface's super-interfaces are to be verified before it itself is.
 pub static TYPE_INTERFACE_VERIFIERS_MAP: LazyLock<
-    FxHashMap<core::any::TypeId, Vec<TypeInterfaceVerifier>>,
+    HMap<core::any::TypeId, Vec<TypeInterfaceVerifier>>,
 > = LazyLock::new(|| collect_deduped_interface_verifiers(statics::get_type_interface_verifiers()));
 
 /// A convenient struct to hold a type signature.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@
 pub mod apfloat;
 pub mod apint;
 pub mod const_bound_n;
+pub mod table;
 pub mod timer;
 pub mod trait_cast;
 pub mod union_find;

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -1,0 +1,672 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) The pliron contributors
+
+//! Two Kinds of Hash Tables.
+//!
+//! * [itable] Provides [IMap] and [ISet]. They provide all standard hash table operations,
+//!   with deterministic iteration.
+//! * [htable] Provides [HMap] and [HSet]. They provide all standard hash table operations,
+//!   except iteration.
+//!
+//! If iteration is not required, Use [htable] since it is faster and uses less memory.
+//!
+//! Currently [itable] is backed by [indexmap], and [htable] is backed by [hashbrown].
+//! They both use [rustc_hash::FxBuildHasher], a fast, non-cryptographic hash function.
+
+pub use htable::{HMap, HSet};
+pub use itable::{IMap, ISet};
+
+/// Hash table with deterministic iteration order.
+pub mod itable {
+    use rustc_hash::FxBuildHasher;
+
+    /// A hash map with a fast, non-cryptographic hasher and deterministic iteration order.
+    pub type IMap<K, V> = indexmap::IndexMap<K, V, FxBuildHasher>;
+
+    /// A hash set with a fast, non-cryptographic hasher and deterministic iteration order.
+    pub type ISet<T> = indexmap::IndexSet<T, FxBuildHasher>;
+
+    /// A view into a single entry of an [IMap], obtained via [IMap::entry].
+    pub use indexmap::map::Entry;
+}
+
+/// Hash table without iteration support.
+pub mod htable {
+    use core::{borrow::Borrow, fmt, hash::Hash};
+
+    use rustc_hash::FxBuildHasher;
+
+    /// A view into a single entry of an [HMap], obtained via [HMap::entry].
+    pub struct Entry<'a, K, V>(hashbrown::hash_map::Entry<'a, K, V, FxBuildHasher>);
+
+    impl<'a, K: Hash, V> Entry<'a, K, V> {
+        /// Ensure a value is present, inserting `default` if it wasn't.
+        pub fn or_insert(self, default: V) -> &'a mut V {
+            self.0.or_insert(default)
+        }
+
+        /// Ensure a value is present, inserting the result of calling
+        /// `default` if it wasn't.
+        pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+            self.0.or_insert_with(default)
+        }
+
+        /// Ensure a value is present, inserting `V::default()` if it wasn't.
+        pub fn or_default(self) -> &'a mut V
+        where
+            V: Default,
+        {
+            self.0.or_default()
+        }
+
+        /// Run `f` on the value if the entry is occupied, without changing
+        /// whether it's occupied.
+        pub fn and_modify<F: FnOnce(&mut V)>(self, f: F) -> Self {
+            Entry(self.0.and_modify(f))
+        }
+
+        /// The key this entry refers to.
+        pub fn key(&self) -> &K {
+            self.0.key()
+        }
+    }
+
+    /// A hash map with a fast, non-cryptographic hasher and no iteration support.
+    #[derive(Clone)]
+    pub struct HMap<K, V>(hashbrown::HashMap<K, V, FxBuildHasher>);
+
+    impl<K, V> Default for HMap<K, V> {
+        fn default() -> Self {
+            HMap(hashbrown::HashMap::default())
+        }
+    }
+
+    impl<K, V> HMap<K, V> {
+        /// Create an empty map.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Create an empty map with at least the given capacity.
+        pub fn with_capacity(capacity: usize) -> Self {
+            HMap(hashbrown::HashMap::with_capacity_and_hasher(
+                capacity,
+                FxBuildHasher,
+            ))
+        }
+
+        /// Number of entries in the map.
+        pub fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        /// Is the map empty?
+        pub fn is_empty(&self) -> bool {
+            self.0.is_empty()
+        }
+
+        /// Remove all entries, keeping the allocated capacity.
+        pub fn clear(&mut self) {
+            self.0.clear()
+        }
+
+        /// Number of entries the map can hold without reallocating.
+        pub fn capacity(&self) -> usize {
+            self.0.capacity()
+        }
+    }
+
+    impl<K: Eq + Hash, V> HMap<K, V> {
+        /// Reserve capacity for at least `additional` more entries.
+        pub fn reserve(&mut self, additional: usize) {
+            self.0.reserve(additional)
+        }
+
+        /// Shrink the map's capacity as much as possible.
+        pub fn shrink_to_fit(&mut self) {
+            self.0.shrink_to_fit()
+        }
+
+        /// Insert `value` for `key`, returning the previous value if any.
+        pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+            self.0.insert(key, value)
+        }
+
+        /// Look up the value for a key.
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.get(key)
+        }
+
+        /// Look up a mutable reference to the value for a key.
+        pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.get_mut(key)
+        }
+
+        /// Look up the stored key and value for a key.
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.get_key_value(key)
+        }
+
+        /// Does the map contain `key`?
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.contains_key(key)
+        }
+
+        /// Remove and return the value for `key`, if present.
+        pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.remove(key)
+        }
+
+        /// Remove and return the stored key and value for `key`, if present.
+        pub fn remove_entry<Q>(&mut self, key: &Q) -> Option<(K, V)>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.remove_entry(key)
+        }
+
+        /// Get the entry for `key`, for in-place insert/update.
+        pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
+            Entry(self.0.entry(key))
+        }
+
+        /// Keep only the entries for which `f` returns `true`.
+        ///
+        /// `f` is run once per entry, in an unspecified, platform-dependent
+        /// order; it must not rely on the order in which entries are
+        /// visited.
+        pub fn retain<F>(&mut self, f: F)
+        where
+            F: FnMut(&K, &mut V) -> bool,
+        {
+            self.0.retain(f)
+        }
+    }
+
+    impl<K: Eq + Hash, V> Extend<(K, V)> for HMap<K, V> {
+        fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+            self.0.extend(iter)
+        }
+    }
+
+    impl<K: Eq + Hash, V> FromIterator<(K, V)> for HMap<K, V> {
+        fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+            let mut map = HMap::default();
+            map.extend(iter);
+            map
+        }
+    }
+
+    impl<K: Eq + Hash, V: PartialEq> PartialEq for HMap<K, V> {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    impl<K: Eq + Hash, V: Eq> Eq for HMap<K, V> {}
+
+    impl<K, V> fmt::Debug for HMap<K, V> {
+        /// Prints only the entry count: printing contents would expose the
+        /// table's platform-dependent order.
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("HMap").field("len", &self.len()).finish()
+        }
+    }
+
+    /// A hash set with a fast, non-cryptographic hasher and no iteration support.
+    #[derive(Clone)]
+    pub struct HSet<T>(hashbrown::HashSet<T, FxBuildHasher>);
+
+    impl<T> Default for HSet<T> {
+        fn default() -> Self {
+            HSet(hashbrown::HashSet::default())
+        }
+    }
+
+    impl<T> HSet<T> {
+        /// Create an empty set.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Create an empty set with at least the given capacity.
+        pub fn with_capacity(capacity: usize) -> Self {
+            HSet(hashbrown::HashSet::with_capacity_and_hasher(
+                capacity,
+                FxBuildHasher,
+            ))
+        }
+
+        /// Number of elements in the set.
+        pub fn len(&self) -> usize {
+            self.0.len()
+        }
+
+        /// Is the set empty?
+        pub fn is_empty(&self) -> bool {
+            self.0.is_empty()
+        }
+
+        /// Remove all elements, keeping the allocated capacity.
+        pub fn clear(&mut self) {
+            self.0.clear()
+        }
+
+        /// Number of elements the set can hold without reallocating.
+        pub fn capacity(&self) -> usize {
+            self.0.capacity()
+        }
+    }
+
+    impl<T: Eq + Hash> HSet<T> {
+        /// Reserve capacity for at least `additional` more elements.
+        pub fn reserve(&mut self, additional: usize) {
+            self.0.reserve(additional)
+        }
+
+        /// Shrink the set's capacity as much as possible.
+        pub fn shrink_to_fit(&mut self) {
+            self.0.shrink_to_fit()
+        }
+
+        /// Insert `value`, returning whether it was newly inserted.
+        pub fn insert(&mut self, value: T) -> bool {
+            self.0.insert(value)
+        }
+
+        /// Does the set contain `value`?
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            T: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.contains(value)
+        }
+
+        /// Get a reference to the stored value equal to `value`, if present.
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            T: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.get(value)
+        }
+
+        /// Remove `value`, returning whether it was present.
+        pub fn remove<Q>(&mut self, value: &Q) -> bool
+        where
+            T: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.remove(value)
+        }
+
+        /// Remove and return the stored value equal to `value`, if present.
+        pub fn take<Q>(&mut self, value: &Q) -> Option<T>
+        where
+            T: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.0.take(value)
+        }
+
+        /// Insert `value`, returning the previously-stored equal value if any.
+        pub fn replace(&mut self, value: T) -> Option<T> {
+            self.0.replace(value)
+        }
+
+        /// Keep only the elements for which `f` returns `true`.
+        ///
+        /// `f` is run once per element, in an unspecified,
+        /// platform-dependent order; it must not rely on the order in
+        /// which elements are visited.
+        pub fn retain<F>(&mut self, f: F)
+        where
+            F: FnMut(&T) -> bool,
+        {
+            self.0.retain(f)
+        }
+
+        /// Are `self` and `other` disjoint (share no elements)?
+        pub fn is_disjoint(&self, other: &Self) -> bool {
+            self.0.is_disjoint(&other.0)
+        }
+
+        /// Is `self` a subset of `other`?
+        pub fn is_subset(&self, other: &Self) -> bool {
+            self.0.is_subset(&other.0)
+        }
+
+        /// Is `self` a superset of `other`?
+        pub fn is_superset(&self, other: &Self) -> bool {
+            self.0.is_superset(&other.0)
+        }
+    }
+
+    impl<T: Eq + Hash> Extend<T> for HSet<T> {
+        fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+            self.0.extend(iter)
+        }
+    }
+
+    impl<T: Eq + Hash> FromIterator<T> for HSet<T> {
+        fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+            let mut set = HSet::default();
+            set.extend(iter);
+            set
+        }
+    }
+
+    impl<T: Eq + Hash> PartialEq for HSet<T> {
+        fn eq(&self, other: &Self) -> bool {
+            self.0 == other.0
+        }
+    }
+
+    impl<T: Eq + Hash> Eq for HSet<T> {}
+
+    impl<T> fmt::Debug for HSet<T> {
+        /// Prints only the element count: printing contents would expose
+        /// the table's platform-dependent order.
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("HSet").field("len", &self.len()).finish()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod itable {
+        use crate::utils::table::itable::{IMap, ISet};
+        use alloc::{vec, vec::Vec};
+
+        #[test]
+        fn imap_preserves_insertion_order() {
+            let mut m = IMap::default();
+            m.insert("z", 1);
+            m.insert("a", 2);
+            m.insert("m", 3);
+            let keys: Vec<_> = m.keys().copied().collect();
+            assert_eq!(keys, vec!["z", "a", "m"]);
+            let values: Vec<_> = m.values().copied().collect();
+            assert_eq!(values, vec![1, 2, 3]);
+        }
+
+        #[test]
+        fn imap_reinsertion_keeps_original_position() {
+            let mut m = IMap::default();
+            m.insert("z", 1);
+            m.insert("a", 2);
+            m.insert("z", 10);
+            let keys: Vec<_> = m.keys().copied().collect();
+            assert_eq!(keys, vec!["z", "a"]);
+            assert_eq!(m["z"], 10);
+        }
+
+        #[test]
+        fn imap_shift_remove_preserves_order_of_remainder() {
+            let mut m: IMap<i32, &str> = IMap::default();
+            for i in [3, 1, 4, 15, 9] {
+                m.insert(i, "v");
+            }
+            m.shift_remove(&15);
+            let keys: Vec<_> = m.keys().copied().collect();
+            assert_eq!(keys, vec![3, 1, 4, 9]);
+        }
+
+        #[test]
+        fn imap_get_contains_len() {
+            let mut m = IMap::default();
+            assert!(m.is_empty());
+            m.insert(1, "one");
+            m.insert(2, "two");
+            assert_eq!(m.len(), 2);
+            assert!(m.contains_key(&1));
+            assert!(!m.contains_key(&3));
+            assert_eq!(m.get(&2), Some(&"two"));
+        }
+
+        #[test]
+        fn imap_entry_api() {
+            let mut m: IMap<&str, i32> = IMap::default();
+            *m.entry("a").or_insert(0) += 1;
+            *m.entry("a").or_insert(0) += 1;
+            *m.entry("b").or_insert(5) += 1;
+            assert_eq!(m["a"], 2);
+            assert_eq!(m["b"], 6);
+        }
+
+        #[test]
+        fn imap_from_iter_and_extend() {
+            let mut m: IMap<i32, i32> = [(1, 10), (2, 20)].into_iter().collect();
+            assert_eq!(m.get(&1), Some(&10));
+            m.extend([(3, 30)]);
+            let keys: Vec<_> = m.keys().copied().collect();
+            assert_eq!(keys, vec![1, 2, 3]);
+        }
+
+        #[test]
+        fn iset_preserves_insertion_order() {
+            let mut s = ISet::default();
+            s.insert("z");
+            s.insert("a");
+            s.insert("m");
+            s.insert("a"); // duplicate, no-op
+            let items: Vec<_> = s.iter().copied().collect();
+            assert_eq!(items, vec!["z", "a", "m"]);
+        }
+
+        #[test]
+        fn iset_contains_len_remove() {
+            let mut s: ISet<i32> = [1, 2, 3].into_iter().collect();
+            assert_eq!(s.len(), 3);
+            assert!(s.contains(&2));
+            s.shift_remove(&2);
+            assert!(!s.contains(&2));
+            let items: Vec<_> = s.iter().copied().collect();
+            assert_eq!(items, vec![1, 3]);
+        }
+    }
+
+    mod htable {
+        use crate::utils::table::htable::{HMap, HSet};
+
+        #[test]
+        fn hmap_insert_get_remove() {
+            let mut m = HMap::default();
+            assert!(m.is_empty());
+            assert_eq!(m.insert("a", 1), None);
+            assert_eq!(m.insert("a", 2), Some(1));
+            assert_eq!(m.get("a"), Some(&2));
+            assert_eq!(m.get("missing"), None);
+            assert!(m.contains_key("a"));
+            assert_eq!(m.len(), 1);
+            assert_eq!(m.remove("a"), Some(2));
+            assert!(m.is_empty());
+            assert_eq!(m.remove("a"), None);
+        }
+
+        #[test]
+        fn hmap_get_mut_and_key_value() {
+            let mut m = HMap::default();
+            m.insert("a", 1);
+            if let Some(v) = m.get_mut("a") {
+                *v += 41;
+            }
+            assert_eq!(m.get("a"), Some(&42));
+            assert_eq!(m.get_key_value("a"), Some((&"a", &42)));
+            assert_eq!(m.remove_entry("a"), Some(("a", 42)));
+        }
+
+        #[test]
+        fn hmap_entry_api() {
+            let mut m: HMap<&str, i32> = HMap::new();
+            *m.entry("a").or_insert(0) += 1;
+            *m.entry("a").or_insert(0) += 1;
+            m.entry("b").or_insert_with(|| 10);
+            m.entry("a").and_modify(|v| *v *= 100);
+            assert_eq!(m.get("a"), Some(&200));
+            assert_eq!(m.get("b"), Some(&10));
+
+            let mut counts: HMap<&str, i32> = HMap::default();
+            *counts.entry("x").or_default() += 1;
+            assert_eq!(counts.get("x"), Some(&1));
+        }
+
+        #[test]
+        fn hmap_clear_and_capacity() {
+            let mut m = HMap::with_capacity(16);
+            assert!(m.capacity() >= 16);
+            m.insert(1, "a");
+            m.insert(2, "b");
+            assert_eq!(m.len(), 2);
+            m.clear();
+            assert!(m.is_empty());
+            assert_eq!(m.len(), 0);
+        }
+
+        #[test]
+        fn hmap_retain() {
+            let mut m: HMap<i32, i32> = (0..10).map(|i| (i, i * i)).collect();
+            m.retain(|k, _| k % 2 == 0);
+            assert_eq!(m.len(), 5);
+            for k in 0..10 {
+                assert_eq!(m.contains_key(&k), k % 2 == 0);
+            }
+        }
+
+        #[test]
+        fn hmap_from_iter_extend_and_equality() {
+            let mut m1: HMap<i32, &str> = [(1, "one"), (2, "two")].into_iter().collect();
+            let mut m2 = HMap::default();
+            m2.insert(1, "one");
+            m2.insert(2, "two");
+            assert_eq!(m1, m2);
+
+            m1.extend([(3, "three")]);
+            assert_ne!(m1, m2);
+            m2.insert(3, "three");
+            assert_eq!(m1, m2);
+        }
+
+        #[test]
+        fn hmap_debug_does_not_panic_and_hides_contents() {
+            let mut m = HMap::default();
+            m.insert("secret-key", "secret-value");
+            let dbg = alloc::format!("{m:?}");
+            assert!(dbg.contains("len"));
+            assert!(!dbg.contains("secret-key"));
+            assert!(!dbg.contains("secret-value"));
+        }
+
+        #[test]
+        fn hset_insert_contains_remove() {
+            let mut s = HSet::default();
+            assert!(s.is_empty());
+            assert!(s.insert(1));
+            assert!(!s.insert(1));
+            assert!(s.contains(&1));
+            assert_eq!(s.len(), 1);
+            assert!(s.remove(&1));
+            assert!(s.is_empty());
+            assert!(!s.remove(&1));
+        }
+
+        #[test]
+        fn hset_take_replace_get() {
+            let mut s = HSet::default();
+            s.insert(1);
+            assert_eq!(s.get(&1), Some(&1));
+            assert_eq!(s.replace(1), Some(1));
+            assert_eq!(s.take(&1), Some(1));
+            assert!(s.is_empty());
+        }
+
+        #[test]
+        fn hset_retain() {
+            let mut s: HSet<i32> = (0..10).collect();
+            s.retain(|v| v % 2 == 0);
+            assert_eq!(s.len(), 5);
+            for v in 0..10 {
+                assert_eq!(s.contains(&v), v % 2 == 0);
+            }
+        }
+
+        #[test]
+        fn hset_relational_ops() {
+            let a: HSet<i32> = [1, 2, 3].into_iter().collect();
+            let b: HSet<i32> = [2, 3, 4].into_iter().collect();
+            let c: HSet<i32> = [1, 2].into_iter().collect();
+
+            assert!(!a.is_disjoint(&b));
+            assert!(a.is_disjoint(&HSet::from_iter([5, 6])));
+            assert!(c.is_subset(&a));
+            assert!(a.is_superset(&c));
+            assert!(!a.is_subset(&c));
+        }
+
+        #[test]
+        fn hset_from_iter_extend_and_equality() {
+            let mut s1: HSet<i32> = [1, 2].into_iter().collect();
+            let mut s2 = HSet::default();
+            s2.insert(1);
+            s2.insert(2);
+            assert_eq!(s1, s2);
+
+            s1.extend([3]);
+            assert_ne!(s1, s2);
+            s2.insert(3);
+            assert_eq!(s1, s2);
+        }
+
+        #[test]
+        fn hset_debug_does_not_panic_and_hides_contents() {
+            let mut s = HSet::default();
+            s.insert("secret-value");
+            let dbg = alloc::format!("{s:?}");
+            assert!(dbg.contains("len"));
+            assert!(!dbg.contains("secret-value"));
+        }
+
+        #[test]
+        fn hmap_clone_is_independent() {
+            let mut m1 = HMap::default();
+            m1.insert(1, "one");
+            let mut m2 = m1.clone();
+            m2.insert(2, "two");
+            assert_eq!(m1.len(), 1);
+            assert_eq!(m2.len(), 2);
+        }
+
+        #[test]
+        fn hset_clone_is_independent() {
+            let mut s1 = HSet::default();
+            s1.insert(1);
+            let mut s2 = s1.clone();
+            s2.insert(2);
+            assert_eq!(s1.len(), 1);
+            assert_eq!(s2.len(), 2);
+        }
+    }
+}

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -36,11 +36,15 @@ pub mod htable {
 
     use rustc_hash::FxBuildHasher;
 
-    /// A view into a single entry of an [HMap], obtained via [HMap::entry].
+    /// A view into a single entry in a map, which may either be vacant or
+    /// occupied.
+    ///
+    /// This `enum` is constructed from the [entry](HMap::entry) method on
+    /// [HMap].
     pub enum Entry<'a, K, V> {
-        /// The entry's key is present in the map.
+        /// An occupied entry.
         Occupied(OccupiedEntry<'a, K, V>),
-        /// The entry's key is absent from the map.
+        /// A vacant entry.
         Vacant(VacantEntry<'a, K, V>),
     }
 
@@ -63,18 +67,23 @@ pub mod htable {
     }
 
     impl<'a, K: Hash, V> Entry<'a, K, V> {
-        /// Ensure a value is present, inserting `default` if it wasn't.
+        /// Ensures a value is in the entry by inserting the default if
+        /// empty, and returns a mutable reference to the value in the
+        /// entry.
         pub fn or_insert(self, default: V) -> &'a mut V {
             hashbrown::hash_map::Entry::from(self).or_insert(default)
         }
 
-        /// Ensure a value is present, inserting the result of calling
-        /// `default` if it wasn't.
+        /// Ensures a value is in the entry by inserting the result of the
+        /// default function if empty, and returns a mutable reference to
+        /// the value in the entry.
         pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
             hashbrown::hash_map::Entry::from(self).or_insert_with(default)
         }
 
-        /// Ensure a value is present, inserting `V::default()` if it wasn't.
+        /// Ensures a value is in the entry by inserting the default value
+        /// if empty, and returns a mutable reference to the value in the
+        /// entry.
         pub fn or_default(self) -> &'a mut V
         where
             V: Default,
@@ -82,13 +91,13 @@ pub mod htable {
             hashbrown::hash_map::Entry::from(self).or_default()
         }
 
-        /// Run `f` on the value if the entry is occupied, without changing
-        /// whether it's occupied.
+        /// Provides in-place mutable access to an occupied entry before
+        /// any potential inserts into the map.
         pub fn and_modify<F: FnOnce(&mut V)>(self, f: F) -> Self {
             hashbrown::hash_map::Entry::from(self).and_modify(f).into()
         }
 
-        /// The key this entry refers to.
+        /// Returns a reference to this entry's key.
         pub fn key(&self) -> &K {
             match self {
                 Entry::Occupied(entry) => entry.key(),
@@ -97,58 +106,61 @@ pub mod htable {
         }
     }
 
-    /// A view into an occupied entry of an [HMap]. See [Entry::Occupied].
+    /// A view into an occupied entry in a [HMap].
     pub struct OccupiedEntry<'a, K, V>(hashbrown::hash_map::OccupiedEntry<'a, K, V, FxBuildHasher>);
 
     impl<'a, K, V> OccupiedEntry<'a, K, V> {
-        /// The key this entry refers to.
+        /// Gets a reference to the key in the entry.
         pub fn key(&self) -> &K {
             self.0.key()
         }
 
-        /// A reference to the entry's value.
+        /// Gets a reference to the value in the entry.
         pub fn get(&self) -> &V {
             self.0.get()
         }
 
-        /// A mutable reference to the entry's value.
+        /// Gets a mutable reference to the value in the entry.
         pub fn get_mut(&mut self) -> &mut V {
             self.0.get_mut()
         }
 
-        /// Convert into a mutable reference to the entry's value, tied to the
-        /// map's lifetime.
+        /// Converts the `OccupiedEntry` into a mutable reference to the
+        /// value in the entry with a lifetime bound to the map itself.
         pub fn into_mut(self) -> &'a mut V {
             self.0.into_mut()
         }
 
-        /// Replace the entry's value, returning the old one.
+        /// Sets the value of the entry, and returns the entry's old value.
         pub fn insert(&mut self, value: V) -> V {
             self.0.insert(value)
         }
 
-        /// Remove the entry, returning its value.
+        /// Takes the value out of the entry, and returns it. Keeps the
+        /// allocated memory for reuse.
         pub fn remove(self) -> V {
             self.0.remove()
         }
 
-        /// Remove the entry, returning its key and value.
+        /// Take the ownership of the key and value from the map. Keeps
+        /// the allocated memory for reuse.
         pub fn remove_entry(self) -> (K, V) {
             self.0.remove_entry()
         }
     }
 
-    /// A view into a vacant entry of an [HMap]. See [Entry::Vacant].
+    /// A view into a vacant entry in a [HMap].
     pub struct VacantEntry<'a, K, V>(hashbrown::hash_map::VacantEntry<'a, K, V, FxBuildHasher>);
 
     impl<'a, K, V> VacantEntry<'a, K, V> {
-        /// The key this entry would use if inserted into.
+        /// Gets a reference to the key that would be used when inserting a
+        /// value through the `VacantEntry`.
         pub fn key(&self) -> &K {
             self.0.key()
         }
 
-        /// Insert a value for this entry's key, returning a mutable
-        /// reference to it.
+        /// Sets the value of the entry with the `VacantEntry`'s key, and
+        /// returns a mutable reference to it.
         pub fn insert(self, value: V) -> &'a mut V
         where
             K: Hash,
@@ -168,12 +180,19 @@ pub mod htable {
     }
 
     impl<K, V> HMap<K, V> {
-        /// Create an empty map.
+        /// Creates an empty [HMap].
+        ///
+        /// The hash map is initially created with a capacity of 0, so it
+        /// will not allocate until it is first inserted into.
         pub fn new() -> Self {
             Self::default()
         }
 
-        /// Create an empty map with at least the given capacity.
+        /// Creates an empty [HMap] with the specified capacity.
+        ///
+        /// The hash map will be able to hold at least `capacity` elements
+        /// without reallocating. If `capacity` is 0, the hash map will not
+        /// allocate.
         pub fn with_capacity(capacity: usize) -> Self {
             HMap(hashbrown::HashMap::with_capacity_and_hasher(
                 capacity,
@@ -181,44 +200,65 @@ pub mod htable {
             ))
         }
 
-        /// Number of entries in the map.
+        /// Returns the number of elements in the map.
         pub fn len(&self) -> usize {
             self.0.len()
         }
 
-        /// Is the map empty?
+        /// Returns `true` if the map contains no elements.
         pub fn is_empty(&self) -> bool {
             self.0.is_empty()
         }
 
-        /// Remove all entries, keeping the allocated capacity.
+        /// Clears the map, removing all key-value pairs. Keeps the
+        /// allocated memory for reuse.
         pub fn clear(&mut self) {
             self.0.clear()
         }
 
-        /// Number of entries the map can hold without reallocating.
+        /// Returns the number of elements the map can hold without
+        /// reallocating.
+        ///
+        /// This number is a lower bound; the [HMap] might be able
+        /// to hold more, but is guaranteed to be able to hold at least this
+        /// many.
         pub fn capacity(&self) -> usize {
             self.0.capacity()
         }
     }
 
     impl<K: Eq + Hash, V> HMap<K, V> {
-        /// Reserve capacity for at least `additional` more entries.
+        /// Reserves capacity for at least `additional` more elements to be
+        /// inserted in the [HMap]. The collection may reserve more space
+        /// to avoid frequent reallocations.
         pub fn reserve(&mut self, additional: usize) {
             self.0.reserve(additional)
         }
 
-        /// Shrink the map's capacity as much as possible.
+        /// Shrinks the capacity of the map as much as possible. It will
+        /// drop down as much as possible while maintaining the internal
+        /// rules and possibly leaving some space in accordance with the
+        /// resize policy.
         pub fn shrink_to_fit(&mut self) {
             self.0.shrink_to_fit()
         }
 
-        /// Insert `value` for `key`, returning the previous value if any.
+        /// Inserts a key-value pair into the map.
+        ///
+        /// If the map did not have this key present, [None] is returned.
+        ///
+        /// If the map did have this key present, the value is updated, and
+        /// the old value is returned. The key is not updated, though; this
+        /// matters for types that can be `==` without being identical.
         pub fn insert(&mut self, key: K, value: V) -> Option<V> {
             self.0.insert(key, value)
         }
 
-        /// Look up the value for a key.
+        /// Returns a reference to the value corresponding to the key.
+        ///
+        /// The key may be any borrowed form of the map's key type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// key type.
         pub fn get<Q>(&self, key: &Q) -> Option<&V>
         where
             K: Borrow<Q>,
@@ -227,7 +267,12 @@ pub mod htable {
             self.0.get(key)
         }
 
-        /// Look up a mutable reference to the value for a key.
+        /// Returns a mutable reference to the value corresponding to the
+        /// key.
+        ///
+        /// The key may be any borrowed form of the map's key type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// key type.
         pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
         where
             K: Borrow<Q>,
@@ -236,7 +281,11 @@ pub mod htable {
             self.0.get_mut(key)
         }
 
-        /// Look up the stored key and value for a key.
+        /// Returns the key-value pair corresponding to the supplied key.
+        ///
+        /// The supplied key may be any borrowed form of the map's key type,
+        /// but [Hash] and [Eq] on the borrowed form *must* match those for
+        /// the key type.
         pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
         where
             K: Borrow<Q>,
@@ -245,7 +294,12 @@ pub mod htable {
             self.0.get_key_value(key)
         }
 
-        /// Does the map contain `key`?
+        /// Returns `true` if the map contains a value for the specified
+        /// key.
+        ///
+        /// The key may be any borrowed form of the map's key type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// key type.
         pub fn contains_key<Q>(&self, key: &Q) -> bool
         where
             K: Borrow<Q>,
@@ -254,7 +308,13 @@ pub mod htable {
             self.0.contains_key(key)
         }
 
-        /// Remove and return the value for `key`, if present.
+        /// Removes a key from the map, returning the value at the key if
+        /// the key was previously in the map. Keeps the allocated memory
+        /// for reuse.
+        ///
+        /// The key may be any borrowed form of the map's key type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// key type.
         pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
         where
             K: Borrow<Q>,
@@ -263,7 +323,13 @@ pub mod htable {
             self.0.remove(key)
         }
 
-        /// Remove and return the stored key and value for `key`, if present.
+        /// Removes a key from the map, returning the stored key and value
+        /// if the key was previously in the map. Keeps the allocated
+        /// memory for reuse.
+        ///
+        /// The key may be any borrowed form of the map's key type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// key type.
         pub fn remove_entry<Q>(&mut self, key: &Q) -> Option<(K, V)>
         where
             K: Borrow<Q>,
@@ -272,16 +338,18 @@ pub mod htable {
             self.0.remove_entry(key)
         }
 
-        /// Get the entry for `key`, for in-place insert/update.
+        /// Gets the given key's corresponding entry in the map for
+        /// in-place manipulation.
         pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
             self.0.entry(key).into()
         }
 
-        /// Keep only the entries for which `f` returns `true`.
+        /// Retains only the elements specified by the predicate. Keeps the
+        /// allocated memory for reuse.
         ///
-        /// `f` is run once per entry, in an unspecified, platform-dependent
-        /// order; it must not rely on the order in which entries are
-        /// visited.
+        /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut
+        /// v)` returns `false`. The elements are visited in unsorted (and
+        /// unspecified) order.
         pub fn retain<F>(&mut self, f: F)
         where
             F: FnMut(&K, &mut V) -> bool,
@@ -344,12 +412,19 @@ pub mod htable {
     }
 
     impl<T> HSet<T> {
-        /// Create an empty set.
+        /// Creates an empty [HSet].
+        ///
+        /// The hash set is initially created with a capacity of 0, so it
+        /// will not allocate until it is first inserted into.
         pub fn new() -> Self {
             Self::default()
         }
 
-        /// Create an empty set with at least the given capacity.
+        /// Creates an empty [HSet] with the specified capacity.
+        ///
+        /// The hash set will be able to hold at least `capacity` elements
+        /// without reallocating. If `capacity` is 0, the hash set will not
+        /// allocate.
         pub fn with_capacity(capacity: usize) -> Self {
             HSet(hashbrown::HashSet::with_capacity_and_hasher(
                 capacity,
@@ -357,44 +432,58 @@ pub mod htable {
             ))
         }
 
-        /// Number of elements in the set.
+        /// Returns the number of elements in the set.
         pub fn len(&self) -> usize {
             self.0.len()
         }
 
-        /// Is the set empty?
+        /// Returns `true` if the set contains no elements.
         pub fn is_empty(&self) -> bool {
             self.0.is_empty()
         }
 
-        /// Remove all elements, keeping the allocated capacity.
+        /// Clears the set, removing all values.
         pub fn clear(&mut self) {
             self.0.clear()
         }
 
-        /// Number of elements the set can hold without reallocating.
+        /// Returns the number of elements the set can hold without
+        /// reallocating.
         pub fn capacity(&self) -> usize {
             self.0.capacity()
         }
     }
 
     impl<T: Eq + Hash> HSet<T> {
-        /// Reserve capacity for at least `additional` more elements.
+        /// Reserves capacity for at least `additional` more elements to be
+        /// inserted in the [HSet]. The collection may reserve more
+        /// space to avoid frequent reallocations.
         pub fn reserve(&mut self, additional: usize) {
             self.0.reserve(additional)
         }
 
-        /// Shrink the set's capacity as much as possible.
+        /// Shrinks the capacity of the set as much as possible. It will
+        /// drop down as much as possible while maintaining the internal
+        /// rules and possibly leaving some space in accordance with the
+        /// resize policy.
         pub fn shrink_to_fit(&mut self) {
             self.0.shrink_to_fit()
         }
 
-        /// Insert `value`, returning whether it was newly inserted.
+        /// Adds a value to the set.
+        ///
+        /// If the set did not have this value present, `true` is returned.
+        ///
+        /// If the set did have this value present, `false` is returned.
         pub fn insert(&mut self, value: T) -> bool {
             self.0.insert(value)
         }
 
-        /// Does the set contain `value`?
+        /// Returns `true` if the set contains a value.
+        ///
+        /// The value may be any borrowed form of the set's value type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// value type.
         pub fn contains<Q>(&self, value: &Q) -> bool
         where
             T: Borrow<Q>,
@@ -403,7 +492,12 @@ pub mod htable {
             self.0.contains(value)
         }
 
-        /// Get a reference to the stored value equal to `value`, if present.
+        /// Returns a reference to the value in the set, if any, that is
+        /// equal to the given value.
+        ///
+        /// The value may be any borrowed form of the set's value type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// value type.
         pub fn get<Q>(&self, value: &Q) -> Option<&T>
         where
             T: Borrow<Q>,
@@ -412,7 +506,12 @@ pub mod htable {
             self.0.get(value)
         }
 
-        /// Remove `value`, returning whether it was present.
+        /// Removes a value from the set. Returns whether the value was
+        /// present in the set.
+        ///
+        /// The value may be any borrowed form of the set's value type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// value type.
         pub fn remove<Q>(&mut self, value: &Q) -> bool
         where
             T: Borrow<Q>,
@@ -421,7 +520,12 @@ pub mod htable {
             self.0.remove(value)
         }
 
-        /// Remove and return the stored value equal to `value`, if present.
+        /// Removes and returns the value in the set, if any, that is equal
+        /// to the given one.
+        ///
+        /// The value may be any borrowed form of the set's value type, but
+        /// [Hash] and [Eq] on the borrowed form *must* match those for the
+        /// value type.
         pub fn take<Q>(&mut self, value: &Q) -> Option<T>
         where
             T: Borrow<Q>,
@@ -430,16 +534,16 @@ pub mod htable {
             self.0.take(value)
         }
 
-        /// Insert `value`, returning the previously-stored equal value if any.
+        /// Adds a value to the set, replacing the existing value, if any,
+        /// that is equal to the given one. Returns the replaced value.
         pub fn replace(&mut self, value: T) -> Option<T> {
             self.0.replace(value)
         }
 
-        /// Keep only the elements for which `f` returns `true`.
+        /// Retains only the elements specified by the predicate.
         ///
-        /// `f` is run once per element, in an unspecified,
-        /// platform-dependent order; it must not rely on the order in
-        /// which elements are visited.
+        /// In other words, remove all elements `e` such that `f(&e)`
+        /// returns `false`.
         pub fn retain<F>(&mut self, f: F)
         where
             F: FnMut(&T) -> bool,
@@ -447,17 +551,21 @@ pub mod htable {
             self.0.retain(f)
         }
 
-        /// Are `self` and `other` disjoint (share no elements)?
+        /// Returns `true` if `self` has no elements in common with
+        /// `other`. This is equivalent to checking for an empty
+        /// intersection.
         pub fn is_disjoint(&self, other: &Self) -> bool {
             self.0.is_disjoint(&other.0)
         }
 
-        /// Is `self` a subset of `other`?
+        /// Returns `true` if the set is a subset of another, i.e., `other`
+        /// contains at least all the values in `self`.
         pub fn is_subset(&self, other: &Self) -> bool {
             self.0.is_subset(&other.0)
         }
 
-        /// Is `self` a superset of `other`?
+        /// Returns `true` if the set is a superset of another, i.e.,
+        /// `self` contains at least all the values in `other`.
         pub fn is_superset(&self, other: &Self) -> bool {
             self.0.is_superset(&other.0)
         }

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -8,10 +8,11 @@
 //! * [htable] Provides [HMap] and [HSet]. They provide all standard hash table operations,
 //!   except iteration.
 //!
+//! Both of these use [rustc_hash::FxBuildHasher], a fast, non-cryptographic hasher.
+//!
 //! If iteration is not required, Use [htable] since it is faster and uses less memory.
 //!
 //! Currently [itable] is backed by [indexmap], and [htable] is backed by [hashbrown].
-//! They both use [rustc_hash::FxBuildHasher], a fast, non-cryptographic hash function.
 
 pub use htable::{HMap, HSet};
 pub use itable::{IMap, ISet};

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -37,18 +37,41 @@ pub mod htable {
     use rustc_hash::FxBuildHasher;
 
     /// A view into a single entry of an [HMap], obtained via [HMap::entry].
-    pub struct Entry<'a, K, V>(hashbrown::hash_map::Entry<'a, K, V, FxBuildHasher>);
+    pub enum Entry<'a, K, V> {
+        /// The entry's key is present in the map.
+        Occupied(OccupiedEntry<'a, K, V>),
+        /// The entry's key is absent from the map.
+        Vacant(VacantEntry<'a, K, V>),
+    }
+
+    impl<'a, K, V> From<hashbrown::hash_map::Entry<'a, K, V, FxBuildHasher>> for Entry<'a, K, V> {
+        fn from(entry: hashbrown::hash_map::Entry<'a, K, V, FxBuildHasher>) -> Self {
+            match entry {
+                hashbrown::hash_map::Entry::Occupied(o) => Entry::Occupied(OccupiedEntry(o)),
+                hashbrown::hash_map::Entry::Vacant(v) => Entry::Vacant(VacantEntry(v)),
+            }
+        }
+    }
+
+    impl<'a, K, V> From<Entry<'a, K, V>> for hashbrown::hash_map::Entry<'a, K, V, FxBuildHasher> {
+        fn from(entry: Entry<'a, K, V>) -> Self {
+            match entry {
+                Entry::Occupied(o) => hashbrown::hash_map::Entry::Occupied(o.0),
+                Entry::Vacant(v) => hashbrown::hash_map::Entry::Vacant(v.0),
+            }
+        }
+    }
 
     impl<'a, K: Hash, V> Entry<'a, K, V> {
         /// Ensure a value is present, inserting `default` if it wasn't.
         pub fn or_insert(self, default: V) -> &'a mut V {
-            self.0.or_insert(default)
+            hashbrown::hash_map::Entry::from(self).or_insert(default)
         }
 
         /// Ensure a value is present, inserting the result of calling
         /// `default` if it wasn't.
         pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
-            self.0.or_insert_with(default)
+            hashbrown::hash_map::Entry::from(self).or_insert_with(default)
         }
 
         /// Ensure a value is present, inserting `V::default()` if it wasn't.
@@ -56,18 +79,81 @@ pub mod htable {
         where
             V: Default,
         {
-            self.0.or_default()
+            hashbrown::hash_map::Entry::from(self).or_default()
         }
 
         /// Run `f` on the value if the entry is occupied, without changing
         /// whether it's occupied.
         pub fn and_modify<F: FnOnce(&mut V)>(self, f: F) -> Self {
-            Entry(self.0.and_modify(f))
+            hashbrown::hash_map::Entry::from(self).and_modify(f).into()
         }
 
         /// The key this entry refers to.
         pub fn key(&self) -> &K {
+            match self {
+                Entry::Occupied(entry) => entry.key(),
+                Entry::Vacant(entry) => entry.key(),
+            }
+        }
+    }
+
+    /// A view into an occupied entry of an [HMap]. See [Entry::Occupied].
+    pub struct OccupiedEntry<'a, K, V>(hashbrown::hash_map::OccupiedEntry<'a, K, V, FxBuildHasher>);
+
+    impl<'a, K, V> OccupiedEntry<'a, K, V> {
+        /// The key this entry refers to.
+        pub fn key(&self) -> &K {
             self.0.key()
+        }
+
+        /// A reference to the entry's value.
+        pub fn get(&self) -> &V {
+            self.0.get()
+        }
+
+        /// A mutable reference to the entry's value.
+        pub fn get_mut(&mut self) -> &mut V {
+            self.0.get_mut()
+        }
+
+        /// Convert into a mutable reference to the entry's value, tied to the
+        /// map's lifetime.
+        pub fn into_mut(self) -> &'a mut V {
+            self.0.into_mut()
+        }
+
+        /// Replace the entry's value, returning the old one.
+        pub fn insert(&mut self, value: V) -> V {
+            self.0.insert(value)
+        }
+
+        /// Remove the entry, returning its value.
+        pub fn remove(self) -> V {
+            self.0.remove()
+        }
+
+        /// Remove the entry, returning its key and value.
+        pub fn remove_entry(self) -> (K, V) {
+            self.0.remove_entry()
+        }
+    }
+
+    /// A view into a vacant entry of an [HMap]. See [Entry::Vacant].
+    pub struct VacantEntry<'a, K, V>(hashbrown::hash_map::VacantEntry<'a, K, V, FxBuildHasher>);
+
+    impl<'a, K, V> VacantEntry<'a, K, V> {
+        /// The key this entry would use if inserted into.
+        pub fn key(&self) -> &K {
+            self.0.key()
+        }
+
+        /// Insert a value for this entry's key, returning a mutable
+        /// reference to it.
+        pub fn insert(self, value: V) -> &'a mut V
+        where
+            K: Hash,
+        {
+            self.0.insert(value)
         }
     }
 
@@ -188,7 +274,7 @@ pub mod htable {
 
         /// Get the entry for `key`, for in-place insert/update.
         pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
-            Entry(self.0.entry(key))
+            self.0.entry(key).into()
         }
 
         /// Keep only the entries for which `f` returns `true`.
@@ -201,6 +287,19 @@ pub mod htable {
             F: FnMut(&K, &mut V) -> bool,
         {
             self.0.retain(f)
+        }
+    }
+
+    impl<K: Eq + Hash, V, Q> core::ops::Index<&Q> for HMap<K, V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        type Output = V;
+
+        /// Look up the value for a key, panicking if it isn't present.
+        fn index(&self, key: &Q) -> &V {
+            self.get(key).expect("no entry found for key")
         }
     }
 
@@ -535,6 +634,30 @@ mod tests {
         }
 
         #[test]
+        fn hmap_entry_occupied_vacant_match() {
+            use crate::utils::table::htable::Entry;
+
+            let mut m: HMap<&str, i32> = HMap::default();
+            match m.entry("a") {
+                Entry::Occupied(_) => panic!("expected vacant entry"),
+                Entry::Vacant(v) => {
+                    assert_eq!(v.key(), &"a");
+                    v.insert(1);
+                }
+            }
+            match m.entry("a") {
+                Entry::Occupied(mut o) => {
+                    assert_eq!(o.key(), &"a");
+                    assert_eq!(o.get(), &1);
+                    assert_eq!(o.insert(2), 1);
+                    assert_eq!(o.remove(), 2);
+                }
+                Entry::Vacant(_) => panic!("expected occupied entry"),
+            }
+            assert!(m.is_empty());
+        }
+
+        #[test]
         fn hmap_clear_and_capacity() {
             let mut m = HMap::with_capacity(16);
             assert!(m.capacity() >= 16);
@@ -647,6 +770,20 @@ mod tests {
             let dbg = alloc::format!("{s:?}");
             assert!(dbg.contains("len"));
             assert!(!dbg.contains("secret-value"));
+        }
+
+        #[test]
+        fn hmap_index() {
+            let mut m = HMap::default();
+            m.insert("a", 1);
+            assert_eq!(m["a"], 1);
+        }
+
+        #[test]
+        #[should_panic]
+        fn hmap_index_missing_key_panics() {
+            let m: HMap<&str, i32> = HMap::default();
+            let _ = m["missing"];
         }
 
         #[test]

--- a/src/utils/trait_cast.rs
+++ b/src/utils/trait_cast.rs
@@ -10,7 +10,7 @@
 
 use core::any::{Any, TypeId};
 
-use crate::std_deps::{hash::FxHashMap, sync::LazyLock};
+use crate::{std_deps::sync::LazyLock, utils::table::HMap};
 
 /// Cast a [dyn Any](Any) object to a `dyn Trait` object for any
 /// trait that the contained (in [Any]) type implements, and for which
@@ -115,7 +115,7 @@ pub use statics::*;
 /// and the type_id of the trait to cast to. The map's values are
 /// the cast function pointers. This is used to avoid having to search
 /// through the distributed slice every time we want to cast an object.
-static TRAIT_CASTERS_MAP: LazyLock<FxHashMap<(TypeId, TypeId), &'static (dyn Any + Sync + Send)>> =
+static TRAIT_CASTERS_MAP: LazyLock<HMap<(TypeId, TypeId), &'static (dyn Any + Sync + Send)>> =
     LazyLock::new(|| {
         get_trait_casters()
             .map(|lazy| ((lazy.from, lazy.to), lazy.caster))

--- a/src/utils/union_find.rs
+++ b/src/utils/union_find.rs
@@ -6,7 +6,7 @@
 use alloc::{vec, vec::Vec};
 use core::hash::Hash;
 
-use crate::std_deps::hash::FxHashMap;
+use crate::utils::table::HMap;
 
 /// A union-find (disjoint-set) structure over values of type `T`.
 ///
@@ -16,16 +16,16 @@ use crate::std_deps::hash::FxHashMap;
 /// ([Self::set_members]) is O(set size).
 #[derive(Clone, Debug)]
 pub struct UnionFind<T: Eq + Hash + Clone> {
-    parent: FxHashMap<T, T>,
+    parent: HMap<T, T>,
     /// Members of each set, keyed by the set's representative.
-    members: FxHashMap<T, Vec<T>>,
+    members: HMap<T, Vec<T>>,
 }
 
 impl<T: Eq + Hash + Clone> Default for UnionFind<T> {
     fn default() -> Self {
         Self {
-            parent: FxHashMap::default(),
-            members: FxHashMap::default(),
+            parent: HMap::default(),
+            members: HMap::default(),
         }
     }
 }


### PR DESCRIPTION
Introduce

1. `HMap` / `HSet`: Wrapper around `hashbrown`'s `HashMap` / `HashSet` without exposing any iteration.
2. `IMap` / `ISet`: Type alias for `indexmap`'s `IndexMap` and `IndexSet`.

All using `rustc_hash::FxBuildHasher`.

This is a move towards ensure that the entire compiler produces deterministic outputs across platforms and versions. Any place where we need to iterate over a map / set will now use indexmap's map / set. Otherwise hashbrown's map / set is used (which can be slightly faster for non-iteration operations). Since the hashbrown wrappers don't expose any iteration API, no accidental iteration over them is possible.

This does not yet eliminate all uses of stdlib / hashbrown's map / set. They are still used inside `Value` and `AttributeDict` (with both places using iteration). That will be changed in a later work.