### PR TITLE
Add `SmallMap` and `SmallSet` and use it for `DefNode` and `AttributeDict`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ rustc_apfloat.workspace = true
 rustc-hash.workspace = true
 hashbrown.workspace = true
 indexmap.workspace = true
+smallvec.workspace = true
 thiserror.workspace = true
 combine.workspace = true
 log.workspace = true
@@ -79,6 +80,7 @@ prettyplease = "0"
 rustc-hash = "2"
 hashbrown = "0"
 indexmap = { version = "2", default-features = false }
+smallvec = { version = "1", default-features = false }
 combine = "4"
 thiserror = "2"
 tempfile = "3"

--- a/examples/kaleidoscope/from_ast.rs
+++ b/examples/kaleidoscope/from_ast.rs
@@ -30,7 +30,7 @@ use pliron::{
     location::Location,
     op::Op,
     result::Result,
-    std_deps::hash::FxHashMap,
+    utils::table::HMap,
     value::Value,
 };
 
@@ -47,7 +47,7 @@ use crate::{
 type OpInserter = IRInserter<DummyListener>;
 
 /// Maps variable names to the slot-pointer [`Value`] produced by their [`DeclOp`].
-type VarMap = FxHashMap<String, Value>;
+type VarMap = HMap<String, Value>;
 // ANCHOR_END: type_aliases
 
 // ─── Public API ─────────────────────────────────────────────────────────────

--- a/pliron-derive/Cargo.toml
+++ b/pliron-derive/Cargo.toml
@@ -18,6 +18,7 @@ proc-macro = true
 proc-macro2.workspace = true
 quote.workspace = true
 combine.workspace = true
+indexmap.workspace = true
 rustc-hash.workspace = true
 convert_case = "0.11"
 

--- a/pliron-derive/src/derive_format.rs
+++ b/pliron-derive/src/derive_format.rs
@@ -3,12 +3,14 @@
 
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, format_ident, quote};
-use rustc_hash::{FxHashMap, FxHashSet};
 use syn::{Data, DeriveInput, Generics, LitStr, Result, spanned::Spanned};
 
-use crate::irfmt::{
-    Directive, Elem, FieldIdent, FmtData, Format, Lit, UnnamedVar, Var, canonical_format_for_enums,
-    canonical_format_for_structs, canonical_op_format,
+use crate::{
+    IMap, ISet,
+    irfmt::{
+        Directive, Elem, FieldIdent, FmtData, Format, Lit, UnnamedVar, Var,
+        canonical_format_for_enums, canonical_format_for_structs, canonical_op_format,
+    },
 };
 
 /// Data parsed from the macro to derive formatting for Rust types
@@ -1070,13 +1072,13 @@ impl ParsableBuilder<()> for DeriveBaseParsable {}
 
 /// Specify various elements individually or all at once.
 enum ElementSpec<T> {
-    Individual(FxHashMap<T, syn::Ident>),
+    Individual(IMap<T, syn::Ident>),
     All(syn::Ident),
 }
 
 impl<T> Default for ElementSpec<T> {
     fn default() -> Self {
-        ElementSpec::Individual(FxHashMap::default())
+        ElementSpec::Individual(IMap::default())
     }
 }
 
@@ -1092,7 +1094,7 @@ struct OpParserState {
     operand_types: ElementSpec<usize>,
     result_types: ElementSpec<usize>,
     // The second element specifies attribtues that are specified as optional.
-    attributes: (ElementSpec<String>, FxHashSet<String>),
+    attributes: (ElementSpec<String>, ISet<String>),
     regions: ElementSpec<usize>,
 }
 

--- a/pliron-derive/src/lib.rs
+++ b/pliron-derive/src/lib.rs
@@ -15,6 +15,12 @@ use syn::parse_quote;
 
 use derive_format::DeriveIRObject;
 
+/// A hash map with a fast, non-cryptographic hasher and deterministic iteration order.
+type IMap<K, V> = indexmap::IndexMap<K, V, rustc_hash::FxBuildHasher>;
+
+/// A hash set with a fast, non-cryptographic hasher and deterministic iteration order.
+type ISet<T> = indexmap::IndexSet<T, rustc_hash::FxBuildHasher>;
+
 /// `#[def_attribute(...)]`: Annotate a Rust struct as a new IR attribute.
 ///
 /// *Note*: It is suggested to use the [pliron_attr] macro instead of using this macro directly.

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -63,8 +63,11 @@ use crate::{
     parsable::{Parsable, ParseResult, StateStream},
     printable::{self, Printable},
     result::Result,
-    std_deps::{hash::FxHashMap, sync::LazyLock},
-    utils::{table::HMap, trait_cast::impls_trait_static},
+    std_deps::sync::LazyLock,
+    utils::{
+        table::{HMap, SmallMap},
+        trait_cast::impls_trait_static,
+    },
 };
 
 /// Convenience type to easily print and parse key-value pairs in an [AttributeDict].
@@ -137,9 +140,11 @@ impl Parsable for AttributeDict {
     }
 }
 
+pub type AttributeDictContainer = SmallMap<Identifier, AttrObj, 1>;
+
 /// A dictionary of attributes, mapping keys to attribute objects.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct AttributeDict(pub FxHashMap<Identifier, AttrObj>);
+pub struct AttributeDict(pub AttributeDictContainer);
 
 impl AttributeDict {
     /// Get reference to attribute value that is mapped to key `k`.
@@ -173,13 +178,13 @@ impl AttributeDict {
                     Some((k.clone(), dyn_clone::clone_box(&**v)))
                 }
             })
-            .collect::<FxHashMap<Identifier, AttrObj>>()
+            .collect::<AttributeDictContainer>()
             .into()
     }
 }
 
