### PR TITLE
[pliron-llvm] Allow vector types for `fpext` and `fptrunc`

### DIFF
--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -3252,10 +3252,10 @@ impl Verify for FPTruncOp {
         if let Some(vec_ty) = opd_ty.downcast_ref::<VectorType>() {
             opd_ty = vec_ty.elem_type().deref(ctx);
         }
-
         let Some(opd_float_ty) = type_cast::<dyn FloatTypeInterface>(&*opd_ty) else {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
         };
+
         let mut res_ty = self.result_type(ctx).deref(ctx);
         if let Some(vec_ty) = res_ty.downcast_ref::<VectorType>() {
             res_ty = vec_ty.elem_type().deref(ctx);

--- a/pliron-llvm/src/ops.rs
+++ b/pliron-llvm/src/ops.rs
@@ -3161,11 +3161,18 @@ pub struct FPExtOp;
 impl Verify for FPExtOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
         // Check operand type to be a float
-        let opd_ty = OneOpdInterface::operand_type(self, ctx).deref(ctx);
+        let mut opd_ty = self.operand_type(ctx).deref(ctx);
+        if let Some(vec_ty) = opd_ty.downcast_ref::<VectorType>() {
+            opd_ty = vec_ty.elem_type().deref(ctx);
+        }
         let Some(opd_float_ty) = type_cast::<dyn FloatTypeInterface>(&*opd_ty) else {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
         };
-        let res_ty = OneResultInterface::result_type(self, ctx).deref(ctx);
+
+        let mut res_ty = self.result_type(ctx).deref(ctx);
+        if let Some(vec_ty) = res_ty.downcast_ref::<VectorType>() {
+            res_ty = vec_ty.elem_type().deref(ctx);
+        }
         let Some(res_float_ty) = type_cast::<dyn FloatTypeInterface>(&*res_ty) else {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
         };
@@ -3226,11 +3233,11 @@ impl Verify for TruncOp {
 /// ### Operands
 /// | operand | description |
 /// |-----|-------|
-/// | `arg` | Floating-point number |
+/// | `arg` | float or vector of float |
 /// ### Result(s):
 /// | result | description |
 /// |-----|-------|
-/// | `res` | Floating-point number |
+/// | `res` | float or vector of float |
 #[pliron_op(
     name = "llvm.fptrunc",
     format = "attr($llvm_fast_math_flags, $FastmathFlagsAttr) ` ` $0 ` to ` type($0)",
@@ -3241,11 +3248,18 @@ pub struct FPTruncOp;
 impl Verify for FPTruncOp {
     fn verify(&self, ctx: &Context) -> Result<()> {
         // Check operand type to be a float
-        let opd_ty = OneOpdInterface::operand_type(self, ctx).deref(ctx);
+        let mut opd_ty = self.operand_type(ctx).deref(ctx);
+        if let Some(vec_ty) = opd_ty.downcast_ref::<VectorType>() {
+            opd_ty = vec_ty.elem_type().deref(ctx);
+        }
+
         let Some(opd_float_ty) = type_cast::<dyn FloatTypeInterface>(&*opd_ty) else {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::OperandTypeErr);
         };
-        let res_ty = OneResultInterface::result_type(self, ctx).deref(ctx);
+        let mut res_ty = self.result_type(ctx).deref(ctx);
+        if let Some(vec_ty) = res_ty.downcast_ref::<VectorType>() {
+            res_ty = vec_ty.elem_type().deref(ctx);
+        }
         let Some(res_float_ty) = type_cast::<dyn FloatTypeInterface>(&*res_ty) else {
             return verify_err!(self.loc(ctx), FloatCastVerifyErr::ResultTypeErr);
         };

--- a/pliron-llvm/tests/resources/vector_ops.ll
+++ b/pliron-llvm/tests/resources/vector_ops.ll
@@ -36,12 +36,14 @@ entry:
   %fadd = fadd <2 x double> %fvec, <double 3.0, double 4.0> ; <4.0,6.0>
   %fneg1 = fneg <2 x double> %fadd; <-4.0,-6.0>
   %fneg2 = fneg <2 x double> %fneg1; <4.0,6.0>
-  %fe0 = extractelement <2 x double> %fneg2, i32 0
+  %ftrunc = fptrunc <2 x double> %fneg2 to <2 x float>; <4.0,6.0>
+  %fpext = fpext <2 x float> %ftrunc to <2 x double>; <4.0,6.0>
+  %fe0 = extractelement <2 x double> %fpext, i32 0
   %fe0_i = fptosi double %fe0 to i32                  ; 4
   %c2 = icmp eq i32 %fe0_i, 4
 
   ; float vector comparison
-  %fcmp = fcmp olt <2 x double> %fneg2, <double 5.0, double 5.0> ; <true,false>
+  %fcmp = fcmp olt <2 x double> %fpext, <double 5.0, double 5.0> ; <true,false>
   %fc0 = extractelement <2 x i1> %fcmp, i32 0           ; true
   %fc1 = extractelement <2 x i1> %fcmp, i32 1           ; false
   %fc1n = xor i1 %fc1, true


### PR DESCRIPTION
## Description

This PR fix verification of fpext and fptrunc for vector of float

## Checklist
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [X] A human is involved in writing this PR description and will handle
review interactions, per our [AI tool policy](../CONTRIBUTING.md).
- [X] I understand every part of this change (including any AI-generated
code) and can explain the reasoning behind it.
- [X] Intrusive / large changes were discussed on Discord before this PR.
- [X] `pre-ci.sh` passes locally.
