### PR TITLE
feat: make libffi linking optional

### DIFF
--- a/pliron-llvm/Cargo.toml
+++ b/pliron-llvm/Cargo.toml
@@ -12,9 +12,11 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["llvm-sys"]
+default = ["llvm-sys", "link-libffi"]
 
 llvm-sys = ["dep:llvm-sys", "std"]
+# Links libffi. Needed when LLVM is built with `LLVM_ENABLE_FFI=ON`
+link-libffi = ["llvm-sys"]
 std = ["pliron/std", "bitflags/std"]
 
 [dependencies]

--- a/pliron-llvm/build.rs
+++ b/pliron-llvm/build.rs
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) The pliron contributors
+
+fn main() {
+    if std::env::var_os("CARGO_FEATURE_LINK_LIBFFI").is_some() {
+        println!("cargo::rustc-link-lib=ffi");
+    }
+}

--- a/pliron-llvm/build.rs
+++ b/pliron-llvm/build.rs
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright (c) The pliron contributors
-
-fn main() {
-    // Tell Cargo to link to libffi
-    println!("cargo::rustc-link-lib=ffi");
-}


### PR DESCRIPTION
## Description

The build.rs of Pliron link libffi everytime even though a llvm version built without the legacy libffi, don't need it. This PR gate it behind feature that's enabled by default

## Checklist
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md).
- [X] A human is involved in writing this PR description and will handle
review interactions, per our [AI tool policy](../CONTRIBUTING.md).
- [X] I understand every part of this change (including any AI-generated
code) and can explain the reasoning behind it.
- [X] Intrusive / large changes were discussed on Discord before this PR.
- [X] `pre-ci.sh` passes locally.