-impl From<FxHashMap<Identifier, AttrObj>> for AttributeDict {
-    fn from(value: FxHashMap<Identifier, AttrObj>) -> Self {
+impl From<AttributeDictContainer> for AttributeDict {
+    fn from(value: AttributeDictContainer) -> Self {
         AttributeDict(value)
     }
 }

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -17,8 +17,7 @@ use crate::{
     operation::Operation,
     parsable::{Parsable, ParseResult, StateStream},
     printable::{self, Printable},
-    std_deps::hash::hash_map::Entry,
-    utils::vec_exns::VecExtns,
+    utils::{table::smalltable::Entry, vec_exns::VecExtns},
 };
 
 #[pliron_attr(name = "builtin.debug_info", verifier = "succ")]

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -509,10 +509,7 @@ mod tests {
     };
 
     use super::*;
-    use crate::{
-        graph::{ControlFlowGraph, HasLabel},
-        std_deps::hash::HashSet,
-    };
+    use crate::graph::{ControlFlowGraph, HasLabel};
 
     #[derive(Clone, Debug)]
     struct Node {
@@ -615,7 +612,7 @@ mod tests {
         assert_eq!(dom.idom(&2), Some(0));
         assert_eq!(dom.idom(&3), Some(0));
 
-        assert_eq!(dom.children(&0).collect::<HashSet<_>>(), [1, 2, 3].into());
+        assert_eq!(dom.children(&0).collect::<ISet<_>>(), [1, 2, 3].into());
         assert_eq!(dom.nearest_common_dominator(&1, &2), 0);
     }
 
@@ -643,10 +640,10 @@ mod tests {
         assert!(dom.dominates(&1, &3));
         assert!(!dom.dominates(&2, &3));
 
-        assert_eq!(dom.children(&0).collect::<HashSet<_>>(), [1].into());
-        assert_eq!(dom.children(&1).collect::<HashSet<_>>(), [2, 3].into());
-        assert_eq!(dom.children(&2).collect::<HashSet<_>>(), [].into());
-        assert_eq!(dom.children(&3).collect::<HashSet<_>>(), [].into());
+        assert_eq!(dom.children(&0).collect::<ISet<_>>(), [1].into());
+        assert_eq!(dom.children(&1).collect::<ISet<_>>(), [2, 3].into());
+        assert_eq!(dom.children(&2).collect::<ISet<_>>(), [].into());
+        assert_eq!(dom.children(&3).collect::<ISet<_>>(), [].into());
 
         assert_eq!(dom.nearest_common_dominator(&2, &3), 1);
         assert_eq!(dom.nearest_common_dominator(&3, &2), 1);
@@ -716,7 +713,7 @@ mod tests {
         assert_eq!(dom.idom(&8), Some(7));
         assert_eq!(dom.idom(&9), Some(7));
 
-        assert_eq!(dom.children(&3).collect::<HashSet<_>>(), [4, 5, 6].into());
+        assert_eq!(dom.children(&3).collect::<ISet<_>>(), [4, 5, 6].into());
     }
 
     #[test]
@@ -733,7 +730,7 @@ mod tests {
         assert_eq!(dom.idom(&0), None);
         assert_eq!(dom.idom(&1), Some(0));
 
-        assert_eq!(dom.children(&0).collect::<HashSet<_>>(), [1].into());
+        assert_eq!(dom.children(&0).collect::<ISet<_>>(), [1].into());
     }
 
     #[test]

--- a/src/graph/dominance.rs
+++ b/src/graph/dominance.rs
@@ -612,7 +612,10 @@ mod tests {
         assert_eq!(dom.idom(&2), Some(0));
         assert_eq!(dom.idom(&3), Some(0));
 
-        assert_eq!(dom.children(&0).collect::<ISet<_>>(), [1, 2, 3].into());
+        assert_eq!(
+            dom.children(&0).collect::<ISet<_>>(),
+            ISet::from_iter([1, 2, 3])
+        );
         assert_eq!(dom.nearest_common_dominator(&1, &2), 0);
     }
 
@@ -640,10 +643,13 @@ mod tests {
         assert!(dom.dominates(&1, &3));
         assert!(!dom.dominates(&2, &3));
 
-        assert_eq!(dom.children(&0).collect::<ISet<_>>(), [1].into());
-        assert_eq!(dom.children(&1).collect::<ISet<_>>(), [2, 3].into());
-        assert_eq!(dom.children(&2).collect::<ISet<_>>(), [].into());
-        assert_eq!(dom.children(&3).collect::<ISet<_>>(), [].into());
+        assert_eq!(dom.children(&0).collect::<ISet<_>>(), ISet::from_iter([1]));
+        assert_eq!(
+            dom.children(&1).collect::<ISet<_>>(),
+            ISet::from_iter([2, 3])
+        );
+        assert_eq!(dom.children(&2).collect::<ISet<_>>(), ISet::from_iter([]));
+        assert_eq!(dom.children(&3).collect::<ISet<_>>(), ISet::from_iter([]));
 
         assert_eq!(dom.nearest_common_dominator(&2, &3), 1);
         assert_eq!(dom.nearest_common_dominator(&3, &2), 1);
@@ -713,7 +719,10 @@ mod tests {
         assert_eq!(dom.idom(&8), Some(7));
         assert_eq!(dom.idom(&9), Some(7));
 
-        assert_eq!(dom.children(&3).collect::<ISet<_>>(), [4, 5, 6].into());
+        assert_eq!(
+            dom.children(&3).collect::<ISet<_>>(),
+            ISet::from_iter([4, 5, 6])
+        );
     }
 
     #[test]
@@ -730,7 +739,7 @@ mod tests {
         assert_eq!(dom.idom(&0), None);
         assert_eq!(dom.idom(&1), Some(0));
 
-        assert_eq!(dom.children(&0).collect::<ISet<_>>(), [1].into());
+        assert_eq!(dom.children(&0).collect::<ISet<_>>(), ISet::from_iter([1]));
     }
 
     #[test]

--- a/src/std_deps.rs
+++ b/src/std_deps.rs
@@ -33,13 +33,6 @@ mod r#impl {
         pub use std::time::Instant;
     }
 
-    pub mod hash {
-        pub use rustc_hash::FxHasher;
-        pub use std::collections::{HashMap, HashSet, hash_map, hash_set};
-        pub type FxHashMap<K, V> = HashMap<K, V, rustc_hash::FxBuildHasher>;
-        pub type FxHashSet<V> = HashSet<V, rustc_hash::FxBuildHasher>;
-    }
-
     pub mod utf8_chars {
         pub use utf8_chars::BufReadCharsExt;
     }
@@ -213,13 +206,6 @@ mod r#impl {
         }
     }
 
-    pub mod hash {
-        pub use hashbrown::{HashMap, HashSet, hash_map, hash_set};
-        pub use rustc_hash::FxHasher;
-        pub type FxHashMap<K, V> = HashMap<K, V, rustc_hash::FxBuildHasher>;
-        pub type FxHashSet<V> = HashSet<V, rustc_hash::FxBuildHasher>;
-    }
-
     pub mod utf8_chars {
         use core::fmt;
 
@@ -244,4 +230,4 @@ mod r#impl {
     }
 }
 
-pub use r#impl::{STD_ENABLED, backtrace, fs, hash, io, path, sync, time, utf8_chars};
+pub use r#impl::{STD_ENABLED, backtrace, fs, io, path, sync, time, utf8_chars};

--- a/src/storage_uniquer.rs
+++ b/src/storage_uniquer.rs
@@ -13,9 +13,9 @@ use core::{
 };
 use once_vec::OnceVec;
 
-use crate::{
-    std_deps::hash::FxHasher,
-    utils::table::htable::{Entry, HMap},
+use crate::utils::table::{
+    FxHasher,
+    htable::{Entry, HMap},
 };
 
 /// Computes the hash of a rust value and its rust type.

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -674,6 +674,17 @@ pub mod smalltable {
             }
         }
 
+        /// Retains only the elements specified by the predicate.
+        ///
+        /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut
+        /// v)` returns `false`.
+        pub fn retain<F: FnMut(&K, &mut V) -> bool>(&mut self, mut f: F) {
+            match &mut self.0 {
+                MapRepr::Inline(v) => v.retain(|(k, v)| f(k, v)),
+                MapRepr::Spilled(m) => m.retain(f),
+            }
+        }
+
         /// Returns an iterator over the map's key-value pairs.
         pub fn iter(&self) -> MapIter<'_, K, V> {
             match &self.0 {
@@ -1048,6 +1059,15 @@ pub mod smalltable {
         }
     }
 
+    impl<'a, K, V> Clone for MapIter<'a, K, V> {
+        fn clone(&self) -> Self {
+            match self {
+                MapIter::Inline(it) => MapIter::Inline(it.clone()),
+                MapIter::Spilled(it) => MapIter::Spilled(it.clone()),
+            }
+        }
+    }
+
     /// Mutable iterator over the key-value pairs of a [SmallMap]. See
     /// [SmallMap::iter_mut].
     pub enum MapIterMut<'a, K, V> {
@@ -1217,6 +1237,17 @@ pub mod smalltable {
             }
         }
 
+        /// Retains only the elements specified by the predicate.
+        ///
+        /// In other words, remove all values `v` such that `f(&v)` returns
+        /// `false`.
+        pub fn retain<F: FnMut(&T) -> bool>(&mut self, mut f: F) {
+            match &mut self.0 {
+                SetRepr::Inline(v) => v.retain(|v| f(v)),
+                SetRepr::Spilled(s) => s.retain(f),
+            }
+        }
+
         /// Returns an iterator over the set's elements.
         pub fn iter(&self) -> SetIter<'_, T> {
             match &self.0 {
@@ -1326,6 +1357,15 @@ pub mod smalltable {
             match self {
                 SetIter::Inline(it) => it.size_hint(),
                 SetIter::Spilled(it) => it.size_hint(),
+            }
+        }
+    }
+
+    impl<'a, T> Clone for SetIter<'a, T> {
+        fn clone(&self) -> Self {
+            match self {
+                SetIter::Inline(it) => SetIter::Inline(it.clone()),
+                SetIter::Spilled(it) => SetIter::Spilled(it.clone()),
             }
         }
     }
@@ -1883,6 +1923,32 @@ mod tests {
         }
 
         #[test]
+        fn smallmap_retain_inline_and_spilled() {
+            let mut m: SmallMap<i32, i32, 4> = SmallMap::new();
+            for i in 1..=3 {
+                m.insert(i, i * 10);
+            }
+            assert!(m.is_inline());
+            m.retain(|k, _| k % 2 == 1);
+            assert!(m.is_inline());
+            let mut keys: Vec<_> = m.keys().copied().collect();
+            keys.sort();
+            assert_eq!(keys, vec![1, 3]);
+
+            let mut m: SmallMap<i32, i32, 2> = SmallMap::new();
+            for i in 1..=4 {
+                m.insert(i, i * 10);
+            }
+            assert!(!m.is_inline());
+            m.retain(|k, _| k % 2 == 1);
+            // A promoted map stays promoted.
+            assert!(!m.is_inline());
+            let mut keys: Vec<_> = m.keys().copied().collect();
+            keys.sort();
+            assert_eq!(keys, vec![1, 3]);
+        }
+
+        #[test]
         fn smallmap_from_iter_and_extend() {
             let mut m: SmallMap<i32, i32, 2> = [(1, 10), (2, 20)].into_iter().collect();
             assert_eq!(m.get(&1), Some(&10));
@@ -1914,6 +1980,29 @@ mod tests {
             let mut pairs: Vec<_> = m.into_iter().collect();
             pairs.sort();
             assert_eq!(pairs, vec![(1, 2), (3, 10), (4, 17)]);
+        }
+
+        #[test]
+        fn smallmap_iter_is_clone() {
+            let m: SmallMap<i32, i32, 4> = [(3, 30), (1, 10), (4, 40)].into_iter().collect();
+            assert!(m.is_inline());
+            let it = m.iter();
+            let mut a: Vec<_> = it.clone().map(|(k, v)| (*k, *v)).collect();
+            let mut b: Vec<_> = it.map(|(k, v)| (*k, *v)).collect();
+            a.sort();
+            b.sort();
+            assert_eq!(a, vec![(1, 10), (3, 30), (4, 40)]);
+            assert_eq!(a, b);
+
+            let m: SmallMap<i32, i32, 2> = [(3, 30), (1, 10), (4, 40)].into_iter().collect();
+            assert!(!m.is_inline());
+            let it = m.iter();
+            let mut a: Vec<_> = it.clone().map(|(k, v)| (*k, *v)).collect();
+            let mut b: Vec<_> = it.map(|(k, v)| (*k, *v)).collect();
+            a.sort();
+            b.sort();
+            assert_eq!(a, vec![(1, 10), (3, 30), (4, 40)]);
+            assert_eq!(a, b);
         }
 
         #[test]
@@ -2000,6 +2089,26 @@ mod tests {
         }
 
         #[test]
+        fn smallset_retain_inline_and_spilled() {
+            let mut s: SmallSet<i32, 4> = [1, 2, 3].into_iter().collect();
+            assert!(s.is_inline());
+            s.retain(|v| v % 2 == 1);
+            assert!(s.is_inline());
+            let mut vals: Vec<_> = s.iter().copied().collect();
+            vals.sort();
+            assert_eq!(vals, vec![1, 3]);
+
+            let mut s: SmallSet<i32, 2> = [1, 2, 3, 4].into_iter().collect();
+            assert!(!s.is_inline());
+            s.retain(|v| v % 2 == 1);
+            // A promoted set stays promoted.
+            assert!(!s.is_inline());
+            let mut vals: Vec<_> = s.iter().copied().collect();
+            vals.sort();
+            assert_eq!(vals, vec![1, 3]);
+        }
+
+        #[test]
         fn smallset_get_and_contains() {
             let s: SmallSet<i32, 2> = [1, 2].into_iter().collect();
             assert_eq!(s.get(&1), Some(&1));
@@ -2031,6 +2140,29 @@ mod tests {
             let mut items: Vec<_> = s.into_iter().collect();
             items.sort();
             assert_eq!(items, vec![1, 3, 4]);
+        }
+
+        #[test]
+        fn smallset_iter_is_clone() {
+            let s: SmallSet<i32, 4> = [3, 1, 4].into_iter().collect();
+            assert!(s.is_inline());
+            let it = s.iter();
+            let mut a: Vec<_> = it.clone().copied().collect();
+            let mut b: Vec<_> = it.copied().collect();
+            a.sort();
+            b.sort();
+            assert_eq!(a, vec![1, 3, 4]);
+            assert_eq!(a, b);
+
+            let s: SmallSet<i32, 2> = [3, 1, 4].into_iter().collect();
+            assert!(!s.is_inline());
+            let it = s.iter();
+            let mut a: Vec<_> = it.clone().copied().collect();
+            let mut b: Vec<_> = it.copied().collect();
+            a.sort();
+            b.sort();
+            assert_eq!(a, vec![1, 3, 4]);
+            assert_eq!(a, b);
         }
 
         #[test]

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -1,21 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) The pliron contributors
 
-//! Two Kinds of Hash Tables.
+//! Hash Tables.
 //!
 //! * [itable] Provides [IMap] and [ISet]. They provide all standard hash table operations,
 //!   with deterministic iteration.
 //! * [htable] Provides [HMap] and [HSet]. They provide all standard hash table operations,
 //!   except iteration.
+//! * [smalltable] Provides [SmallMap] and [SmallSet], for tables that are usually small.
 //!
-//! Both of these use [rustc_hash::FxBuildHasher], a fast, non-cryptographic hasher.
+//! All of these use [rustc_hash::FxBuildHasher], a fast, non-cryptographic hasher.
 //!
-//! If iteration is not required, Use [htable] since it is faster and uses less memory.
+//! If iteration is not required, use [htable] since it is faster and uses less memory.
 //!
 //! Currently [itable] is backed by [indexmap], and [htable] is backed by [hashbrown].
 
 pub use htable::{HMap, HSet};
 pub use itable::{IMap, ISet};
+pub use smalltable::{SmallMap, SmallSet};
 
 /// Hash table with deterministic iteration order.
 pub mod itable {
@@ -603,6 +605,608 @@ pub mod htable {
     }
 }
 
+/// Hash table optimized for the common case of very few entries.
+pub mod smalltable {
+    use alloc::boxed::Box;
+    use core::{borrow::Borrow, fmt, hash::Hash, mem};
+
+    use rustc_hash::FxBuildHasher;
+    use smallvec::SmallVec;
+
+    use super::itable::{IMap, ISet};
+
+    /// Backing storage for a [SmallMap]: either up to `N` entries inline in
+    /// a flat, linearly-scanned array, or (once grown past `N` entries) a
+    /// heap-allocated [IMap].
+    enum MapRepr<K, V, const N: usize> {
+        Inline(SmallVec<[(K, V); N]>),
+        Spilled(Box<IMap<K, V>>),
+    }
+
+    /// A hash map, with a fast non-cryptographic hasher and deterministic
+    /// iteration order, optimized for the common case of very few entries.
+    ///
+    /// Up to `N` entries are stored inline, in a flat, linearly-scanned
+    /// array, with no heap allocation and no hashing. Once an insert
+    /// grows the map past `N` entries, it transparently and permanently
+    /// promotes itself to an [IMap]
+    pub struct SmallMap<K, V, const N: usize>(MapRepr<K, V, N>);
+
+    impl<K, V, const N: usize> Default for SmallMap<K, V, N> {
+        fn default() -> Self {
+            SmallMap(MapRepr::Inline(SmallVec::new()))
+        }
+    }
+
+    impl<K, V, const N: usize> SmallMap<K, V, N> {
+        /// Creates an empty [SmallMap]. Does not allocate until it grows
+        /// past `N` entries.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Returns `true` if this map has not (yet) grown past `N`
+        /// entries, i.e., is still using inline, non-heap-allocated
+        /// storage.
+        pub fn is_inline(&self) -> bool {
+            matches!(self.0, MapRepr::Inline(_))
+        }
+
+        /// Returns the number of elements in the map.
+        pub fn len(&self) -> usize {
+            match &self.0 {
+                MapRepr::Inline(v) => v.len(),
+                MapRepr::Spilled(m) => m.len(),
+            }
+        }
+
+        /// Returns `true` if the map contains no elements.
+        pub fn is_empty(&self) -> bool {
+            self.len() == 0
+        }
+
+        /// Clears the map, removing all key-value pairs. A previously
+        /// promoted map stays promoted; see the [SmallMap] documentation.
+        pub fn clear(&mut self) {
+            match &mut self.0 {
+                MapRepr::Inline(v) => v.clear(),
+                MapRepr::Spilled(m) => m.clear(),
+            }
+        }
+
+        /// Returns an iterator over the map's key-value pairs.
+        pub fn iter(&self) -> MapIter<'_, K, V> {
+            match &self.0 {
+                MapRepr::Inline(v) => MapIter::Inline(v.iter()),
+                MapRepr::Spilled(map) => MapIter::Spilled(map.iter()),
+            }
+        }
+
+        /// Returns a mutable iterator over the map's key-value pairs.
+        pub fn iter_mut(&mut self) -> MapIterMut<'_, K, V> {
+            match &mut self.0 {
+                MapRepr::Inline(v) => MapIterMut::Inline(v.iter_mut()),
+                MapRepr::Spilled(map) => MapIterMut::Spilled(map.iter_mut()),
+            }
+        }
+
+        /// Returns an iterator over the map's keys.
+        pub fn keys(&self) -> impl Iterator<Item = &K> + '_ {
+            self.iter().map(|(k, _)| k)
+        }
+
+        /// Returns an iterator over the map's values.
+        pub fn values(&self) -> impl Iterator<Item = &V> + '_ {
+            self.iter().map(|(_, v)| v)
+        }
+
+        /// Returns a mutable iterator over the map's values.
+        pub fn values_mut(&mut self) -> impl Iterator<Item = &mut V> + '_ {
+            self.iter_mut().map(|(_, v)| v)
+        }
+    }
+
+    impl<K: Hash + Eq, V, const N: usize> SmallMap<K, V, N> {
+        /// Moves from inline storage to a heap-allocated [IMap].
+        fn promote(inline: &mut SmallVec<[(K, V); N]>) -> Box<IMap<K, V>> {
+            let mut map = IMap::with_capacity_and_hasher(inline.len() + 1, FxBuildHasher);
+            for (k, v) in inline.drain(..) {
+                map.insert(k, v);
+            }
+            Box::new(map)
+        }
+
+        /// Inserts a key-value pair into the map.
+        ///
+        /// If the map did not have this key present, [None] is returned.
+        /// If the map did have this key present, the value is updated,
+        /// and the old value is returned. The key is not updated, though;
+        /// this matters for types that can be `==` without being
+        /// identical.
+        pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+            match &mut self.0 {
+                MapRepr::Inline(v) => {
+                    if let Some(i) = v.iter().position(|(k, _)| *k == key) {
+                        return Some(mem::replace(&mut v[i].1, value));
+                    }
+                    if v.len() < N {
+                        v.push((key, value));
+                        None
+                    } else {
+                        let mut map = Self::promote(v);
+                        let old = map.insert(key, value);
+                        self.0 = MapRepr::Spilled(map);
+                        old
+                    }
+                }
+                MapRepr::Spilled(map) => map.insert(key, value),
+            }
+        }
+
+        /// Returns a reference to the value corresponding to the key.
+        pub fn get<Q>(&self, key: &Q) -> Option<&V>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            match &self.0 {
+                MapRepr::Inline(v) => v.iter().find(|(k, _)| k.borrow() == key).map(|(_, v)| v),
+                MapRepr::Spilled(map) => map.get(key),
+            }
+        }
+
+        /// Returns a mutable reference to the value corresponding to the
+        /// key.
+        pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            match &mut self.0 {
+                MapRepr::Inline(v) => {
+                    let i = v.iter().position(|(k, _)| k.borrow() == key)?;
+                    Some(&mut v[i].1)
+                }
+                MapRepr::Spilled(map) => map.get_mut(key),
+            }
+        }
+
+        /// Returns the key-value pair corresponding to the supplied key.
+        pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            match &self.0 {
+                MapRepr::Inline(v) => v
+                    .iter()
+                    .find(|(k, _)| k.borrow() == key)
+                    .map(|(k, v)| (k, v)),
+                MapRepr::Spilled(map) => map.get_key_value(key),
+            }
+        }
+
+        /// Returns `true` if the map contains a value for the specified
+        /// key.
+        pub fn contains_key<Q>(&self, key: &Q) -> bool
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            self.get(key).is_some()
+        }
+
+        /// Removes a key from the map, returning the value at the key if
+        /// the key was previously in the map.
+        pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            match &mut self.0 {
+                MapRepr::Inline(v) => v
+                    .iter()
+                    .position(|(k, _)| k.borrow() == key)
+                    .map(|i| v.swap_remove(i).1),
+                MapRepr::Spilled(map) => map.swap_remove(key),
+            }
+        }
+    }
+
+    /// Iterator over the key-value pairs of a [SmallMap]. See
+    /// [SmallMap::iter].
+    pub enum MapIter<'a, K, V> {
+        Inline(core::slice::Iter<'a, (K, V)>),
+        Spilled(indexmap::map::Iter<'a, K, V>),
+    }
+
+    impl<'a, K, V> Iterator for MapIter<'a, K, V> {
+        type Item = (&'a K, &'a V);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self {
+                MapIter::Inline(it) => it.next().map(|(k, v)| (k, v)),
+                MapIter::Spilled(it) => it.next(),
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            match self {
+                MapIter::Inline(it) => it.size_hint(),
+                MapIter::Spilled(it) => it.size_hint(),
+            }
+        }
+    }
+
+    /// Mutable iterator over the key-value pairs of a [SmallMap]. See
+    /// [SmallMap::iter_mut].
+    pub enum MapIterMut<'a, K, V> {
+        Inline(core::slice::IterMut<'a, (K, V)>),
+        Spilled(indexmap::map::IterMut<'a, K, V>),
+    }
+
+    impl<'a, K, V> Iterator for MapIterMut<'a, K, V> {
+        type Item = (&'a K, &'a mut V);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self {
+                MapIterMut::Inline(it) => it.next().map(|(k, v)| (&*k, v)),
+                MapIterMut::Spilled(it) => it.next(),
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            match self {
+                MapIterMut::Inline(it) => it.size_hint(),
+                MapIterMut::Spilled(it) => it.size_hint(),
+            }
+        }
+    }
+
+    /// Owned iterator over the key-value pairs of a [SmallMap]. See
+    /// `IntoIterator for SmallMap`.
+    pub enum MapIntoIter<K, V, const N: usize> {
+        Inline(smallvec::IntoIter<[(K, V); N]>),
+        Spilled(indexmap::map::IntoIter<K, V>),
+    }
+
+    impl<K, V, const N: usize> Iterator for MapIntoIter<K, V, N> {
+        type Item = (K, V);
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self {
+                MapIntoIter::Inline(it) => it.next(),
+                MapIntoIter::Spilled(it) => it.next(),
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            match self {
+                MapIntoIter::Inline(it) => it.size_hint(),
+                MapIntoIter::Spilled(it) => it.size_hint(),
+            }
+        }
+    }
+
+    impl<K, V, const N: usize> IntoIterator for SmallMap<K, V, N> {
+        type Item = (K, V);
+        type IntoIter = MapIntoIter<K, V, N>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            match self.0 {
+                MapRepr::Inline(v) => MapIntoIter::Inline(v.into_iter()),
+                MapRepr::Spilled(map) => MapIntoIter::Spilled((*map).into_iter()),
+            }
+        }
+    }
+
+    impl<'a, K, V, const N: usize> IntoIterator for &'a SmallMap<K, V, N> {
+        type Item = (&'a K, &'a V);
+        type IntoIter = MapIter<'a, K, V>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter()
+        }
+    }
+
+    impl<K: Hash + Eq, V, const N: usize> Extend<(K, V)> for SmallMap<K, V, N> {
+        fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
+            for (k, v) in iter {
+                self.insert(k, v);
+            }
+        }
+    }
+
+    impl<K: Hash + Eq, V, const N: usize> FromIterator<(K, V)> for SmallMap<K, V, N> {
+        fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
+            let mut map = Self::default();
+            map.extend(iter);
+            map
+        }
+    }
+
+    impl<K: Hash + Eq, V: PartialEq, const N: usize> PartialEq for SmallMap<K, V, N> {
+        fn eq(&self, other: &Self) -> bool {
+            self.len() == other.len()
+                && self.iter().all(|(k, v)| other.get(k) == Some(v))
+        }
+    }
+
+    impl<K: Hash + Eq, V: Eq, const N: usize> Eq for SmallMap<K, V, N> {}
+
+    impl<K: fmt::Debug, V: fmt::Debug, const N: usize> fmt::Debug for SmallMap<K, V, N> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_map().entries(self.iter()).finish()
+        }
+    }
+
+    impl<K: Clone, V: Clone, const N: usize> Clone for SmallMap<K, V, N> {
+        fn clone(&self) -> Self {
+            match &self.0 {
+                MapRepr::Inline(v) => SmallMap(MapRepr::Inline(v.clone())),
+                MapRepr::Spilled(map) => SmallMap(MapRepr::Spilled(map.clone())),
+            }
+        }
+    }
+
+    /// Backing storage for a [SmallSet]: either up to `N` elements inline
+    /// in a flat, linearly-scanned array, or (once grown past `N`
+    /// elements) a heap-allocated [ISet].
+    enum SetRepr<T, const N: usize> {
+        Inline(SmallVec<[T; N]>),
+        Spilled(Box<ISet<T>>),
+    }
+
+    /// A hash set, with a fast non-cryptographic hasher and deterministic
+    /// iteration order, optimized for the common case of very few elements.
+    ///
+    /// Up to `N` entries are stored inline, in a flat, linearly-scanned
+    /// array, with no heap allocation and no hashing. Once an insert
+    /// grows the set past `N` entries, it transparently and permanently
+    /// promotes itself to an [ISet]
+    pub struct SmallSet<T, const N: usize>(SetRepr<T, N>);
+
+    impl<T, const N: usize> Default for SmallSet<T, N> {
+        fn default() -> Self {
+            SmallSet(SetRepr::Inline(SmallVec::new()))
+        }
+    }
+
+    impl<T, const N: usize> SmallSet<T, N> {
+        /// Creates an empty [SmallSet]. Does not allocate until it grows
+        /// past `N` elements.
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        /// Returns `true` if this set has not (yet) grown past `N`
+        /// elements, i.e., is still using inline, non-heap-allocated
+        /// storage.
+        pub fn is_inline(&self) -> bool {
+            matches!(self.0, SetRepr::Inline(_))
+        }
+
+        /// Returns the number of elements in the set.
+        pub fn len(&self) -> usize {
+            match &self.0 {
+                SetRepr::Inline(v) => v.len(),
+                SetRepr::Spilled(s) => s.len(),
+            }
+        }
+
+        /// Returns `true` if the set contains no elements.
+        pub fn is_empty(&self) -> bool {
+            self.len() == 0
+        }
+
+        /// Clears the set, removing all values. A previously promoted set
+        /// stays promoted; see the [SmallMap] documentation.
+        pub fn clear(&mut self) {
+            match &mut self.0 {
+                SetRepr::Inline(v) => v.clear(),
+                SetRepr::Spilled(s) => s.clear(),
+            }
+        }
+
+        /// Returns an iterator over the set's elements.
+        pub fn iter(&self) -> SetIter<'_, T> {
+            match &self.0 {
+                SetRepr::Inline(v) => SetIter::Inline(v.iter()),
+                SetRepr::Spilled(set) => SetIter::Spilled(set.iter()),
+            }
+        }
+    }
+
+    impl<T: Hash + Eq, const N: usize> SmallSet<T, N> {
+        /// Moves from inline storage to a heap-allocated [ISet].
+        fn promote(inline: &mut SmallVec<[T; N]>) -> Box<ISet<T>> {
+            let mut set = ISet::with_capacity_and_hasher(inline.len() + 1, FxBuildHasher);
+            for v in inline.drain(..) {
+                set.insert(v);
+            }
+            Box::new(set)
+        }
+
+        /// Adds a value to the set.
+        ///
+        /// If the set did not have this value present, `true` is
+        /// returned. If the set did have this value present, `false` is
+        /// returned.
+        pub fn insert(&mut self, value: T) -> bool {
+            match &mut self.0 {
+                SetRepr::Inline(v) => {
+                    if v.contains(&value) {
+                        return false;
+                    }
+                    if v.len() < N {
+                        v.push(value);
+                        true
+                    } else {
+                        let mut set = Self::promote(v);
+                        let inserted = set.insert(value);
+                        self.0 = SetRepr::Spilled(set);
+                        inserted
+                    }
+                }
+                SetRepr::Spilled(set) => set.insert(value),
+            }
+        }
+
+        /// Returns `true` if the set contains a value.
+        pub fn contains<Q>(&self, value: &Q) -> bool
+        where
+            T: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            match &self.0 {
+                SetRepr::Inline(v) => v.iter().any(|x| x.borrow() == value),
+                SetRepr::Spilled(set) => set.contains(value),
+            }
+        }
+
+        /// Returns a reference to the value in the set, if any, that is
+        /// equal to the given value.
+        pub fn get<Q>(&self, value: &Q) -> Option<&T>
+        where
+            T: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            match &self.0 {
+                SetRepr::Inline(v) => v.iter().find(|&x| x.borrow() == value),
+                SetRepr::Spilled(set) => set.get(value),
+            }
+        }
+
+        /// Removes a value from the set. Returns whether the value was
+        /// present.
+        pub fn remove<Q>(&mut self, value: &Q) -> bool
+        where
+            T: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            match &mut self.0 {
+                SetRepr::Inline(v) => match v.iter().position(|x| x.borrow() == value) {
+                    Some(i) => {
+                        v.swap_remove(i);
+                        true
+                    }
+                    None => false,
+                },
+                SetRepr::Spilled(set) => set.swap_remove(value),
+            }
+        }
+    }
+
+    /// Iterator over the elements of a [SmallSet]. See [SmallSet::iter].
+    pub enum SetIter<'a, T> {
+        Inline(core::slice::Iter<'a, T>),
+        Spilled(indexmap::set::Iter<'a, T>),
+    }
+
+    impl<'a, T> Iterator for SetIter<'a, T> {
+        type Item = &'a T;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self {
+                SetIter::Inline(it) => it.next(),
+                SetIter::Spilled(it) => it.next(),
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            match self {
+                SetIter::Inline(it) => it.size_hint(),
+                SetIter::Spilled(it) => it.size_hint(),
+            }
+        }
+    }
+
+    /// Owned iterator over the elements of a [SmallSet]. See
+    /// `IntoIterator for SmallSet`.
+    pub enum SetIntoIter<T, const N: usize> {
+        Inline(smallvec::IntoIter<[T; N]>),
+        Spilled(indexmap::set::IntoIter<T>),
+    }
+
+    impl<T, const N: usize> Iterator for SetIntoIter<T, N> {
+        type Item = T;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            match self {
+                SetIntoIter::Inline(it) => it.next(),
+                SetIntoIter::Spilled(it) => it.next(),
+            }
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            match self {
+                SetIntoIter::Inline(it) => it.size_hint(),
+                SetIntoIter::Spilled(it) => it.size_hint(),
+            }
+        }
+    }
+
+    impl<T, const N: usize> IntoIterator for SmallSet<T, N> {
+        type Item = T;
+        type IntoIter = SetIntoIter<T, N>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            match self.0 {
+                SetRepr::Inline(v) => SetIntoIter::Inline(v.into_iter()),
+                SetRepr::Spilled(set) => SetIntoIter::Spilled((*set).into_iter()),
+            }
+        }
+    }
+
+    impl<'a, T, const N: usize> IntoIterator for &'a SmallSet<T, N> {
+        type Item = &'a T;
+        type IntoIter = SetIter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter()
+        }
+    }
+
+    impl<T: Hash + Eq, const N: usize> Extend<T> for SmallSet<T, N> {
+        fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+            for v in iter {
+                self.insert(v);
+            }
+        }
+    }
+
+    impl<T: Hash + Eq, const N: usize> FromIterator<T> for SmallSet<T, N> {
+        fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+            let mut set = Self::default();
+            set.extend(iter);
+            set
+        }
+    }
+
+    impl<T: Hash + Eq, const N: usize> PartialEq for SmallSet<T, N> {
+        fn eq(&self, other: &Self) -> bool {
+            self.len() == other.len() && self.iter().all(|v| other.contains(v))
+        }
+    }
+
+    impl<T: Hash + Eq, const N: usize> Eq for SmallSet<T, N> {}
+
+    impl<T: fmt::Debug, const N: usize> fmt::Debug for SmallSet<T, N> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_set().entries(self.iter()).finish()
+        }
+    }
+
+    impl<T: Clone, const N: usize> Clone for SmallSet<T, N> {
+        fn clone(&self) -> Self {
+            match &self.0 {
+                SetRepr::Inline(v) => SmallSet(SetRepr::Inline(v.clone())),
+                SetRepr::Spilled(set) => SmallSet(SetRepr::Spilled(set.clone())),
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     mod itable {
@@ -908,6 +1512,291 @@ mod tests {
         #[test]
         fn hset_clone_is_independent() {
             let mut s1 = HSet::default();
+            s1.insert(1);
+            let mut s2 = s1.clone();
+            s2.insert(2);
+            assert_eq!(s1.len(), 1);
+            assert_eq!(s2.len(), 2);
+        }
+    }
+
+    mod smalltable {
+        use crate::utils::table::smalltable::{SmallMap, SmallSet};
+        use alloc::{vec, vec::Vec};
+
+        #[test]
+        fn smallmap_stays_inline_below_threshold() {
+            let mut m: SmallMap<i32, &str, 2> = SmallMap::new();
+            assert!(m.is_inline());
+            m.insert(1, "one");
+            assert!(m.is_inline());
+            m.insert(2, "two");
+            assert!(m.is_inline());
+            assert_eq!(m.len(), 2);
+        }
+
+        #[test]
+        fn smallmap_promotes_past_threshold() {
+            let mut m: SmallMap<i32, &str, 2> = SmallMap::new();
+            m.insert(1, "one");
+            m.insert(2, "two");
+            assert!(m.is_inline());
+            m.insert(3, "three");
+            assert!(!m.is_inline());
+            assert_eq!(m.len(), 3);
+            assert_eq!(m.get(&1), Some(&"one"));
+            assert_eq!(m.get(&2), Some(&"two"));
+            assert_eq!(m.get(&3), Some(&"three"));
+        }
+
+        #[test]
+        fn smallmap_stays_promoted_after_shrinking() {
+            let mut m: SmallMap<i32, i32, 2> = SmallMap::new();
+            m.insert(1, 1);
+            m.insert(2, 2);
+            m.insert(3, 3);
+            assert!(!m.is_inline());
+            m.remove(&3);
+            m.remove(&2);
+            assert_eq!(m.len(), 1);
+            assert!(!m.is_inline());
+        }
+
+        #[test]
+        fn smallmap_insert_overwrites_existing_key() {
+            let mut m: SmallMap<&str, i32, 2> = SmallMap::new();
+            assert_eq!(m.insert("a", 1), None);
+            assert_eq!(m.insert("a", 2), Some(1));
+            assert_eq!(m.get("a"), Some(&2));
+            assert_eq!(m.len(), 1);
+        }
+
+        #[test]
+        fn smallmap_get_mut_and_key_value() {
+            let mut m: SmallMap<&str, i32, 2> = SmallMap::new();
+            m.insert("a", 1);
+            if let Some(v) = m.get_mut("a") {
+                *v += 41;
+            }
+            assert_eq!(m.get("a"), Some(&42));
+            assert_eq!(m.get_key_value("a"), Some((&"a", &42)));
+            assert!(m.contains_key("a"));
+            assert!(!m.contains_key("missing"));
+        }
+
+        #[test]
+        fn smallmap_remove_inline_and_spilled() {
+            let mut m: SmallMap<i32, &str, 2> = SmallMap::new();
+            for i in [1, 2, 3] {
+                m.insert(i, "v");
+            }
+            assert!(!m.is_inline());
+            assert_eq!(m.remove(&1), Some("v"));
+            assert_eq!(m.remove(&1), None);
+            assert_eq!(m.len(), 2);
+
+            let mut m: SmallMap<i32, &str, 4> = SmallMap::new();
+            m.insert(1, "v");
+            assert!(m.is_inline());
+            assert_eq!(m.remove(&1), Some("v"));
+            assert!(m.is_empty());
+        }
+
+        #[test]
+        fn smallmap_from_iter_and_extend() {
+            let mut m: SmallMap<i32, i32, 2> = [(1, 10), (2, 20)].into_iter().collect();
+            assert_eq!(m.get(&1), Some(&10));
+            m.extend([(3, 30)]);
+            assert!(!m.is_inline());
+            let mut keys: Vec<_> = m.keys().copied().collect();
+            keys.sort();
+            assert_eq!(keys, vec![1, 2, 3]);
+        }
+
+        #[test]
+        fn smallmap_values_mut_and_into_iter() {
+            let mut m: SmallMap<i32, i32, 2> = SmallMap::new();
+            for i in [3, 1, 4] {
+                m.insert(i, i * i);
+            }
+            assert!(!m.is_inline());
+            for v in m.values_mut() {
+                *v += 1;
+            }
+            let mut values: Vec<_> = m.values().copied().collect();
+            values.sort();
+            assert_eq!(values, vec![2, 10, 17]);
+
+            let mut pairs: Vec<_> = (&m).into_iter().map(|(k, v)| (*k, *v)).collect();
+            pairs.sort();
+            assert_eq!(pairs, vec![(1, 2), (3, 10), (4, 17)]);
+
+            let mut pairs: Vec<_> = m.into_iter().collect();
+            pairs.sort();
+            assert_eq!(pairs, vec![(1, 2), (3, 10), (4, 17)]);
+        }
+
+        #[test]
+        fn smallmap_equality_ignores_inline_vs_spilled() {
+            let m1: SmallMap<i32, i32, 1> = [(1, 1), (2, 2)].into_iter().collect();
+            let m2: SmallMap<i32, i32, 4> = [(2, 2), (1, 1)].into_iter().collect();
+            assert!(!m1.is_inline());
+            assert!(m2.is_inline());
+            assert_eq!(m1.len(), m2.len());
+            assert!(m1.iter().all(|(k, v)| m2.get(k) == Some(v)));
+        }
+
+        #[test]
+        fn smallmap_debug_shows_contents() {
+            let mut m: SmallMap<&str, i32, 2> = SmallMap::new();
+            m.insert("a", 1);
+            let dbg = alloc::format!("{m:?}");
+            assert!(dbg.contains('a'));
+            assert!(dbg.contains('1'));
+        }
+
+        #[test]
+        fn smallmap_clone_is_independent() {
+            let mut m1: SmallMap<i32, i32, 2> = SmallMap::new();
+            m1.insert(1, 1);
+            let mut m2 = m1.clone();
+            m2.insert(2, 2);
+            assert_eq!(m1.len(), 1);
+            assert_eq!(m2.len(), 2);
+        }
+
+        #[test]
+        fn smallset_stays_inline_below_threshold() {
+            let mut s: SmallSet<i32, 2> = SmallSet::new();
+            assert!(s.is_inline());
+            s.insert(1);
+            s.insert(2);
+            assert!(s.is_inline());
+            assert_eq!(s.len(), 2);
+        }
+
+        #[test]
+        fn smallset_promotes_past_threshold() {
+            let mut s: SmallSet<i32, 2> = SmallSet::new();
+            s.insert(1);
+            s.insert(2);
+            assert!(s.is_inline());
+            s.insert(3);
+            assert!(!s.is_inline());
+            assert_eq!(s.len(), 3);
+            assert!(s.contains(&1));
+            assert!(s.contains(&2));
+            assert!(s.contains(&3));
+        }
+
+        #[test]
+        fn smallset_insert_duplicate_is_noop() {
+            let mut s: SmallSet<i32, 2> = SmallSet::new();
+            assert!(s.insert(1));
+            assert!(!s.insert(1));
+            assert_eq!(s.len(), 1);
+
+            let mut s: SmallSet<i32, 1> = SmallSet::new();
+            s.insert(1);
+            s.insert(2); // promotes
+            assert!(!s.is_inline());
+            assert!(!s.insert(1));
+            assert_eq!(s.len(), 2);
+        }
+
+        #[test]
+        fn smallset_remove_inline_and_spilled() {
+            let mut s: SmallSet<i32, 2> = [1, 2, 3].into_iter().collect();
+            assert!(!s.is_inline());
+            assert!(s.remove(&1));
+            assert!(!s.remove(&1));
+            assert_eq!(s.len(), 2);
+
+            let mut s: SmallSet<i32, 4> = SmallSet::new();
+            s.insert(1);
+            assert!(s.is_inline());
+            assert!(s.remove(&1));
+            assert!(s.is_empty());
+        }
+
+        #[test]
+        fn smallset_get_and_contains() {
+            let s: SmallSet<i32, 2> = [1, 2].into_iter().collect();
+            assert_eq!(s.get(&1), Some(&1));
+            assert_eq!(s.get(&3), None);
+            assert!(s.contains(&2));
+            assert!(!s.contains(&3));
+        }
+
+        #[test]
+        fn smallset_from_iter_and_extend() {
+            let mut s: SmallSet<i32, 2> = [1, 2].into_iter().collect();
+            assert!(s.is_inline());
+            s.extend([3]);
+            assert!(!s.is_inline());
+            let mut items: Vec<_> = s.iter().copied().collect();
+            items.sort();
+            assert_eq!(items, vec![1, 2, 3]);
+        }
+
+        #[test]
+        fn smallset_into_iter_owned_and_borrowed() {
+            let s: SmallSet<i32, 2> = [3, 1, 4].into_iter().collect();
+            assert!(!s.is_inline());
+
+            let mut items: Vec<_> = (&s).into_iter().copied().collect();
+            items.sort();
+            assert_eq!(items, vec![1, 3, 4]);
+
+            let mut items: Vec<_> = s.into_iter().collect();
+            items.sort();
+            assert_eq!(items, vec![1, 3, 4]);
+        }
+
+        #[test]
+        fn smallset_equality_ignores_inline_vs_spilled() {
+            let s1: SmallSet<i32, 1> = [1, 2].into_iter().collect();
+            let s2: SmallSet<i32, 4> = [2, 1].into_iter().collect();
+            assert!(!s1.is_inline());
+            assert!(s2.is_inline());
+            assert_eq!(s1.len(), s2.len());
+            assert!(s1.iter().all(|v| s2.contains(v)));
+        }
+
+        #[test]
+        fn smallset_partial_eq_same_n() {
+            let s1: SmallSet<i32, 4> = [1, 2, 3].into_iter().collect();
+            let mut s2: SmallSet<i32, 4> = SmallSet::new();
+            s2.insert(3);
+            s2.insert(2);
+            s2.insert(1);
+            assert_eq!(s1, s2);
+            s2.insert(4);
+            assert_ne!(s1, s2);
+        }
+
+        #[test]
+        fn smallmap_partial_eq_same_n() {
+            let m1: SmallMap<i32, i32, 4> = [(1, 1), (2, 2)].into_iter().collect();
+            let mut m2: SmallMap<i32, i32, 4> = SmallMap::new();
+            m2.insert(2, 2);
+            m2.insert(1, 1);
+            assert_eq!(m1, m2);
+            m2.insert(1, 99);
+            assert_ne!(m1, m2);
+        }
+
+        #[test]
+        fn smallset_debug_shows_contents() {
+            let mut s: SmallSet<&str, 2> = SmallSet::new();
+            s.insert("hello");
+            let dbg = alloc::format!("{s:?}");
+            assert!(dbg.contains("hello"));
+        }
+
+        #[test]
+        fn smallset_clone_is_independent() {
+            let mut s1: SmallSet<i32, 2> = SmallSet::new();
             s1.insert(1);
             let mut s2 = s1.clone();
             s2.insert(2);

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -17,6 +17,7 @@
 
 pub use htable::{HMap, HSet};
 pub use itable::{IMap, ISet};
+pub use rustc_hash::FxHasher;
 pub use smalltable::{SmallMap, SmallSet};
 
 /// Hash table with deterministic iteration order.

--- a/src/utils/table.rs
+++ b/src/utils/table.rs
@@ -811,6 +811,216 @@ pub mod smalltable {
                 MapRepr::Spilled(map) => map.swap_remove(key),
             }
         }
+
+        /// Gets the given key's corresponding entry in the map for
+        /// in-place manipulation.
+        pub fn entry(&mut self, key: K) -> Entry<'_, K, V, N> {
+            if let MapRepr::Inline(v) = &self.0 {
+                if let Some(index) = v.iter().position(|(k, _)| *k == key) {
+                    let MapRepr::Inline(v) = &mut self.0 else {
+                        unreachable!()
+                    };
+                    return Entry::Occupied(OccupiedEntry(OccupiedEntryRepr::Inline {
+                        vec: v,
+                        index,
+                    }));
+                }
+                return Entry::Vacant(VacantEntry(VacantEntryRepr::Inline {
+                    repr: &mut self.0,
+                    key,
+                }));
+            }
+            let MapRepr::Spilled(map) = &mut self.0 else {
+                unreachable!()
+            };
+            match map.entry(key) {
+                indexmap::map::Entry::Occupied(e) => {
+                    Entry::Occupied(OccupiedEntry(OccupiedEntryRepr::Spilled(e)))
+                }
+                indexmap::map::Entry::Vacant(e) => {
+                    Entry::Vacant(VacantEntry(VacantEntryRepr::Spilled(e)))
+                }
+            }
+        }
+    }
+
+    /// A view into a single entry in a [SmallMap], which may either be
+    /// vacant or occupied. Obtained via [SmallMap::entry].
+    pub enum Entry<'a, K, V, const N: usize> {
+        /// An occupied entry.
+        Occupied(OccupiedEntry<'a, K, V, N>),
+        /// A vacant entry.
+        Vacant(VacantEntry<'a, K, V, N>),
+    }
+
+    impl<'a, K, V, const N: usize> Entry<'a, K, V, N> {
+        /// Provides in-place mutable access to an occupied entry before
+        /// any potential inserts into the map.
+        pub fn and_modify<F: FnOnce(&mut V)>(self, f: F) -> Self {
+            match self {
+                Entry::Occupied(mut e) => {
+                    f(e.get_mut());
+                    Entry::Occupied(e)
+                }
+                Entry::Vacant(e) => Entry::Vacant(e),
+            }
+        }
+
+        /// Returns a reference to this entry's key.
+        pub fn key(&self) -> &K {
+            match self {
+                Entry::Occupied(e) => e.key(),
+                Entry::Vacant(e) => e.key(),
+            }
+        }
+    }
+
+    impl<'a, K: Hash + Eq, V, const N: usize> Entry<'a, K, V, N> {
+        /// Ensures a value is in the entry by inserting the default if
+        /// empty, and returns a mutable reference to the value in the
+        /// entry.
+        pub fn or_insert(self, default: V) -> &'a mut V {
+            match self {
+                Entry::Occupied(e) => e.into_mut(),
+                Entry::Vacant(e) => e.insert(default),
+            }
+        }
+
+        /// Ensures a value is in the entry by inserting the result of the
+        /// default function if empty, and returns a mutable reference to
+        /// the value in the entry.
+        pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
+            match self {
+                Entry::Occupied(e) => e.into_mut(),
+                Entry::Vacant(e) => e.insert(default()),
+            }
+        }
+
+        /// Ensures a value is in the entry by inserting the default value
+        /// if empty, and returns a mutable reference to the value in the
+        /// entry.
+        pub fn or_default(self) -> &'a mut V
+        where
+            V: Default,
+        {
+            self.or_insert_with(V::default)
+        }
+    }
+
+    enum OccupiedEntryRepr<'a, K, V, const N: usize> {
+        Inline {
+            vec: &'a mut SmallVec<[(K, V); N]>,
+            index: usize,
+        },
+        Spilled(indexmap::map::OccupiedEntry<'a, K, V>),
+    }
+
+    /// A view into an occupied entry in a [SmallMap].
+    pub struct OccupiedEntry<'a, K, V, const N: usize>(OccupiedEntryRepr<'a, K, V, N>);
+
+    impl<'a, K, V, const N: usize> OccupiedEntry<'a, K, V, N> {
+        /// Gets a reference to the key in the entry.
+        pub fn key(&self) -> &K {
+            match &self.0 {
+                OccupiedEntryRepr::Inline { vec, index } => &vec[*index].0,
+                OccupiedEntryRepr::Spilled(e) => e.key(),
+            }
+        }
+
+        /// Gets a reference to the value in the entry.
+        pub fn get(&self) -> &V {
+            match &self.0 {
+                OccupiedEntryRepr::Inline { vec, index } => &vec[*index].1,
+                OccupiedEntryRepr::Spilled(e) => e.get(),
+            }
+        }
+
+        /// Gets a mutable reference to the value in the entry.
+        pub fn get_mut(&mut self) -> &mut V {
+            match &mut self.0 {
+                OccupiedEntryRepr::Inline { vec, index } => &mut vec[*index].1,
+                OccupiedEntryRepr::Spilled(e) => e.get_mut(),
+            }
+        }
+
+        /// Converts the `OccupiedEntry` into a mutable reference to the
+        /// value in the entry with a lifetime bound to the map itself.
+        pub fn into_mut(self) -> &'a mut V {
+            match self.0 {
+                OccupiedEntryRepr::Inline { vec, index } => &mut vec[index].1,
+                OccupiedEntryRepr::Spilled(e) => e.into_mut(),
+            }
+        }
+
+        /// Sets the value of the entry, and returns the entry's old value.
+        pub fn insert(&mut self, value: V) -> V {
+            mem::replace(self.get_mut(), value)
+        }
+
+        /// Takes the value out of the entry, and returns it.
+        pub fn remove(self) -> V {
+            match self.0 {
+                OccupiedEntryRepr::Inline { vec, index } => vec.swap_remove(index).1,
+                OccupiedEntryRepr::Spilled(e) => e.swap_remove(),
+            }
+        }
+    }
+
+    enum VacantEntryRepr<'a, K, V, const N: usize> {
+        Inline {
+            repr: &'a mut MapRepr<K, V, N>,
+            key: K,
+        },
+        Spilled(indexmap::map::VacantEntry<'a, K, V>),
+    }
+
+    /// A view into a vacant entry in a [SmallMap].
+    pub struct VacantEntry<'a, K, V, const N: usize>(VacantEntryRepr<'a, K, V, N>);
+
+    impl<'a, K, V, const N: usize> VacantEntry<'a, K, V, N> {
+        /// Gets a reference to the key that would be used when inserting a
+        /// value through the `VacantEntry`.
+        pub fn key(&self) -> &K {
+            match &self.0 {
+                VacantEntryRepr::Inline { key, .. } => key,
+                VacantEntryRepr::Spilled(e) => e.key(),
+            }
+        }
+    }
+
+    impl<'a, K: Hash + Eq, V, const N: usize> VacantEntry<'a, K, V, N> {
+        /// Sets the value of the entry with the `VacantEntry`'s key, and
+        /// returns a mutable reference to it.
+        pub fn insert(self, value: V) -> &'a mut V {
+            match self.0 {
+                VacantEntryRepr::Inline { repr, key } => {
+                    let needs_promotion = match &*repr {
+                        MapRepr::Inline(v) => v.len() >= N,
+                        MapRepr::Spilled(_) => unreachable!(),
+                    };
+                    if !needs_promotion {
+                        let MapRepr::Inline(v) = repr else {
+                            unreachable!()
+                        };
+                        v.push((key, value));
+                        &mut v.last_mut().unwrap().1
+                    } else {
+                        let MapRepr::Inline(v) = &mut *repr else {
+                            unreachable!()
+                        };
+                        let mut map = SmallMap::<K, V, N>::promote(v);
+                        map.insert(key, value);
+                        *repr = MapRepr::Spilled(map);
+                        let MapRepr::Spilled(map) = repr else {
+                            unreachable!()
+                        };
+                        let index = map.len() - 1;
+                        map.get_index_mut(index).unwrap().1
+                    }
+                }
+                VacantEntryRepr::Spilled(e) => e.insert(value),
+            }
+        }
     }
 
     /// Iterator over the key-value pairs of a [SmallMap]. See
@@ -927,8 +1137,7 @@ pub mod smalltable {
 
     impl<K: Hash + Eq, V: PartialEq, const N: usize> PartialEq for SmallMap<K, V, N> {
         fn eq(&self, other: &Self) -> bool {
-            self.len() == other.len()
-                && self.iter().all(|(k, v)| other.get(k) == Some(v))
+            self.len() == other.len() && self.iter().all(|(k, v)| other.get(k) == Some(v))
         }
     }
 
@@ -1582,6 +1791,77 @@ mod tests {
             assert_eq!(m.get_key_value("a"), Some((&"a", &42)));
             assert!(m.contains_key("a"));
             assert!(!m.contains_key("missing"));
+        }
+
+        #[test]
+        fn smallmap_entry_api_inline() {
+            let mut m: SmallMap<&str, i32, 2> = SmallMap::new();
+            *m.entry("a").or_insert(0) += 1;
+            *m.entry("a").or_insert(0) += 1;
+            *m.entry("b").or_insert(5) += 1;
+            assert!(m.is_inline());
+            assert_eq!(m.get("a"), Some(&2));
+            assert_eq!(m.get("b"), Some(&6));
+
+            let mut counts: SmallMap<&str, i32, 2> = SmallMap::new();
+            *counts.entry("x").or_default() += 1;
+            assert_eq!(counts.get("x"), Some(&1));
+        }
+
+        #[test]
+        fn smallmap_entry_api_triggers_promotion() {
+            let mut m: SmallMap<i32, i32, 2> = SmallMap::new();
+            m.entry(1).or_insert(1);
+            m.entry(2).or_insert(2);
+            assert!(m.is_inline());
+            // A third distinct key should promote to the spilled repr.
+            *m.entry(3).or_insert(0) += 3;
+            assert!(!m.is_inline());
+            assert_eq!(m.get(&1), Some(&1));
+            assert_eq!(m.get(&2), Some(&2));
+            assert_eq!(m.get(&3), Some(&3));
+        }
+
+        #[test]
+        fn smallmap_entry_api_spilled() {
+            let mut m: SmallMap<i32, i32, 1> = [(1, 10), (2, 20)].into_iter().collect();
+            assert!(!m.is_inline());
+            *m.entry(1).or_insert(0) += 1;
+            m.entry(3).or_insert(30);
+            assert_eq!(m.get(&1), Some(&11));
+            assert_eq!(m.get(&3), Some(&30));
+        }
+
+        #[test]
+        fn smallmap_entry_and_modify() {
+            let mut m: SmallMap<&str, i32, 2> = SmallMap::new();
+            m.entry("a").and_modify(|v| *v += 1).or_insert(1);
+            m.entry("a").and_modify(|v| *v += 1).or_insert(1);
+            assert_eq!(m.get("a"), Some(&2));
+        }
+
+        #[test]
+        fn smallmap_entry_occupied_vacant_match() {
+            use crate::utils::table::smalltable::Entry;
+
+            let mut m: SmallMap<&str, i32, 2> = SmallMap::new();
+            match m.entry("a") {
+                Entry::Occupied(_) => panic!("expected vacant entry"),
+                Entry::Vacant(v) => {
+                    assert_eq!(v.key(), &"a");
+                    v.insert(1);
+                }
+            }
+            match m.entry("a") {
+                Entry::Occupied(mut o) => {
+                    assert_eq!(o.key(), &"a");
+                    assert_eq!(o.get(), &1);
+                    assert_eq!(o.insert(2), 1);
+                    assert_eq!(o.remove(), 2);
+                }
+                Entry::Vacant(_) => panic!("expected occupied entry"),
+            }
+            assert!(m.is_empty());
         }
 
         #[test]

--- a/src/utils/vec_exns.rs
+++ b/src/utils/vec_exns.rs
@@ -4,6 +4,7 @@
 //! Extend functionality of Rust vectors.
 
 use alloc::vec::Vec;
+use smallvec::{Array, SmallVec};
 
 /// This trait provides additionaly functionality for Rust vectors
 pub trait VecExtns<T> {
@@ -16,7 +17,7 @@ pub trait VecExtns<T> {
     fn push_back_with(&mut self, ctor: impl FnMut(usize) -> T) -> usize;
 
     /// Create and initialize a new vector.
-    fn new_init<U: FnMut(usize) -> T>(size: usize, initf: U) -> Vec<T>;
+    fn new_init<U: FnMut(usize) -> T>(size: usize, initf: U) -> Self;
 
     /// Grow the vector to the new size, initializing new elements with `initf`.
     fn grow_to(&mut self, new_size: usize, initf: impl FnMut(usize) -> T);
@@ -34,7 +35,7 @@ impl<T> VecExtns<T> for Vec<T> {
         idx
     }
 
-    fn new_init<U: FnMut(usize) -> T>(size: usize, mut initf: U) -> Vec<T> {
+    fn new_init<U: FnMut(usize) -> T>(size: usize, mut initf: U) -> Self {
         let mut v = Vec::<T>::with_capacity(size);
         for i in 0..size {
             v.push(initf(i));
@@ -43,6 +44,37 @@ impl<T> VecExtns<T> for Vec<T> {
     }
 
     fn grow_to(&mut self, new_size: usize, mut initf: impl FnMut(usize) -> T) {
+        let current_size = self.len();
+        if new_size > current_size {
+            self.reserve(new_size - current_size);
+            for i in current_size..new_size {
+                self.push(initf(i));
+            }
+        }
+    }
+}
+
+impl<A: Array> VecExtns<A::Item> for SmallVec<A> {
+    fn push_back(&mut self, t: A::Item) -> usize {
+        self.push(t);
+        self.len() - 1
+    }
+
+    fn push_back_with(&mut self, mut ctor: impl FnMut(usize) -> A::Item) -> usize {
+        let idx = self.len();
+        self.push(ctor(idx));
+        idx
+    }
+
+    fn new_init<U: FnMut(usize) -> A::Item>(size: usize, mut initf: U) -> Self {
+        let mut v = SmallVec::<A>::with_capacity(size);
+        for i in 0..size {
+            v.push(initf(i));
+        }
+        v
+    }
+
+    fn grow_to(&mut self, new_size: usize, mut initf: impl FnMut(usize) -> A::Item) {
         let current_size = self.len();
         if new_size > current_size {
             self.reserve(new_size - current_size);

--- a/src/value.rs
+++ b/src/value.rs
@@ -25,6 +25,7 @@ use crate::{
     result::Result,
     std_deps::hash::FxHashSet,
     r#type::{TypeHandle, Typed},
+    utils::table::SmallSet,
     verify_err, verify_error,
 };
 use alloc::{format, vec::Vec};
@@ -42,14 +43,14 @@ impl DefUseParticipant for Ptr<BasicBlock> {}
 /// A def node contains a list of its uses.
 pub(crate) struct DefNode<T: DefUseParticipant> {
     /// The list of uses of this Def.
-    uses: FxHashSet<Use<T>>,
+    uses: SmallSet<Use<T>, 1>,
 }
 
 impl<T: DefUseParticipant> DefNode<T> {
     /// Create a new definition.
     pub(crate) fn new() -> DefNode<T> {
         DefNode {
-            uses: FxHashSet::default(),
+            uses: SmallSet::default(),
         }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -23,7 +23,6 @@ use crate::{
     operation::{DefUseVerifyErr, Operation},
     printable::Printable,
     result::Result,
-    std_deps::hash::FxHashSet,
     r#type::{TypeHandle, Typed},
     utils::table::SmallSet,
     verify_err, verify_error,
@@ -239,7 +238,7 @@ impl Value {
         other: &Value,
     ) {
         // We collect because we don't want to keep the defnode locked up.
-        let touched_uses: FxHashSet<_> = self
+        let touched_uses: Vec<_> = self
             .get_defnode_ref(ctx)
             .uses
             .iter()
@@ -483,7 +482,7 @@ impl Ptr<BasicBlock> {
         };
 
         // We collect because we don't want to keep the defnode locked up.
-        let touched_uses: FxHashSet<_> = self
+        let touched_uses: Vec<_> = self
             .get_defnode_ref(ctx)
             .uses
             .iter()

--- a/tests/rewriter.rs
+++ b/tests/rewriter.rs
@@ -348,7 +348,7 @@ fn scoped_rewriter_test() -> Result<()> {
         builtin.module @bar 
         {
           ^block1v1():
-            v1 = test.global () [] [test_global_op_const_val: builtin.integer <0: si64>, sym_name: builtin.identifier global_0]: <() -> (test.ptr )>;
+            v1 = test.global () [] [sym_name: builtin.identifier global_0, test_global_op_const_val: builtin.integer <0: si64>]: <() -> (test.ptr )>;
             builtin.func @foo: builtin.function <() -> (builtin.integer si64)> 
             {
               ^entry_block2v1():


### PR DESCRIPTION
Based on benchmarking with https://github.com/pliron-org/mlir-pliron-bench.

I also tried replacing Operation results / operands, block args etc with `SmallVec`, but there was no performance gain, only increase in the size of each graph node.

While this also increases the size of `AttributeDict` (from 32 bytes to 56 bytes, and `DefNode` size remains the same at 32 bytes) it's still a clear improvement (~25%) in performance overall. We needed to use `IMap` (or `ISet`) for these two anyway for deterministic iteration (see #212) and this is a clear win.

Closes #140 